### PR TITLE
fix: eliminate double getUserMedia call in microphone API

### DIFF
--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -418,8 +418,7 @@ export class Cacophony {
       navigator.mediaDevices
         .getUserMedia({ audio: true })
         .then((stream) => {
-          const microphoneStream = new MicrophoneStream(this.context);
-          microphoneStream.play();
+          const microphoneStream = new MicrophoneStream(this.context, stream);
           resolve(microphoneStream);
         })
         .catch((err) => {

--- a/src/microphone.test.ts
+++ b/src/microphone.test.ts
@@ -125,27 +125,22 @@ describe("MicrophoneStream", () => {
     context.close();
   });
 
-  it("play() returns empty array on first call (stream not yet acquired)", () => {
+  it("play() returns playback immediately when constructed with a stream", () => {
+    const mic = new MicrophoneStream(context, mockStream);
+    const result = mic.play();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBeInstanceOf(MicrophonePlayback);
+  });
+
+  it("play() returns empty array and calls getUserMedia when constructed without a stream", () => {
     (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
     const mic = new MicrophoneStream(context);
     const result = mic.play();
     expect(result).toEqual([]);
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ audio: true });
   });
 
-  it("play() acquires microphone stream via getUserMedia", async () => {
-    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
-    const mic = new MicrophoneStream(context);
-    mic.play();
-
-    // Wait for the async getUserMedia to resolve
-    await vi.waitFor(() => {
-      expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({
-        audio: true,
-      });
-    });
-  });
-
-  it("play() sets up streamPlayback after getUserMedia resolves", async () => {
+  it("play() sets up streamPlayback after getUserMedia resolves (no-stream path)", async () => {
     (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
     const mic = new MicrophoneStream(context);
     mic.play();
@@ -176,55 +171,34 @@ describe("MicrophoneStream", () => {
     consoleSpy.mockRestore();
   });
 
-  it("does not call getUserMedia again if stream already acquired", async () => {
-    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
-    const mic = new MicrophoneStream(context);
+  it("does not call getUserMedia when constructed with a stream", () => {
+    const mic = new MicrophoneStream(context, mockStream);
     mic.play();
-
-    await vi.waitFor(() => {
-      expect(mic.isPlaying).toBe(true);
-    });
-
-    // Second play should not call getUserMedia again
     mic.play();
-    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+    expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
   });
 
-  it("stop() delegates to streamPlayback and clears it", async () => {
-    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
-    const mic = new MicrophoneStream(context);
+  it("stop() delegates to streamPlayback and clears it", () => {
+    const mic = new MicrophoneStream(context, mockStream);
     mic.play();
-
-    await vi.waitFor(() => {
-      expect(mic.isPlaying).toBe(true);
-    });
+    expect(mic.isPlaying).toBe(true);
 
     mic.stop();
     expect(mic.isPlaying).toBe(false);
     expect(mockTrack.stop).toHaveBeenCalled();
   });
 
-  it("pause() delegates to streamPlayback", async () => {
-    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
-    const mic = new MicrophoneStream(context);
+  it("pause() delegates to streamPlayback", () => {
+    const mic = new MicrophoneStream(context, mockStream);
     mic.play();
-
-    await vi.waitFor(() => {
-      expect(mic.isPlaying).toBe(true);
-    });
 
     mic.pause();
     expect(mockTrack.enabled).toBe(false);
   });
 
-  it("resume() delegates to streamPlayback", async () => {
-    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
-    const mic = new MicrophoneStream(context);
+  it("resume() delegates to streamPlayback", () => {
+    const mic = new MicrophoneStream(context, mockStream);
     mic.play();
-
-    await vi.waitFor(() => {
-      expect(mic.isPlaying).toBe(true);
-    });
 
     mic.pause();
     mic.resume();

--- a/src/microphone.ts
+++ b/src/microphone.ts
@@ -128,10 +128,14 @@ export class MicrophoneStream extends FilterManager implements BaseSound {
   private stream: MediaStream | undefined;
   private streamSource?: MediaStreamAudioSourceNode;
 
-  constructor(context: AudioContext) {
+  constructor(context: AudioContext, stream?: MediaStream) {
     super();
     this.context = context;
     this.microphoneGainNode = this.context.createGain();
+    if (stream) {
+      this.stream = stream;
+      this.streamSource = this.context.createMediaStreamSource(stream);
+    }
   }
 
   play(): MicrophonePlayback[] {
@@ -147,8 +151,13 @@ export class MicrophoneStream extends FilterManager implements BaseSound {
         .catch((err) => {
           console.error("Error initializing microphone stream:", err);
         });
+      return [];
     }
-    return this.streamPlayback ? [this.streamPlayback] : [];
+    if (!this.streamPlayback) {
+      this.streamSource = this.streamSource ?? this.context.createMediaStreamSource(this.stream);
+      this.streamPlayback = new MicrophonePlayback(this.streamSource, this.microphoneGainNode, this.context);
+    }
+    return [this.streamPlayback];
   }
 
   get duration() {


### PR DESCRIPTION
## Summary
- `MicrophoneStream` constructor now accepts the already-acquired `MediaStream`, so `play()` creates playback synchronously instead of firing a redundant `getUserMedia` request
- `getMicrophoneStream()` passes the stream it already obtained to `MicrophoneStream`, eliminating the duplicate permission prompt
- First `play()` call now returns `[playback]` instead of `[]` when constructed with a stream

Fixes #32

## Test plan
- [x] All 355 existing tests pass
- [x] TypeScript typecheck clean
- [x] Updated microphone tests to verify synchronous playback return when stream is provided
- [x] Preserved async fallback path for direct `MicrophoneStream` construction without a stream