### PR TITLE
fix: guard playOrdered against indexing past end when not looping

### DIFF
--- a/src/group.test.ts
+++ b/src/group.test.ts
@@ -71,6 +71,25 @@ describe("Group class", () => {
     expect(playback2).toBeDefined();
   });
 
+  it("playOrdered(false) returns undefined after exhausting all sounds", () => {
+    vi.spyOn(sound1, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+    vi.spyOn(sound2, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+
+    const playback1 = group.playOrdered(false);
+    expect(playback1).toBeDefined();
+
+    const playback2 = group.playOrdered(false);
+    expect(playback2).toBeDefined();
+
+    // All sounds exhausted — should return undefined, not crash
+    const playback3 = group.playOrdered(false);
+    expect(playback3).toBeUndefined();
+
+    // Subsequent calls should also return undefined
+    const playback4 = group.playOrdered(false);
+    expect(playback4).toBeUndefined();
+  });
+
   it("plays random sounds", () => {
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.7);
     const preplaySpy1 = vi.spyOn(sound1, "preplay").mockReturnValue([]);

--- a/src/group.ts
+++ b/src/group.ts
@@ -46,6 +46,9 @@ export class Group implements BaseSound {
     if (this.sounds.length === 0) {
       return undefined;
     }
+    if (this.playIndex >= this.sounds.length) {
+      return undefined;
+    }
     const sound = this.sounds[this.playIndex];
     const playbacks = sound.preplay();
     if (playbacks.length === 0) {


### PR DESCRIPTION
## Summary
- `Group.preplayOrdered(false)` set `playIndex` to `sounds.length` after the last sound, causing the next call to index `undefined` and crash on `.preplay()`
- Added bounds check at top of `preplayOrdered` to return `undefined` cleanly when playback is exhausted
- Added test covering the non-looping exhaustion case and subsequent calls

Fixes #35

## Test plan
- [x] New test: `playOrdered(false)` returns `undefined` after all sounds exhausted
- [x] New test: subsequent calls also return `undefined` (no crash)
- [x] All 329 existing tests pass