### PR TITLE
fix: emit onLoadingError callback in AudioCache error paths

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -667,6 +667,13 @@ export class AudioCache implements ICache {
             AudioCache.decodedBuffers.set(url, audioBuffer);
             return audioBuffer;
           } catch (error) {
+            if (callbacks?.onLoadingError) {
+              callbacks.onLoadingError({
+                url,
+                error: error as Error,
+                timestamp: Date.now(),
+              });
+            }
             if (callbacks?.onCacheError) {
               callbacks.onCacheError({
                 url,
@@ -705,17 +712,28 @@ export class AudioCache implements ICache {
             }
 
             // Fallback to network if body missing but metadata is fresh
-            const arrayBuffer = await AudioCache.fetchAndCacheBuffer(
-              url,
-              cache,
-              metadata?.etag,
-              metadata?.lastModified,
-              signal,
-              { onCacheHit: callbacks?.onCacheHit },
-            );
-            const audioBuffer = await AudioCache.decodeAudioData(context, arrayBuffer);
-            AudioCache.decodedBuffers.set(url, audioBuffer);
-            return audioBuffer;
+            try {
+              const arrayBuffer = await AudioCache.fetchAndCacheBuffer(
+                url,
+                cache,
+                metadata?.etag,
+                metadata?.lastModified,
+                signal,
+                { onCacheHit: callbacks?.onCacheHit },
+              );
+              const audioBuffer = await AudioCache.decodeAudioData(context, arrayBuffer);
+              AudioCache.decodedBuffers.set(url, audioBuffer);
+              return audioBuffer;
+            } catch (error) {
+              if (callbacks?.onLoadingError) {
+                callbacks.onLoadingError({
+                  url,
+                  error: error as Error,
+                  timestamp: Date.now(),
+                });
+              }
+              throw error;
+            }
           }
         }
       },


### PR DESCRIPTION
## Summary
- `AudioCache.getAudioBuffer()` declared `onLoadingError` in its callback type but never called it in any error path, making the public `loadingError` event dead in production
- Added `onLoadingError` invocation in the primary fetch/decode catch block
- Wrapped the cache-inconsistency fallback fetch in try/catch with `onLoadingError`

## Test plan
- [x] All 328 existing tests pass
- [ ] Manual verification that `cacophony.on('loadingError', ...)` fires on network failure

Fixes #30