### PR TITLE
fix: return volume 1 for empty Group instead of NaN

### DIFF
--- a/src/group.test.ts
+++ b/src/group.test.ts
@@ -133,6 +133,11 @@ describe("Group class", () => {
     expect(emptyGroup.play()).toEqual([]);
   });
 
+  it("returns volume of 1 for an empty group", () => {
+    const emptyGroup = new Group();
+    expect(emptyGroup.volume).toBe(1);
+  });
+
   describe("Global events", () => {
     it("emits globalPlay when using Group.play()", () => {
       const globalPlayListener = vi.fn();

--- a/src/group.ts
+++ b/src/group.ts
@@ -192,6 +192,9 @@ export class Group implements BaseSound {
   }
 
   get volume(): number {
+    if (this.sounds.length === 0) {
+      return 1;
+    }
     return this.sounds.map((sound) => sound.volume).reduce((a, b) => a + b, 0) / this.sounds.length;
   }
 


### PR DESCRIPTION
## Summary
- Guard `Group.volume` getter against empty `sounds` array, returning `1` (full volume) instead of `NaN` from `0 / 0`
- Follows the existing pattern used by `Group.playbackRate` for the same edge case
- Adds test asserting `emptyGroup.volume === 1`

Closes #38

## Test plan
- [x] New test: `returns volume of 1 for an empty group`
- [x] All 340 existing tests pass