### PR TITLE
fix: preserve panner in MicrophonePlayback.refreshFilters()

### DIFF
--- a/src/microphone.ts
+++ b/src/microphone.ts
@@ -101,11 +101,11 @@ export class MicrophonePlayback extends FilterManager {
   }
 
   private refreshFilters(): void {
-    if (!this.source || !this.gainNode) {
+    if (!this.panner || !this.gainNode) {
       throw new Error("Cannot update filters on a sound that has been cleaned up");
     }
-    let connection = this.source;
-    this.source.disconnect();
+    let connection = this.panner;
+    connection.disconnect();
     connection = this.applyFilters(connection);
     connection.connect(this.gainNode);
   }


### PR DESCRIPTION
## Summary
- `MicrophonePlayback.refreshFilters()` was rewiring the audio graph as `source -> filters -> gain`, bypassing the panner node entirely
- Fixed to start the filter chain from `this.panner` (matching `Playback` and `SynthPlayback`), preserving `source -> panner -> filters -> gain`

## Test plan
- [x] TypeScript typecheck passes
- [x] All 355 existing tests pass
- Manually verify that microphone panning continues to work after adding/removing filters

Fixes #33