### PR TITLE
fix: prune naturally ended playbacks from Sound.playbacks

### DIFF
--- a/src/playback.ts
+++ b/src/playback.ts
@@ -160,9 +160,13 @@ export class Playback extends BasePlayback implements BaseSound {
     if (this.loopCount !== "infinite" && this.currentLoop > this.loopCount) {
       // Final iteration -- either fade out or stop immediately
       if (this._fadeOutConfig) {
-        this.fadeOut(this._fadeOutConfig.duration, this._fadeOutConfig.type).then(() => this.stop());
+        this.fadeOut(this._fadeOutConfig.duration, this._fadeOutConfig.type).then(() => {
+          this.stop();
+          this.removeFromOrigin();
+        });
       } else {
         this.stop();
+        this.removeFromOrigin();
       }
     } else {
       this.seek(0); // Resets offset and handles play/pause state internally.
@@ -375,6 +379,13 @@ export class Playback extends BasePlayback implements BaseSound {
       return this._offset + elapsed;
     } else {
       return this._offset;
+    }
+  }
+
+  private removeFromOrigin(): void {
+    const idx = this.origin.playbacks.indexOf(this);
+    if (idx !== -1) {
+      this.origin.playbacks.splice(idx, 1);
     }
   }
 

--- a/src/sound.test.ts
+++ b/src/sound.test.ts
@@ -62,6 +62,101 @@ describe("Sound playback and state management", () => {
     expect(playbacks2[0].isPlaying).toBe(false);
   });
 
+  it("removes playback from sound when it ends naturally", () => {
+    const playbacks = sound.play();
+    const playback = playbacks[0];
+    expect(sound.playbacks.length).toBe(1);
+    expect(sound.playbacks).toContain(playback);
+
+    // Simulate natural end by triggering loopEnded
+    playback.loopEnded();
+
+    expect(sound.playbacks.length).toBe(0);
+    expect(sound.playbacks).not.toContain(playback);
+  });
+
+  it("only removes the ended playback, not others", () => {
+    const p1 = sound.play()[0];
+    const p2 = sound.play()[0];
+    expect(sound.playbacks.length).toBe(2);
+
+    // Simulate p1 ending naturally
+    p1.loopEnded();
+
+    expect(sound.playbacks.length).toBe(1);
+    expect(sound.playbacks).not.toContain(p1);
+    expect(sound.playbacks).toContain(p2);
+    expect(p2.isPlaying).toBe(true);
+  });
+
+  it("does not remove playback while it is still looping", () => {
+    sound.loop(2);
+    const playback = sound.play()[0];
+    expect(sound.playbacks.length).toBe(1);
+
+    // First loop end — should keep playing
+    playback.loopEnded();
+    expect(sound.playbacks.length).toBe(1);
+    expect(sound.playbacks).toContain(playback);
+    expect(playback.isPlaying).toBe(true);
+
+    // Second loop end — should keep playing
+    playback.loopEnded();
+    expect(sound.playbacks.length).toBe(1);
+    expect(sound.playbacks).toContain(playback);
+    expect(playback.isPlaying).toBe(true);
+
+    // Third loopEnded — loops exhausted, should be removed
+    playback.loopEnded();
+    expect(sound.playbacks.length).toBe(0);
+    expect(playback.isPlaying).toBe(false);
+  });
+
+  it("does not remove playback when looping infinitely", () => {
+    sound.loop("infinite");
+    const playback = sound.play()[0];
+    expect(sound.playbacks.length).toBe(1);
+
+    // Many loop ends — should never be removed
+    for (let i = 0; i < 10; i++) {
+      playback.loopEnded();
+      expect(sound.playbacks.length).toBe(1);
+      expect(sound.playbacks).toContain(playback);
+      expect(playback.isPlaying).toBe(true);
+    }
+  });
+
+  it("does not remove playback on explicit stop (container.stop handles that)", () => {
+    const playback = sound.play()[0];
+    expect(sound.playbacks.length).toBe(1);
+
+    // Explicit stop on the playback — does NOT auto-remove
+    playback.stop();
+    expect(playback.isPlaying).toBe(false);
+    // The playback stays in the array; Sound.stop() is responsible for clearing
+    expect(sound.playbacks.length).toBe(1);
+  });
+
+  it("removes multiple playbacks independently as each ends naturally", () => {
+    const p1 = sound.play()[0];
+    const p2 = sound.play()[0];
+    const p3 = sound.play()[0];
+    expect(sound.playbacks.length).toBe(3);
+
+    p2.loopEnded();
+    expect(sound.playbacks.length).toBe(2);
+    expect(sound.playbacks).toContain(p1);
+    expect(sound.playbacks).not.toContain(p2);
+    expect(sound.playbacks).toContain(p3);
+
+    p1.loopEnded();
+    expect(sound.playbacks.length).toBe(1);
+    expect(sound.playbacks).toContain(p3);
+
+    p3.loopEnded();
+    expect(sound.playbacks.length).toBe(0);
+  });
+
   it("manages multiple playbacks correctly", () => {
     const playbacks1 = sound.play();
     const playbacks2 = sound.play();


### PR DESCRIPTION
## Summary
- When a playback ends naturally (loops exhausted), it now removes itself from `Sound.playbacks`
- Previously, dead playback objects accumulated indefinitely in the array
- Only affects natural end — explicit `stop()` and infinite loops are unaffected

## Test plan
- [x] Playback removed from `Sound.playbacks` on natural end
- [x] Only the ended playback is removed, not siblings
- [x] Playback retained while still looping (finite loops)
- [x] Playback retained when looping infinitely
- [x] Explicit `playback.stop()` does not auto-remove (container's responsibility)
- [x] Multiple playbacks removed independently as each ends
- [x] Full test suite passes (335 tests)

Fixes #36