### PR TITLE
Add synthesis

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,22 @@
                 const soundUrl = document.getElementById('soundUrl').value;
                 // Removed duplicate declaration of loopCheckbox
                 const loopCheckbox = document.getElementById('loopSound').checked;
-                sound = await cacophony.createSound(soundUrl, SoundType.Buffer, panType);
+                switch (soundUrl) {
+                    case "sine":
+                    case "sawtooth":
+                    case "square":
+                    case "triangle":
+                        sound = await cacophony.createOscillator({
+                            type: soundUrl,
+                            panType: panType,
+                            loop: loopCheckbox
+                        });
+                        
+                        break;
+                    default:
+                        sound = await cacophony.createSound(soundUrl, SoundType.Buffer, panType);
+                        break;
+                }
                 if (loopCheckbox) sound.loop('infinite');
                 sound.play();
 window.sound = sound;

--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
                         sound = await cacophony.createOscillator({
                             type: soundUrl,
                             panType: panType,
-                            loop: loopCheckbox
                         });
                         
                         break;

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -12,7 +12,8 @@ import { createStream } from './stream';
 export enum SoundType {
     HTML = 'HTML',
     Streaming = 'Streaming',
-    Buffer = 'Buffer'
+    Buffer = 'Buffer',
+    Oscillator = 'oscillator'
 }
 
 
@@ -75,6 +76,8 @@ export interface BaseSound {
     playbackRate: number;
     loop?(loopCount?: LoopCount): LoopCount;
     duration: number;
+    position?: Position;
+    threeDOptions?: any;
 }
 
 

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -140,8 +140,9 @@ export class Cacophony {
     }
 
 
-    createOscillator(options: IOscillatorOptions) {
+    createOscillator(options: OscillatorOptions) {
         const synth = new Synth(this.context, this.globalGainNode, SoundType.Oscillator, 'HRTF', options);
+        console.log('synth', synth);    
         return synth;
     }
 

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -142,7 +142,6 @@ export class Cacophony {
 
     createOscillator(options: OscillatorOptions) {
         const synth = new Synth(this.context, this.globalGainNode, SoundType.Oscillator, 'HRTF', options);
-        console.log('synth', synth);    
         return synth;
     }
 

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -1,4 +1,4 @@
-import { AudioContext, AudioWorkletNode, IAudioListener, IMediaStreamAudioSourceNode, IPannerNode, IPannerOptions } from 'standardized-audio-context';
+import { AudioContext, AudioWorkletNode, IAudioListener, IMediaStreamAudioSourceNode, IOscillatorOptions, IPannerNode, IPannerOptions } from 'standardized-audio-context';
 import phaseVocoderProcessorWorkletUrl from './bundles/phase-vocoder-bundle.js?url';
 import { AudioCache } from './cache';
 import { BiquadFilterNode, GainNode, AudioBuffer } from './context';
@@ -7,6 +7,7 @@ import { Group } from './group';
 import { Playback } from './playback';
 import { Sound } from './sound';
 import { createStream } from './stream';
+import { Synth } from './synth';
 
 
 export enum SoundType {
@@ -142,20 +143,10 @@ export class Cacophony {
     }
 
 
-    createOscillator = ({ frequency, type, periodicWave }: OscillatorOptions) => {
-        if (frequency === undefined) {
-            frequency = 440;
-        }
-        const oscillator = this.context.createOscillator();
-        oscillator.type = type || 'sine';
-        if (periodicWave) {
-            oscillator.setPeriodicWave(periodicWave);
-        }
-        oscillator.frequency.setValueAtTime(frequency, this.context.currentTime);
-        oscillator.connect(this.globalGainNode);
-        return oscillator
+    createOscillator(options: IOscillatorOptions) {
+        const synth = new Synth(this.context, this.globalGainNode, SoundType.Oscillator, 'HRTF', options);
+        return synth;
     }
-
 
     async createSound(buffer: AudioBuffer, soundType?: SoundType, panType?: PanType): Promise<Sound>
 

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -74,9 +74,6 @@ export interface BaseSound {
     addFilter(filter: BiquadFilterNode): void;
     removeFilter(filter: BiquadFilterNode): void;
     volume: number;
-    playbackRate: number;
-    loop?(loopCount?: LoopCount): LoopCount;
-    duration: number;
     position?: Position;
     threeDOptions?: any;
 }
@@ -137,7 +134,7 @@ export class Cacophony {
             return new AudioWorkletNode!(this.context, name);
         }
     }
-    
+
     clearMemoryCache(): void {
         AudioCache.clearMemoryCache();
     }

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,5 +1,5 @@
 import { Position } from "./cacophony";
-import { BiquadFilterNode, IPannerOptions } from "./context";
+import { BiquadFilterNode } from "./context";
 import { FilterManager } from "./filters";
 import { BasePlayback, Playback } from "./playback";
 
@@ -10,7 +10,7 @@ export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
         protected playbacks: BasePlayback[] = [];
         protected _position: Position = [0, 0, 0];
         protected _stereoPan: number = 0;
-        protected _threeDOptions: IPannerOptions = {
+        protected _threeDOptions: PannerOptions = {
             coneInnerAngle: 360,
             coneOuterAngle: 360,
             coneOuterGain: 0,
@@ -103,7 +103,7 @@ export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
         */
 
         get position(): Position {
-            return [this._threeDOptions.positionX, this._threeDOptions.positionY, this._threeDOptions.positionZ]
+            return [this._threeDOptions.positionX as number, this._threeDOptions.positionY as number, this._threeDOptions.positionZ as number]
         }
 
         /**
@@ -121,11 +121,11 @@ export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
         }
 
 
-        get threeDOptions(): IPannerOptions {
+        get threeDOptions(): PannerOptions {
             return this._threeDOptions;
         }
 
-        set threeDOptions(options: Partial<IPannerOptions>) {
+        set threeDOptions(options: Partial<PannerOptions>) {
             this._threeDOptions = { ...this._threeDOptions, ...options };
             this.playbacks.forEach(p => p.threeDOptions = this._threeDOptions);
         }

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,13 +1,13 @@
 import { Position } from "./cacophony";
 import { BiquadFilterNode, IPannerOptions } from "./context";
 import { FilterManager } from "./filters";
-import { Playback } from "./playback";
+import { BasePlayback, Playback } from "./playback";
 
 type Constructor<T = FilterManager> = abstract new (...args: any[]) => T;
 
 export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
     abstract class PlaybackContainer extends Base {
-        protected playbacks: Playback[] = [];
+        protected playbacks: BasePlayback[] = [];
         protected _position: Position = [0, 0, 0];
         protected _stereoPan: number = 0;
         protected _threeDOptions: IPannerOptions = {
@@ -31,7 +31,7 @@ export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
         };
         protected _volume: number = 1;
 
-        abstract preplay(): Playback[]
+        abstract preplay(): BasePlayback[]
 
         /**
         * Starts playback of the sound and returns a Playback instance representing this particular playback.
@@ -40,7 +40,7 @@ export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
         * @returns {Playback[]} An array containing the Playback instances that have been started.
         */
 
-        play(): Playback[] {
+        play(): BasePlayback[] {
             const playback = this.preplay();
             playback.forEach(p => p.play());
             return playback;
@@ -95,7 +95,6 @@ export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
         get isPlaying(): boolean {
             return this.playbacks.some(p => p.isPlaying);
         }
-
 
         /**
         * Retrieves the current 3D spatial position of the sound in the audio context.

--- a/src/container.ts
+++ b/src/container.ts
@@ -5,7 +5,7 @@ import { Playback } from "./playback";
 
 type Constructor<T = FilterManager> = abstract new (...args: any[]) => T;
 
-export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
+export function PlaybackContainer<TBase extends Constructor, >(Base: TBase) {
     abstract class PlaybackContainer extends Base {
         playbacks: Playback[] = [];
         protected _position: Position = [0, 0, 0];

--- a/src/container.ts
+++ b/src/container.ts
@@ -5,7 +5,7 @@ import { Playback } from "./playback";
 
 type Constructor<T = FilterManager> = abstract new (...args: any[]) => T;
 
-export function PlaybackContainer<TBase extends Constructor, >(Base: TBase) {
+export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
     abstract class PlaybackContainer extends Base {
         playbacks: Playback[] = [];
         protected _position: Position = [0, 0, 0];

--- a/src/container.ts
+++ b/src/container.ts
@@ -7,7 +7,7 @@ type Constructor<T = FilterManager> = abstract new (...args: any[]) => T;
 
 export function PlaybackContainer<TBase extends Constructor>(Base: TBase) {
     abstract class PlaybackContainer extends Base {
-        playbacks: Playback[] = [];
+        protected playbacks: Playback[] = [];
         protected _position: Position = [0, 0, 0];
         protected _stereoPan: number = 0;
         protected _threeDOptions: IPannerOptions = {

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,8 @@
-import { AudioContext, IAudioBuffer, IAudioBufferSourceNode, IAudioContext, IBiquadFilterNode, IGainNode, IMediaElementAudioSourceNode, IOscillatorNode, IPannerNode, IStereoPannerNode } from 'standardized-audio-context';
+import { IAudioNode, AudioContext, IAudioBuffer, IAudioBufferSourceNode, IAudioContext, IBiquadFilterNode, IGainNode, IMediaElementAudioSourceNode, IOscillatorNode, IPannerNode, IStereoPannerNode } from 'standardized-audio-context';
 export {
     AudioBuffer, AudioContext, IAudioBuffer, IPannerOptions,
 } from 'standardized-audio-context';
+export type AudioNode = IAudioNode<AudioContext>;
 export type BiquadFilterNode = IBiquadFilterNode<AudioContext>;
 export type MediaElementSourceNode = IMediaElementAudioSourceNode<AudioContext>;
 export type AudioBufferSourceNode = IAudioBufferSourceNode<AudioContext>;

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,10 +1,8 @@
-import { IAudioNode, AudioContext, IAudioBuffer, IAudioBufferSourceNode, IAudioContext, IBiquadFilterNode, IGainNode, IMediaElementAudioSourceNode, IOscillatorNode, IPannerNode, IStereoPannerNode } from 'standardized-audio-context';
-export {
-    AudioBuffer, AudioContext, IAudioBuffer, IPannerOptions,
-} from 'standardized-audio-context';
+import { AudioContext, IAudioBuffer, IAudioBufferSourceNode, IAudioNode, IBiquadFilterNode, IGainNode, IMediaElementAudioSourceNode, IOscillatorNode, IPannerNode, IStereoPannerNode } from 'standardized-audio-context';
 export type AudioNode = IAudioNode<AudioContext>;
 export type BiquadFilterNode = IBiquadFilterNode<AudioContext>;
 export type MediaElementSourceNode = IMediaElementAudioSourceNode<AudioContext>;
+export type AudioBuffer = IAudioBuffer;
 export type AudioBufferSourceNode = IAudioBufferSourceNode<AudioContext>;
 export type OscillatorNode = IOscillatorNode<AudioContext>;
 export type SourceNode = AudioBufferSourceNode | MediaElementSourceNode | OscillatorNode;
@@ -12,3 +10,4 @@ export type SourceNode = AudioBufferSourceNode | MediaElementSourceNode | Oscill
 export type GainNode = IGainNode<AudioContext>;
 export type PannerNode = IPannerNode<AudioContext>;
 export type StereoPannerNode = IStereoPannerNode<AudioContext>;
+export { AudioContext };

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,12 +1,12 @@
-import { AudioContext, IAudioBuffer, IAudioBufferSourceNode, IBiquadFilterNode, IGainNode, IMediaElementAudioSourceNode, IPannerNode, IStereoPannerNode } from 'standardized-audio-context';
+import { AudioContext, IAudioBuffer, IAudioBufferSourceNode, IAudioContext, IBiquadFilterNode, IGainNode, IMediaElementAudioSourceNode, IOscillatorNode, IPannerNode, IStereoPannerNode } from 'standardized-audio-context';
 export {
     AudioBuffer, AudioContext, IAudioBuffer, IPannerOptions,
 } from 'standardized-audio-context';
 export type BiquadFilterNode = IBiquadFilterNode<AudioContext>;
 export type MediaElementSourceNode = IMediaElementAudioSourceNode<AudioContext>;
 export type AudioBufferSourceNode = IAudioBufferSourceNode<AudioContext>;
-export type SourceNode = AudioBufferSourceNode | MediaElementSourceNode;
-
+export type OscillatorNode = IOscillatorNode<AudioContext>;
+export type SourceNode = AudioBufferSourceNode | MediaElementSourceNode | OscillatorNode;
 
 export type GainNode = IGainNode<AudioContext>;
 export type PannerNode = IPannerNode<AudioContext>;

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,5 +1,9 @@
 import { BiquadFilterNode } from './context'
 
+export type FilterCloneOverrides = {
+    filters?: BiquadFilterNode[];
+};
+
 export abstract class FilterManager {
     protected _filters: BiquadFilterNode[] = [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from './cacophony';
 export * from './group';
 export * from './playback';
 export * from './sound';
+export * from './synth';

--- a/src/oscillatorMixin.ts
+++ b/src/oscillatorMixin.ts
@@ -1,7 +1,7 @@
 import { Playback } from "./playback";
 import { OscillatorNode, IOscillatorOptions } from "standardized-audio-context";
 
-type Constructor<T = {}> = new (...args: any[]) => T;
+type Constructor<T = {}> = abstract new (...args: any[]) => T;
 
 export function OscillatorMixin<TBase extends Constructor>(Base: TBase) {
     return class extends Playback {

--- a/src/oscillatorMixin.ts
+++ b/src/oscillatorMixin.ts
@@ -1,4 +1,4 @@
-import { OscillatorNode } from "./context";
+import type { OscillatorNode } from "./context";
 import { BasePlayback } from "./playback";
 
 export type OscillatorCloneOverrides = {
@@ -8,7 +8,7 @@ export type OscillatorCloneOverrides = {
 type Constructor<T = {}> = abstract new (...args: any[]) => T;
 
 export function OscillatorMixin<TBase extends Constructor>(Base: TBase) {
-    return class extends BasePlayback {
+    abstract class OscillatorMixin extends BasePlayback {
 
         private _oscillatorOptions: Partial<OscillatorOptions> = {};
         declare public source?: OscillatorNode;
@@ -45,4 +45,5 @@ export function OscillatorMixin<TBase extends Constructor>(Base: TBase) {
         }
 
     };
+    return OscillatorMixin;
 }

--- a/src/oscillatorMixin.ts
+++ b/src/oscillatorMixin.ts
@@ -1,11 +1,14 @@
-import { Playback } from "./playback";
-import { OscillatorNode, IOscillatorOptions } from "standardized-audio-context";
+import { IOscillatorOptions } from "standardized-audio-context";
+import { OscillatorNode } from "./context";
+import { BasePlayback } from "./playback";
 
 type Constructor<T = {}> = abstract new (...args: any[]) => T;
 
 export function OscillatorMixin<TBase extends Constructor>(Base: TBase) {
-    return class extends Playback {
+    return class extends BasePlayback {
+
         private _oscillatorOptions: Partial<IOscillatorOptions> = {};
+        declare public source?: OscillatorNode;
 
         get oscillatorOptions(): Partial<IOscillatorOptions> {
             return this._oscillatorOptions;
@@ -17,5 +20,26 @@ export function OscillatorMixin<TBase extends Constructor>(Base: TBase) {
                 Object.assign(this.source, options);
             }
         }
+
+        play(): [this] {
+            if (!this.source) {
+                throw new Error('No source node found');
+            }
+            this.source.start();
+            this._playing = true;
+            return [this];
+        }
+
+        stop() {
+            if (this.source && this.source.stop) {
+                this.source.stop();
+                this._playing = false;
+            }
+        }
+
+        pause(): void {
+            this.stop();
+        }
+
     };
 }

--- a/src/oscillatorMixin.ts
+++ b/src/oscillatorMixin.ts
@@ -1,20 +1,23 @@
-import { IOscillatorOptions } from "standardized-audio-context";
 import { OscillatorNode } from "./context";
 import { BasePlayback } from "./playback";
+
+export type OscillatorCloneOverrides = {
+    oscillatorOptions?: Partial<OscillatorOptions>;
+};
 
 type Constructor<T = {}> = abstract new (...args: any[]) => T;
 
 export function OscillatorMixin<TBase extends Constructor>(Base: TBase) {
     return class extends BasePlayback {
 
-        private _oscillatorOptions: Partial<IOscillatorOptions> = {};
+        private _oscillatorOptions: Partial<OscillatorOptions> = {};
         declare public source?: OscillatorNode;
 
-        get oscillatorOptions(): Partial<IOscillatorOptions> {
+        get oscillatorOptions(): Partial<OscillatorOptions> {
             return this._oscillatorOptions;
         }
 
-        set oscillatorOptions(options: Partial<IOscillatorOptions>) {
+        set oscillatorOptions(options: Partial<OscillatorOptions>) {
             this._oscillatorOptions = options;
             if (this.source && this.source instanceof OscillatorNode) {
                 Object.assign(this.source, options);

--- a/src/oscillatorMixin.ts
+++ b/src/oscillatorMixin.ts
@@ -1,0 +1,21 @@
+import { Playback } from "./playback";
+import { OscillatorNode, IOscillatorOptions } from "standardized-audio-context";
+
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+export function OscillatorMixin<TBase extends Constructor>(Base: TBase) {
+    return class extends Playback {
+        private _oscillatorOptions: Partial<IOscillatorOptions> = {};
+
+        get oscillatorOptions(): Partial<IOscillatorOptions> {
+            return this._oscillatorOptions;
+        }
+
+        set oscillatorOptions(options: Partial<IOscillatorOptions>) {
+            this._oscillatorOptions = options;
+            if (this.source && this.source instanceof OscillatorNode) {
+                Object.assign(this.source, options);
+            }
+        }
+    };
+}

--- a/src/pannerMixin.ts
+++ b/src/pannerMixin.ts
@@ -1,8 +1,13 @@
-import type { AudioContext, IPannerOptions, PannerNode, StereoPannerNode } from "./context";
-
+import type { AudioContext, PannerNode, StereoPannerNode } from "./context";
 import { PanType, Position } from "./cacophony";
 import { FilterManager } from "./filters";
 
+export type PanCloneOverrides = {
+    panType?: PanType;
+    stereoPan?: number; // -1 (left) to 1 (right)
+    threeDOptions?: Partial<PannerOptions>; // HRTF panning only
+    position?: Position; // HRTF panning only, [x, y, z]
+};
 
 type Constructor<T = FilterManager> = abstract new (...args: any[]) => T;
 
@@ -67,7 +72,7 @@ export function PannerMixin<TBase extends Constructor>(Base: TBase) {
         * @throws {Error} Throws an error if the sound has been cleaned up or if HRTF panning is not used.
         */
 
-        get threeDOptions(): IPannerOptions {
+        get threeDOptions(): PannerOptions {
             if (!this.panner) {
                 throw new Error('Cannot get 3D options of a sound that has been cleaned up');
             }
@@ -101,7 +106,7 @@ export function PannerMixin<TBase extends Constructor>(Base: TBase) {
      * @param {Partial<IPannerOptions>} options - The 3D audio options to set.
      * @throws {Error} Throws an error if the sound has been cleaned up or if HRTF panning is not used.
      */
-        set threeDOptions(options: Partial<IPannerOptions>) {
+        set threeDOptions(options: Partial<PannerOptions>) {
             if (!this.panner) {
                 throw new Error('Cannot set 3D options of a sound that has been cleaned up');
             }

--- a/src/pannerMixin.ts
+++ b/src/pannerMixin.ts
@@ -20,7 +20,6 @@ export function PannerMixin<TBase extends Constructor>(Base: TBase) {
             return this._panType;
         }
 
-
         setPanType(panType: PanType, audioContext: AudioContext) {
             this._panType = panType;
             if (panType === 'stereo') {
@@ -29,7 +28,6 @@ export function PannerMixin<TBase extends Constructor>(Base: TBase) {
                 this.panner = audioContext.createPanner();
             }
         }
-
 
         setPannerNode(pannerNode: PannerNode) {
             this.panner = pannerNode;

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -20,14 +20,35 @@
 
 
 import type { BaseSound, FadeType, LoopCount, PanType, Position } from "./cacophony";
-import type { AudioBuffer, AudioBufferSourceNode, AudioContext, BiquadFilterNode, GainNode, IPannerOptions, PannerNode, SourceNode, StereoPannerNode } from "./context";
+import type { AudioBuffer, AudioBufferSourceNode, AudioContext, AudioNode, BiquadFilterNode, GainNode, IPannerOptions, PannerNode, SourceNode, StereoPannerNode } from "./context";
 import { FilterManager } from "./filters";
 import { PannerMixin } from "./pannerMixin";
 import { VolumeMixin } from "./volumeMixin";
 
+export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager)) {
+    public source?: AudioNode
+    protected _playing: boolean = false;
 
-export class Playback extends PannerMixin(VolumeMixin(FilterManager)) implements BaseSound {
-    private _playing: boolean = false;
+    abstract play(): [this];
+    abstract pause(): void;
+    abstract stop(): void;
+
+    /**
+    * Checks if the audio is currently playing.
+    * @returns {boolean} True if the audio is playing, false otherwise.
+    */
+
+    get isPlaying(): boolean {
+        if (!this.source) {
+            return false;
+        }
+        return this._playing;
+    }
+
+
+}
+
+export class Playback extends BasePlayback implements BaseSound {
     private context: AudioContext;
     public source?: SourceNode;
     loopCount: LoopCount = 0;
@@ -240,18 +261,6 @@ export class Playback extends PannerMixin(VolumeMixin(FilterManager)) implements
         if ("mediaElement" in this.source && this.source.mediaElement) {
             this.source.mediaElement.loop = loop;
         }
-    }
-
-    /**
-    * Checks if the audio is currently playing.
-    * @returns {boolean} True if the audio is playing, false otherwise.
-    */
-
-    get isPlaying(): boolean {
-        if (!this.source) {
-            return false;
-        }
-        return this._playing;
     }
 
     /**

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -29,7 +29,7 @@ import { VolumeMixin } from "./volumeMixin";
 export class Playback extends PannerMixin(VolumeMixin(FilterManager)) implements BaseSound {
     private _playing: boolean = false;
     private context: AudioContext;
-    private source?: SourceNode;
+    public source?: SourceNode;
     loopCount: LoopCount = 0;
     currentLoop: number = 0;
     private buffer?: AudioBuffer;

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -19,8 +19,8 @@
  */
 
 
-import type { BaseSound, FadeType, LoopCount, PanType, Position } from "./cacophony";
-import type { AudioBuffer, AudioBufferSourceNode, AudioContext, AudioNode, BiquadFilterNode, GainNode, IPannerOptions, PannerNode, SourceNode, StereoPannerNode } from "./context";
+import type { BaseSound, LoopCount, PanType } from "./cacophony";
+import type { AudioBuffer, AudioBufferSourceNode, AudioContext, AudioNode, BiquadFilterNode, GainNode, SourceNode } from "./context";
 import { FilterManager } from "./filters";
 import { PannerMixin } from "./pannerMixin";
 import { VolumeMixin } from "./volumeMixin";

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -43,6 +43,7 @@ type SoundCloneOverrides = {
 
 
 export class Sound extends PlaybackContainer(FilterManager) implements BaseSound {
+    protected playbacks: Playback[] = [];
     buffer?: IAudioBuffer;
     context: AudioContext;
     loopCount: LoopCount = 0;

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -22,12 +22,12 @@
  */
 
 
-import { PanCloneOverrides } from "pannerMixin";
+import type { PanCloneOverrides } from "pannerMixin";
 import { AudioContext, IAudioBuffer } from "standardized-audio-context";
-import { VolumeCloneOverrides } from "volumeMixin";
-import { BaseSound, LoopCount, PanType, SoundType } from "./cacophony";
+import type { VolumeCloneOverrides } from "volumeMixin";
+import { SoundType, type BaseSound, type LoopCount, type PanType } from "./cacophony";
 import { PlaybackContainer } from "./container";
-import { BiquadFilterNode, GainNode, SourceNode, } from './context';
+import type { BiquadFilterNode, GainNode, SourceNode, } from './context';
 import { FilterManager } from "./filters";
 import { Playback } from "./playback";
 

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -22,7 +22,7 @@
  */
 
 
-import { PlaybackContainer } from "container";
+import { PlaybackContainer } from "./container";
 import { AudioContext, IAudioBuffer, IPannerOptions } from "standardized-audio-context";
 import { BaseSound, LoopCount, PanType, Position, SoundType } from "./cacophony";
 import { BiquadFilterNode, GainNode, SourceNode, } from './context';

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -22,25 +22,20 @@
  */
 
 
+import { PanCloneOverrides } from "pannerMixin";
+import { AudioContext, IAudioBuffer } from "standardized-audio-context";
+import { VolumeCloneOverrides } from "volumeMixin";
+import { BaseSound, LoopCount, PanType, SoundType } from "./cacophony";
 import { PlaybackContainer } from "./container";
-import { AudioContext, IAudioBuffer, IPannerOptions } from "standardized-audio-context";
-import { BaseSound, LoopCount, PanType, Position, SoundType } from "./cacophony";
 import { BiquadFilterNode, GainNode, SourceNode, } from './context';
 import { FilterManager } from "./filters";
 import { Playback } from "./playback";
 
-
-type SoundCloneOverrides = {
-    panType?: PanType;
-    stereoPan?: number;
-    threeDOptions?: Partial<IPannerOptions>;
+type SoundCloneOverrides = PanCloneOverrides & VolumeCloneOverrides & {
     loopCount?: LoopCount;
     playbackRate?: number;
-    volume?: number;
-    position?: Position;
     filters?: BiquadFilterNode[];
 };
-
 
 export class Sound extends PlaybackContainer(FilterManager) implements BaseSound {
     protected playbacks: Playback[] = [];
@@ -72,7 +67,7 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
     clone(overrides: Partial<SoundCloneOverrides> = {}): Sound {
         const panType = overrides.panType || this.panType;
         const stereoPan = overrides.stereoPan !== undefined ? overrides.stereoPan : this.stereoPan;
-        const threeDOptions = (overrides.threeDOptions || this.threeDOptions) as IPannerOptions;
+        const threeDOptions = (overrides.threeDOptions || this.threeDOptions) as PannerOptions;
         const loopCount = overrides.loopCount !== undefined ? overrides.loopCount : this.loopCount;
         const playbackRate = overrides.playbackRate || this.playbackRate;
         const volume = overrides.volume !== undefined ? overrides.volume : this.volume;

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -1,12 +1,13 @@
-import { PanCloneOverrides } from "pannerMixin";
-import { AudioContext, IOscillatorOptions, IPannerOptions } from "standardized-audio-context";
-import { VolumeCloneOverrides } from "volumeMixin";
+import type { OscillatorCloneOverrides } from "oscillatorMixin";
+import type { PanCloneOverrides } from "pannerMixin";
+import type { VolumeCloneOverrides } from "volumeMixin";
 import { BaseSound, PanType, SoundType } from "./cacophony";
 import { PlaybackContainer } from "./container";
-import { BiquadFilterNode, GainNode } from './context';
-import { FilterCloneOverrides, FilterManager } from "./filters";
+import type { GainNode } from './context';
+import { AudioContext } from './context';
+import type { FilterCloneOverrides } from "./filters";
+import { FilterManager } from "./filters";
 import { SynthPlayback } from "./synthPlayback";
-import { OscillatorCloneOverrides } from "oscillatorMixin";
 
 type SynthCloneOverrides = FilterCloneOverrides & OscillatorCloneOverrides & PanCloneOverrides & VolumeCloneOverrides
 
@@ -41,7 +42,7 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
     clone(overrides: Partial<SynthCloneOverrides> = {}): Synth {
         const panType = overrides.panType || this.panType;
         const stereoPan = overrides.stereoPan !== undefined ? overrides.stereoPan : this.stereoPan;
-        const threeDOptions = (overrides.threeDOptions || this.threeDOptions) as IPannerOptions;
+        const threeDOptions = (overrides.threeDOptions || this.threeDOptions) as PannerOptions;
         const volume = overrides.volume !== undefined ? overrides.volume : this.volume;
         const position = overrides.position && overrides.position.length ? overrides.position : this.position;
         const filters = overrides.filters && overrides.filters.length ? overrides.filters : this._filters;
@@ -68,7 +69,6 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
         const gainNode = this.context.createGain();
         gainNode.connect(this.globalGainNode);
         const playback = new SynthPlayback(oscillator, gainNode, this.context, this.panType);
-        playback.setGainNode(gainNode);
         playback.volume = this.volume;
         this._filters.forEach(filter => playback.addFilter(filter));
         if (this.panType === 'HRTF') {
@@ -81,11 +81,11 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
         return [playback];
     }
 
-    get oscillatorOptions(): Partial<IOscillatorOptions> {
+    get oscillatorOptions(): Partial<OscillatorOptions> {
         return this._oscillatorOptions;
     }
 
-    set oscillatorOptions(options: Partial<IOscillatorOptions>) {
+    set oscillatorOptions(options: Partial<OscillatorOptions>) {
         this._oscillatorOptions = options;
         this.playbacks.forEach(p => {
             if (p.source instanceof OscillatorNode) {

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -1,0 +1,146 @@
+import { PlaybackContainer } from "container";
+import { AudioContext, IOscillatorOptions, IPannerOptions } from "standardized-audio-context";
+import { BaseSound, LoopCount, PanType, Position, SoundType } from "./cacophony";
+import { BiquadFilterNode, GainNode, OscillatorNode, } from './context';
+import { FilterManager } from "./filters";
+import { Playback } from "./playback";
+import { OscillatorMixin } from "./oscillatorMixin";
+
+type SoundCloneOverrides = {
+    panType?: PanType;
+    stereoPan?: number;
+    threeDOptions?: Partial<IPannerOptions>;
+    loopCount?: LoopCount;
+    playbackRate?: number;
+    volume?: number;
+    position?: Position;
+    filters?: BiquadFilterNode[];
+    oscillatorOptions?: Partial<IOscillatorOptions>;
+};
+
+export class Synth extends PlaybackContainer(FilterManager) implements BaseSound {
+    loopCount: LoopCount = 0;
+    private _playbackRate: number = 1;
+    private _oscillatorOptions: Partial<IOscillatorOptions>;
+
+    constructor(
+        public context: AudioContext,
+        private globalGainNode: GainNode,
+        public type: SoundType = SoundType.Oscillator,
+        public panType: PanType = 'HRTF',
+        oscillatorOptions: Partial<IOscillatorOptions> = {}
+    ) {
+        super();
+        this.context = context;
+        this._oscillatorOptions = oscillatorOptions;
+    }
+    duration: number = 0;
+
+    /**
+     * Clones the current Sound instance, creating a deep copy with the option to override specific properties.
+     * This method allows for the creation of a new, independent Sound instance based on the current one, with the
+     * flexibility to modify certain attributes through the `overrides` parameter. This is particularly useful for
+     * creating variations of a sound without affecting the original instance. The cloned instance includes all properties,
+     * playback settings, and filters of the original, unless explicitly overridden.
+     *
+     * @param {SoundCloneOverrides} overrides - An object specifying properties to override in the cloned instance.
+     *        This can include audio settings like volume, playback rate, and spatial positioning, as well as
+     *        more complex configurations like 3D audio options and filter adjustments.
+     * @returns {Sound} A new Sound instance that is a clone of the current sound.
+     */
+    clone(overrides: Partial<SoundCloneOverrides> = {}): Synth {
+        const panType = overrides.panType || this.panType;
+        const stereoPan = overrides.stereoPan !== undefined ? overrides.stereoPan : this.stereoPan;
+        const threeDOptions = (overrides.threeDOptions || this.threeDOptions) as IPannerOptions;
+        const loopCount = overrides.loopCount !== undefined ? overrides.loopCount : this.loopCount;
+        const playbackRate = overrides.playbackRate || this.playbackRate;
+        const volume = overrides.volume !== undefined ? overrides.volume : this.volume;
+        const position = overrides.position && overrides.position.length ? overrides.position : this.position;
+        const filters = overrides.filters && overrides.filters.length ? overrides.filters : this._filters;
+        const oscillatorOptions = overrides.oscillatorOptions || this._oscillatorOptions;
+
+        const clone = new Synth(this.context, this.globalGainNode, this.type, panType, oscillatorOptions);
+        clone.loopCount = loopCount;
+        clone._playbackRate = playbackRate;
+        clone._volume = volume;
+        clone._position = position;
+        clone._stereoPan = stereoPan as number;
+        clone._threeDOptions = threeDOptions;
+        clone.addFilters(filters);
+        return clone;
+    }
+
+    /**
+     * Generates a Playback instance for the sound without starting playback.
+     * This allows for pre-configuration of playback properties such as volume and position before the sound is actually played.
+     * @returns {Playback[]} An array of Playback instances that are ready to be played.
+     */
+    preplay(): Playback[] {
+        const oscillator = this.context.createOscillator();
+        Object.assign(oscillator, this._oscillatorOptions);
+
+        const gainNode = this.context.createGain();
+        gainNode.connect(this.globalGainNode);
+        const playback = new Playback(oscillator, gainNode, this.context, this.loopCount, this.panType);
+        playback.setGainNode(gainNode);
+        playback.volume = this.volume;
+        playback.playbackRate = this.playbackRate;
+        this._filters.forEach(filter => playback.addFilter(filter));
+        if (this.panType === 'HRTF') {
+            playback.threeDOptions = this.threeDOptions;
+            playback.position = this.position;
+        } else if (this.panType === 'stereo') {
+            playback.stereoPan = this.stereoPan as number;
+        }
+        this.playbacks.push(playback);
+        return [playback];
+    }
+
+    /**
+     * Seeks to a specific time within the sound's playback.
+     * @param { number } time - The time in seconds to seek to.
+     * This method iterates through all active `Playback` instances and calls their `seek()` method with the specified time.
+     */
+    seek(time: number): void {
+        this.playbacks.forEach(playback => playback.seek(time));
+    }
+
+    /**
+     * Sets or retrieves the loop behavior for the sound.
+     * If loopCount is provided, the sound will loop the specified number of times.
+     * If loopCount is 'infinite', the sound will loop indefinitely until stopped.
+     * If no argument is provided, the method returns the current loop count setting.
+     * @param { LoopCount } [loopCount] - The number of times to loop or 'infinite' for indefinite looping.
+     * @returns { LoopCount } The current loop count setting if no argument is provided.
+     */
+    loop(loopCount?: LoopCount): LoopCount {
+        if (loopCount === undefined) {
+            return this.loopCount;
+        }
+        this.loopCount = loopCount;
+        this.playbacks.forEach(p => p.loop(loopCount));
+        return this.loopCount;
+    }
+
+    get playbackRate(): number {
+        return this._playbackRate;
+    }
+
+    set playbackRate(rate: number) {
+        this._playbackRate = rate;
+        this.playbacks.forEach(p => p.playbackRate = rate);
+    }
+
+    get oscillatorOptions(): Partial<IOscillatorOptions> {
+        return this._oscillatorOptions;
+    }
+
+    set oscillatorOptions(options: Partial<IOscillatorOptions>) {
+        this._oscillatorOptions = options;
+        this.playbacks.forEach(p => {
+            if (p.source instanceof OscillatorNode) {
+                Object.assign(p.source, options);
+            }
+        });
+    }
+}

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,0 +1,4 @@
+import { OscillatorMixin } from "./oscillatorMixin";
+import { Playback } from "./playback";
+
+export class SynthPlayback extends OscillatorMixin(Playback) {}

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,4 +1,8 @@
+import { BaseSound } from "./cacophony";
+import { FilterManager } from "./filters";
+import { PannerMixin } from "./pannerMixin";
+import { VolumeMixin } from "./volumeMixin";
 import { OscillatorMixin } from "./oscillatorMixin";
-import { Playback } from "./playback";
 
-export class SynthPlayback extends OscillatorMixin(Playback) {}
+export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(FilterManager))) implements BaseSound {
+}

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,8 +1,15 @@
-import { BaseSound } from "./cacophony";
+import { BaseSound, PanType } from "./cacophony";
+import type { AudioContext, GainNode } from "./context";
+import { OscillatorNode } from "./context";
 import { FilterManager } from "./filters";
+import { OscillatorMixin } from "./oscillatorMixin";
 import { PannerMixin } from "./pannerMixin";
 import { VolumeMixin } from "./volumeMixin";
-import { OscillatorMixin } from "./oscillatorMixin";
 
 export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(FilterManager))) implements BaseSound {
+    constructor(public source: OscillatorNode, gainNode: GainNode, private context: AudioContext, panType: PanType = 'HRTF') {
+        super()
+        this.setPanType(panType, context)
+        this.setGainNode(gainNode)
+    }
 }

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,6 +1,5 @@
 import { BaseSound, PanType } from "./cacophony";
-import type { AudioContext, GainNode } from "./context";
-import { OscillatorNode } from "./context";
+import type { AudioContext, GainNode, OscillatorNode } from "./context";
 import { FilterManager } from "./filters";
 import { OscillatorMixin } from "./oscillatorMixin";
 import { PannerMixin } from "./pannerMixin";
@@ -10,6 +9,29 @@ export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(Filte
     constructor(public source: OscillatorNode, gainNode: GainNode, private context: AudioContext, panType: PanType = 'HRTF') {
         super()
         this.setPanType(panType, context)
+        this.source.connect(this.panner!);
         this.setGainNode(gainNode)
+        this.panner!.connect(this.gainNode!);
+        this.refreshFilters()
     }
+
+
+    /**
+    * Refreshes the audio filters by re-applying them to the audio signal chain.
+    * This method is called internally whenever filters are added or removed.
+    * @throws {Error} Throws an error if the sound has been cleaned up.
+    */
+
+    private refreshFilters(): void {
+        if (!this.panner || !this.gainNode) {
+            throw new Error('Cannot update filters on a sound that has been cleaned up');
+        }
+        let connection = this.panner;
+        connection.disconnect();
+        connection = this.applyFilters(connection);
+        connection.connect(this.gainNode);
+    }
+
+
+
 }

--- a/src/volumeMixin.ts
+++ b/src/volumeMixin.ts
@@ -1,6 +1,10 @@
 import { FilterManager } from "./filters";
 import { GainNode } from "./context";
 
+export type VolumeCloneOverrides = {
+    volume?: number;
+};
+
 type Constructor<T = FilterManager> = abstract new (...args: any[]) => T;
 
 export function VolumeMixin<TBase extends Constructor>(Base: TBase) {
@@ -37,7 +41,7 @@ export function VolumeMixin<TBase extends Constructor>(Base: TBase) {
             this.gainNode.gain.value = v;
         }
 
+    };
 
-            };
     return VolumeMixin;
 }


### PR DESCRIPTION
This adds the ability to do synthesis using cacophony, utilizing OscillatorNode.
To test, enter sine, sawtooth or triangle in the URL box of the demo development page. 