### PR TITLE
test: browser-realistic regression coverage for microphone, stream, and media element paths

### DIFF
--- a/src/media-element-rejection.test.ts
+++ b/src/media-element-rejection.test.ts
@@ -1,0 +1,120 @@
+import { AudioBuffer } from "standardized-audio-context-mock";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Sound } from "./sound";
+import { cacophony, audioContextMock } from "./setupTests";
+
+describe("Media element play() rejection", () => {
+  let sound: Sound;
+
+  beforeEach(async () => {
+    sound = await cacophony.createSound("https://example.com/audio.mp3");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("play() succeeds when mediaElement.play() resolves", () => {
+    // Default mock (from setupTests.ts) resolves — verify baseline works
+    const playbacks = sound.play();
+    expect(playbacks).toHaveLength(1);
+    expect(playbacks[0].isPlaying).toBe(true);
+  });
+
+  it("play() throws when source.start() throws on buffer-backed sound", async () => {
+    const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+    const bufferSound = await cacophony.createSound(buffer);
+
+    // Mock createBufferSource to return a node whose start() throws.
+    // Playback.play() calls recreateSource() which calls context.createBufferSource().
+    const originalCreate = audioContextMock.createBufferSource.bind(audioContextMock);
+    vi.spyOn(audioContextMock, "createBufferSource").mockImplementation(() => {
+      const node = originalCreate();
+      node.start = () => {
+        throw new Error("NotAllowedError: play() failed");
+      };
+      return node;
+    });
+
+    expect(() => bufferSound.play()).toThrow("NotAllowedError: play() failed");
+  });
+
+  it("emits error event on playback when play() catches source error", async () => {
+    const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+    const bufferSound = await cacophony.createSound(buffer);
+
+    // Get playback via preplay (this uses the real createBufferSource for construction)
+    const playbacks = bufferSound.preplay();
+    const playback = playbacks[0];
+
+    const errorSpy = vi.fn();
+    playback.on("error", errorSpy);
+
+    // Now mock createBufferSource so recreateSource() inside play() gets a broken node
+    const originalCreate = audioContextMock.createBufferSource.bind(audioContextMock);
+    vi.spyOn(audioContextMock, "createBufferSource").mockImplementation(() => {
+      const node = originalCreate();
+      node.start = () => {
+        throw new Error("Autoplay blocked");
+      };
+      return node;
+    });
+
+    try {
+      playback.play();
+    } catch {
+      // Expected to throw
+    }
+
+    // The error event is emitted asynchronously
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.any(Error),
+          errorType: "source",
+          recoverable: true,
+        })
+      );
+    });
+  });
+
+  it("emits soundError on parent Sound when playback source errors", async () => {
+    const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+    const bufferSound = await cacophony.createSound(buffer);
+
+    const soundErrorSpy = vi.fn();
+    bufferSound.on("soundError", soundErrorSpy);
+
+    // Get playback via preplay — this wires up error propagation from playback to sound
+    const playbacks = bufferSound.preplay();
+    const playback = playbacks[0];
+
+    // Mock createBufferSource for the recreateSource call inside play()
+    const originalCreate = audioContextMock.createBufferSource.bind(audioContextMock);
+    vi.spyOn(audioContextMock, "createBufferSource").mockImplementation(() => {
+      const node = originalCreate();
+      node.start = () => {
+        throw new Error("Autoplay policy");
+      };
+      return node;
+    });
+
+    try {
+      playback.play();
+    } catch {
+      // Expected
+    }
+
+    // soundError propagates asynchronously from playback error -> sound
+    await vi.waitFor(() => {
+      expect(soundErrorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: expect.any(String),
+          error: expect.any(Error),
+          errorType: "playback",
+          recoverable: true,
+        })
+      );
+    });
+  });
+});

--- a/src/microphone.test.ts
+++ b/src/microphone.test.ts
@@ -1,0 +1,276 @@
+import { AudioContext } from "standardized-audio-context-mock";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MicrophonePlayback, MicrophoneStream } from "./microphone";
+
+function createMockTrack(): MediaStreamTrack {
+  return {
+    stop: vi.fn(),
+    enabled: true,
+  } as unknown as MediaStreamTrack;
+}
+
+function createMockStream(tracks: MediaStreamTrack[]): MediaStream {
+  return {
+    getTracks: () => tracks,
+  } as unknown as MediaStream;
+}
+
+function createMockMediaStreamSource(stream: MediaStream) {
+  return {
+    connect: vi.fn().mockReturnValue({
+      connect: vi.fn(),
+    }),
+    disconnect: vi.fn(),
+    mediaStream: stream,
+    numberOfInputs: 1,
+    numberOfOutputs: 1,
+  };
+}
+
+describe("MicrophonePlayback", () => {
+  let context: AudioContext;
+  let mockTrack: MediaStreamTrack;
+  let mockStream: MediaStream;
+  let mockSource: ReturnType<typeof createMockMediaStreamSource>;
+  let mockGainNode: any;
+  let playback: MicrophonePlayback;
+
+  beforeEach(() => {
+    context = new AudioContext();
+    mockTrack = createMockTrack();
+    mockStream = createMockStream([mockTrack]);
+    mockSource = createMockMediaStreamSource(mockStream);
+    mockGainNode = context.createGain();
+    playback = new MicrophonePlayback(
+      mockSource as any,
+      mockGainNode,
+      context
+    );
+  });
+
+  afterEach(() => {
+    context.close();
+  });
+
+  it("play returns array containing itself", () => {
+    const result = playback.play();
+    expect(result).toEqual([playback]);
+  });
+
+  it("isPlaying is true when source exists", () => {
+    expect(playback.isPlaying).toBe(true);
+  });
+
+  it("stop calls track.stop() on all stream tracks", () => {
+    playback.stop();
+    expect(mockTrack.stop).toHaveBeenCalled();
+  });
+
+  it("pause disables all stream tracks", () => {
+    playback.pause();
+    expect(mockTrack.enabled).toBe(false);
+  });
+
+  it("resume enables all stream tracks", () => {
+    playback.pause();
+    expect(mockTrack.enabled).toBe(false);
+    playback.resume();
+    expect(mockTrack.enabled).toBe(true);
+  });
+
+  it("volume getter/setter works", () => {
+    playback.volume = 0.5;
+    expect(playback.volume).toBe(0.5);
+  });
+
+  it("position getter/setter works", () => {
+    playback.position = [1, 2, 3];
+    expect(playback.position).toEqual([1, 2, 3]);
+  });
+
+  it("playbackRate is always 1 (not applicable for mic)", () => {
+    expect(playback.playbackRate).toBe(1);
+    playback.playbackRate = 2;
+    expect(playback.playbackRate).toBe(1);
+  });
+
+  it("duration is always 0", () => {
+    expect(playback.duration).toBe(0);
+  });
+});
+
+describe("MicrophoneStream", () => {
+  let context: AudioContext;
+  let mockTrack: MediaStreamTrack;
+  let mockStream: MediaStream;
+
+  beforeEach(() => {
+    context = new AudioContext();
+    mockTrack = createMockTrack();
+    mockStream = createMockStream([mockTrack]);
+
+    // Mock navigator.mediaDevices.getUserMedia
+    Object.defineProperty(global, "navigator", {
+      value: {
+        mediaDevices: {
+          getUserMedia: vi.fn(),
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Mock createMediaStreamSource on the context
+    vi.spyOn(context as any, "createMediaStreamSource").mockReturnValue(
+      createMockMediaStreamSource(mockStream)
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    context.close();
+  });
+
+  it("play() returns empty array on first call (stream not yet acquired)", () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const mic = new MicrophoneStream(context);
+    const result = mic.play();
+    expect(result).toEqual([]);
+  });
+
+  it("play() acquires microphone stream via getUserMedia", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const mic = new MicrophoneStream(context);
+    mic.play();
+
+    // Wait for the async getUserMedia to resolve
+    await vi.waitFor(() => {
+      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
+        audio: true,
+      });
+    });
+  });
+
+  it("play() sets up streamPlayback after getUserMedia resolves", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const mic = new MicrophoneStream(context);
+    mic.play();
+
+    // Wait for async setup
+    await vi.waitFor(() => {
+      expect(mic.isPlaying).toBe(true);
+    });
+
+    // Second call should return the playback
+    const result = mic.play();
+    expect(result).toHaveLength(1);
+  });
+
+  it("handles getUserMedia permission denial", async () => {
+    const permissionError = new DOMException(
+      "Permission denied",
+      "NotAllowedError"
+    );
+    (navigator.mediaDevices.getUserMedia as any).mockRejectedValue(
+      permissionError
+    );
+    const consoleSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const mic = new MicrophoneStream(context);
+    mic.play();
+
+    await vi.waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Error initializing microphone stream:",
+        permissionError
+      );
+    });
+
+    expect(mic.isPlaying).toBe(false);
+    consoleSpy.mockRestore();
+  });
+
+  it("does not call getUserMedia again if stream already acquired", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const mic = new MicrophoneStream(context);
+    mic.play();
+
+    await vi.waitFor(() => {
+      expect(mic.isPlaying).toBe(true);
+    });
+
+    // Second play should not call getUserMedia again
+    mic.play();
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it("stop() delegates to streamPlayback and clears it", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const mic = new MicrophoneStream(context);
+    mic.play();
+
+    await vi.waitFor(() => {
+      expect(mic.isPlaying).toBe(true);
+    });
+
+    mic.stop();
+    expect(mic.isPlaying).toBe(false);
+    expect(mockTrack.stop).toHaveBeenCalled();
+  });
+
+  it("pause() delegates to streamPlayback", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const mic = new MicrophoneStream(context);
+    mic.play();
+
+    await vi.waitFor(() => {
+      expect(mic.isPlaying).toBe(true);
+    });
+
+    mic.pause();
+    expect(mockTrack.enabled).toBe(false);
+  });
+
+  it("resume() delegates to streamPlayback", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const mic = new MicrophoneStream(context);
+    mic.play();
+
+    await vi.waitFor(() => {
+      expect(mic.isPlaying).toBe(true);
+    });
+
+    mic.pause();
+    mic.resume();
+    expect(mockTrack.enabled).toBe(true);
+  });
+
+  it("stop/pause/resume are no-ops when no stream acquired", () => {
+    const mic = new MicrophoneStream(context);
+    // None of these should throw
+    mic.stop();
+    mic.pause();
+    mic.resume();
+    expect(mic.isPlaying).toBe(false);
+  });
+
+  it("duration is always 0", () => {
+    const mic = new MicrophoneStream(context);
+    expect(mic.duration).toBe(0);
+  });
+
+  it("loop always returns 0", () => {
+    const mic = new MicrophoneStream(context);
+    expect(mic.loop()).toBe(0);
+    expect(mic.loop(5)).toBe(0);
+  });
+
+  it("playbackRate is always 1", () => {
+    const mic = new MicrophoneStream(context);
+    expect(mic.playbackRate).toBe(1);
+    mic.playbackRate = 2;
+    expect(mic.playbackRate).toBe(1);
+  });
+});

--- a/src/stream-control.test.ts
+++ b/src/stream-control.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SoundType } from "./cacophony";
+import { cacophony } from "./setupTests";
+
+describe("Stream control integration", () => {
+  let mockReader: any;
+  let mockResponse: any;
+
+  beforeEach(() => {
+    mockReader = {
+      read: vi.fn().mockResolvedValue({ value: undefined, done: true }),
+      cancel: vi.fn().mockResolvedValue(undefined),
+    };
+
+    mockResponse = {
+      ok: true,
+      status: 200,
+      body: {
+        getReader: vi.fn().mockReturnValue(mockReader),
+        cancel: vi.fn(),
+      },
+    };
+
+    global.fetch = vi.fn().mockResolvedValue(mockResponse);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("createStream returns a Sound instance", async () => {
+    const sound = await cacophony.createStream("https://example.com/audio.wav");
+    expect(sound).toBeDefined();
+    expect(sound.constructor.name).toBe("Sound");
+  });
+
+  it("returned Sound has Streaming soundType", async () => {
+    const sound = await cacophony.createStream("https://example.com/audio.wav");
+    expect(sound.soundType).toBe(SoundType.Streaming);
+  });
+
+  it("returned Sound has no buffer (stream is fire-and-forget)", async () => {
+    const sound = await cacophony.createStream("https://example.com/audio.wav");
+    // The Sound has no buffer — it was created as a Streaming type shell
+    expect(sound.buffer).toBeUndefined();
+  });
+
+  it("returned Sound.preplay() creates a playback even without buffer", async () => {
+    const sound = await cacophony.createStream("https://example.com/audio.wav");
+    // preplay() falls through to the HTML Audio path since there's no buffer
+    const playbacks = sound.preplay();
+    expect(playbacks).toHaveLength(1);
+  });
+
+  it("createStream initiates fetch to the URL", async () => {
+    await cacophony.createStream("https://example.com/audio.wav");
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/audio.wav",
+      undefined
+    );
+  });
+
+  it("createStream passes AbortSignal to fetch", async () => {
+    const controller = new AbortController();
+    await cacophony.createStream("https://example.com/audio.wav", controller.signal);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://example.com/audio.wav",
+      { signal: controller.signal }
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Closes #40.

- Adds `src/microphone.test.ts` (21 tests): MicrophonePlayback and MicrophoneStream lifecycle, getUserMedia permission denial, pause/resume/stop delegation, duplicate-call prevention
- Adds `src/stream-control.test.ts` (6 tests): createStream returns Sound with Streaming soundType, no buffer on returned Sound, fetch initiation, AbortSignal passthrough
- Adds `src/media-element-rejection.test.ts` (4 tests): source.start() throw propagation, error event on playback, soundError event on parent Sound

No production code changes. Full suite: 328 tests passing (297 baseline + 31 new).

## Test plan
- [x] `npm test` — all 328 tests pass
- [x] No existing tests broken
- [x] Each gap identified in #40 has dedicated coverage