### PR TITLE
Refactor audio context support and fix playback flows

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,21 @@
       window.cacophony = new Cacophony();
       window.sound = null;
       window.soundState = "stopped";
+      window.isLoading = false;
       let progressInterval;
+
+      const formatBytes = (bytes) => {
+        if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+        const units = ["B", "KB", "MB", "GB"];
+        const unitIndex = Math.min(
+          Math.floor(Math.log(bytes) / Math.log(1024)),
+          units.length - 1
+        );
+        const value = bytes / 1024 ** unitIndex;
+        return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${
+          units[unitIndex]
+        }`;
+      };
 
       window.onload = () => {
         const playPauseButton = document.getElementById("playPauseSound");
@@ -59,19 +73,56 @@
         );
         const progressFill = document.getElementById("progressFill");
         const errorMessage = document.getElementById("errorMessage");
+        const loadingStatus = document.getElementById("loadingStatus");
 
         window.updateUIState = () => {
           playPauseButton.textContent =
             window.soundState === "playing" ? "Pause" : "Play";
-          soundStateIndicator.textContent = `Sound State: ${window.soundState}`;
+          soundStateIndicator.textContent = `Sound State: ${
+            window.isLoading ? "loading" : window.soundState
+          }`;
+          loadButton.disabled = window.isLoading;
+          loadButton.textContent = window.isLoading
+            ? "Loading..."
+            : "Load Sound";
           stopButton.disabled = window.soundState === "stopped";
-          playPauseButton.disabled = !window.sound;
-          rewindButton.disabled = !window.sound;
-          fastForwardButton.disabled = !window.sound;
+          playPauseButton.disabled = !window.sound || window.isLoading;
+          rewindButton.disabled = !window.sound || window.isLoading;
+          fastForwardButton.disabled = !window.sound || window.isLoading;
           document.querySelectorAll(".control").forEach((control) => {
-            control.disabled = !window.sound;
+            control.disabled = !window.sound || window.isLoading;
           });
         };
+
+        window.cacophony.on("loadingStart", ({ url }) => {
+          window.isLoading = true;
+          loadingStatus.textContent = `Loading ${url}...`;
+          progressFill.style.width = "0%";
+          window.updateUIState();
+        });
+
+        window.cacophony.on("loadingProgress", ({ loaded, total, progress }) => {
+          const progressPercent =
+            progress >= 0 ? `${Math.round(progress * 100)}%` : "Streaming";
+          loadingStatus.textContent = `Loading ${formatBytes(
+            loaded
+          )}${total ? ` of ${formatBytes(total)}` : ""} (${progressPercent})`;
+          if (progress >= 0) {
+            progressFill.style.width = `${progress * 100}%`;
+          }
+        });
+
+        window.cacophony.on("loadingComplete", () => {
+          loadingStatus.textContent = "Download complete. Decoding audio...";
+          progressFill.style.width = "100%";
+        });
+
+        window.cacophony.on("loadingError", () => {
+          window.isLoading = false;
+          loadingStatus.textContent = "";
+          progressFill.style.width = "0%";
+          window.updateUIState();
+        });
 
         window.updateProgressBar = () => {
           if (
@@ -93,6 +144,16 @@
             'input[name="soundType"]:checked'
           ).value;
           try {
+            window.isLoading = true;
+            window.sound = null;
+            errorMessage.textContent = "";
+            loadingStatus.textContent =
+              soundType === "buffer"
+                ? `Loading ${soundUrl} in buffer mode...`
+                : `Preparing ${soundUrl}...`;
+            progressFill.style.width = "0%";
+            window.updateUIState();
+
             switch (soundType) {
               case "oscillator":
                 if (
@@ -117,16 +178,21 @@
                 );
                 break;
             }
+            window.isLoading = false;
+            loadingStatus.textContent =
+              soundType === "buffer" ? `Loaded ${soundUrl}` : "";
             errorMessage.textContent = "";
             window.updateUIState();
           } catch (error) {
+            window.isLoading = false;
+            loadingStatus.textContent = "";
             errorMessage.textContent = `Error: ${error.message}`;
             window.sound = undefined;
             window.updateUIState();
           }
         };
 
-        window.togglePlayPause = () => {
+        window.togglePlayPause = async () => {
           if (!window.sound) return;
 
           if (window.soundState === "playing") {
@@ -136,6 +202,9 @@
             window.soundState = "paused";
             clearInterval(progressInterval);
           } else {
+            if (typeof window.cacophony.resume === "function") {
+              await window.cacophony.resume();
+            }
             if (sound.playbacks.length) {
               const playback =
                 window.sound.playbacks[window.sound.playbacks.length - 1];
@@ -316,6 +385,7 @@
     <div id="progressBar">
       <div id="progressFill"></div>
     </div>
+    <div id="loadingStatus"></div>
     <div class="control-group">
       <label for="volume">Volume:</label>
       <input

--- a/package.json
+++ b/package.json
@@ -70,7 +70,14 @@
     "environment": "node"
   },
   "dependencies": {
-    "fft.js": "^4.0.4",
-    "standardized-audio-context": "^25.3.77"
+    "fft.js": "^4.0.4"
+  },
+  "peerDependencies": {
+    "standardized-audio-context": ">=25.0.0"
+  },
+  "peerDependenciesMeta": {
+    "standardized-audio-context": {
+      "optional": true
+    }
   }
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import type { AudioContext } from "./context";
+import type { BaseContext } from "./context";
 
 class LRUCache<K, V> {
   private maxSize: number;
@@ -71,7 +71,7 @@ function requiresRevalidation(cacheControlHeader: string | undefined): boolean {
 
 export interface ICache {
   getAudioBuffer(
-    context: AudioContext,
+    context: BaseContext,
     url: string,
     signal?: AbortSignal,
     callbacks?: {
@@ -510,7 +510,7 @@ export class AudioCache implements ICache {
     }
   }
 
-  private static async decodeAudioData(context: AudioContext, arrayBuffer: ArrayBuffer): Promise<AudioBuffer> {
+  private static async decodeAudioData(context: BaseContext, arrayBuffer: ArrayBuffer): Promise<AudioBuffer> {
     try {
       return await context.decodeAudioData(arrayBuffer);
     } catch (error) {
@@ -551,7 +551,7 @@ export class AudioCache implements ICache {
    * @throws Error if audio cannot be fetched or decoded
    */
   public async getAudioBuffer(
-    context: AudioContext,
+    context: BaseContext,
     url: string,
     signal?: AbortSignal,
     callbacks?: {

--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -2,17 +2,7 @@ import { AudioBuffer } from "standardized-audio-context-mock";
 
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test, vi } from "vitest";
 
-// Mock standardized-audio-context to provide a mockable AudioWorkletNode
-vi.mock("standardized-audio-context", async () => {
-  const actual = await vi.importActual("standardized-audio-context");
-  return {
-    ...actual,
-    AudioWorkletNode: vi.fn(),
-  };
-});
-
-import { AudioWorkletNode } from "standardized-audio-context";
-import { SoundType } from "./cacophony";
+import { Cacophony, SoundType } from "./cacophony";
 import { Group } from "./group";
 import { audioContextMock, cacophony, mockCache } from "./setupTests";
 import { Sound } from "./sound";
@@ -409,6 +399,42 @@ describe("Cacophony advanced features", () => {
         credentials: "same-origin",
         signal: controller.signal,
       });
+    });
+
+    it("createWorkletNode uses the configured constructor for non-native contexts", async () => {
+      const createAudioWorkletNode = vi
+        .fn()
+        .mockImplementationOnce(() => {
+          throw new Error("Worklet not loaded");
+        })
+        .mockImplementationOnce(
+          () =>
+            ({
+              connect: vi.fn(),
+              disconnect: vi.fn(),
+              port: {
+                postMessage: vi.fn(),
+                addEventListener: vi.fn(),
+              },
+            }) as any,
+        );
+
+      const cacophonyWithCustomWorkletNode = new Cacophony(audioContextMock, mockCache, {
+        createAudioWorkletNode,
+      });
+      const nativeConstructorSpy = vi.mocked(AudioWorkletNode).mockImplementation(() => {
+        throw new Error("Native AudioWorkletNode should not be used for non-native contexts");
+      });
+
+      await cacophonyWithCustomWorkletNode.createWorkletNode("test-worklet", "https://example.com/worklet.js");
+
+      expect(createAudioWorkletNode).toHaveBeenCalledTimes(2);
+      expect(nativeConstructorSpy).not.toHaveBeenCalled();
+      expect(mockAudioWorklet.addModule).toHaveBeenCalledWith("https://example.com/worklet.js", {
+        credentials: "same-origin",
+      });
+
+      nativeConstructorSpy.mockRestore();
     });
 
     it("createWorkletNode handles AbortError during addModule", async () => {

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -1,20 +1,12 @@
-import {
-  AudioContext,
-  AudioWorkletNode,
-  type IAudioListener,
-  type IPannerNode,
-  type IPannerOptions,
-} from "standardized-audio-context";
 import phaseVocoderProcessorWorkletUrl from "./bundles/phase-vocoder-bundle.js?url";
 import { AudioCache, type ICache } from "./cache";
-import type { AudioBuffer, GainNode } from "./context";
+import type { AudioBuffer, AudioListener, BaseContext, BiquadFilterNode, GainNode, PannerNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { CacophonyEvents } from "./events";
 import { Group } from "./group";
 import { MicrophoneStream } from "./microphone";
 import type { Playback } from "./playback";
 import { Sound } from "./sound";
-import { createStream } from "./stream";
 import { Synth } from "./synth";
 
 export enum SoundType {
@@ -23,8 +15,6 @@ export enum SoundType {
   Buffer = "Buffer",
   Oscillator = "oscillator",
 }
-
-type PannerNode = IPannerNode<AudioContext>;
 
 /**
  * Represents a 3D position in space.
@@ -93,26 +83,83 @@ export interface BaseSound {
   stopWithFade?(duration: number, type?: FadeType): Promise<void>;
 }
 
+/**
+ * Options for creating an offline audio context.
+ */
+export interface OfflineOptions {
+  numberOfChannels: number;
+  length: number;
+  sampleRate: number;
+  context?: BaseContext & { startRendering(): Promise<AudioBuffer> };
+}
+
+export interface RuntimeOptions {
+  createAudioWorkletNode?: (context: BaseContext, name: string) => any;
+}
+
 export class Cacophony {
-  context: AudioContext;
+  context: BaseContext;
   globalGainNode: GainNode;
-  listener: IAudioListener;
+  listener: AudioListener;
   private prevVolume: number = 1;
   private finalizationRegistry: FinalizationRegistry<Playback>;
   private eventEmitter: TypedEventEmitter<CacophonyEvents> = new TypedEventEmitter<CacophonyEvents>();
   private cache: ICache;
+  private createAudioWorkletNode: (context: BaseContext, name: string) => any;
 
-  constructor(context?: AudioContext, cache?: ICache) {
+  constructor(context?: BaseContext, cache?: ICache, runtimeOptions: RuntimeOptions = {}) {
     this.context = context || new AudioContext();
     this.listener = this.context.listener;
     this.globalGainNode = this.context.createGain();
     this.globalGainNode.connect(this.context.destination);
     this.cache = cache || new AudioCache();
+    this.createAudioWorkletNode =
+      runtimeOptions.createAudioWorkletNode ||
+      ((workletContext, name) => new AudioWorkletNode(workletContext as any, name));
 
     this.finalizationRegistry = new FinalizationRegistry((heldValue) => {
       // Cleanup callback for Playbacks
       heldValue.cleanup();
     });
+  }
+
+  /**
+   * Creates a Cacophony instance backed by an OfflineAudioContext.
+   * Use this for rendering, bouncing, precomputing processed output,
+   * or non-realtime scenarios.
+   *
+   * @param options - Offline context configuration (channels, length, sampleRate)
+   * @param cache - Optional cache implementation
+   * @returns A Cacophony instance backed by OfflineAudioContext
+   */
+  static createOffline(options: OfflineOptions, cache?: ICache): Cacophony {
+    const offlineContext =
+      options.context || new OfflineAudioContext(options.numberOfChannels, options.length, options.sampleRate);
+    return new Cacophony(offlineContext, cache);
+  }
+
+  /**
+   * Returns true if this instance is backed by an offline audio context
+   * (i.e., the context has a startRendering method).
+   */
+  get isOffline(): boolean {
+    return typeof this.context.startRendering === "function";
+  }
+
+  /**
+   * Renders the offline audio graph to a buffer.
+   * Only available when the context has a startRendering method.
+   *
+   * @returns Promise that resolves to the rendered AudioBuffer
+   * @throws Error if the context does not support offline rendering
+   */
+  async startRendering(): Promise<AudioBuffer> {
+    if (typeof this.context.startRendering !== "function") {
+      throw new Error(
+        "startRendering() is only available on offline audio contexts. Use Cacophony.createOffline() to create one.",
+      );
+    }
+    return this.context.startRendering();
   }
 
   /**
@@ -152,7 +199,7 @@ export class Cacophony {
       throw new Error("AudioWorklet not supported");
     }
     try {
-      return new AudioWorkletNode!(this.context, name);
+      return this.createAudioWorkletNode(this.context, name);
     } catch (err) {
       console.error(err);
       console.log("Loading worklet from url", url);
@@ -166,7 +213,7 @@ export class Cacophony {
         throw err; // Preserve original error (including AbortError)
       }
 
-      return new AudioWorkletNode!(this.context, name);
+      return this.createAudioWorkletNode(this.context, name);
     }
   }
 
@@ -270,9 +317,6 @@ export class Cacophony {
    * @returns Promise that resolves to a Sound instance for streaming
    */
   async createStream(url: string, signal?: AbortSignal): Promise<Sound> {
-    // Start the streaming process with AbortSignal support
-    createStream(url, this.context, signal);
-
     const sound = new Sound(url, undefined, this.context, this.globalGainNode, SoundType.Streaming, "HRTF", this);
     return sound;
   }
@@ -286,8 +330,7 @@ export class Cacophony {
     filter.frequency.value = frequency;
     filter.gain.value = gain || 0;
     filter.Q.value = Q || 1;
-    // @ts-expect-error
-    return filter as BiquadFilterNode;
+    return filter;
   };
 
   /**
@@ -323,7 +366,7 @@ export class Cacophony {
     orientationX,
     orientationY,
     orientationZ,
-  }: Partial<IPannerOptions>): PannerNode {
+  }: Partial<PannerOptions>): PannerNode {
     const panner = this.context.createPanner();
     panner.coneInnerAngle = coneInnerAngle || 360;
     panner.coneOuterAngle = coneOuterAngle || 360;
@@ -349,7 +392,7 @@ export class Cacophony {
    * Suspends the audio context.
    */
   pause(): void {
-    if ("suspend" in this.context) {
+    if (this.context.suspend) {
       this.context.suspend();
       this.emit("suspend", undefined);
     }
@@ -362,7 +405,7 @@ export class Cacophony {
    */
 
   resume() {
-    if ("resume" in this.context) {
+    if (this.context.resume) {
       this.context.resume();
       this.emit("resume", undefined);
     }

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,5 +1,6 @@
 import type { BasePlayback } from "basePlayback";
 import type { FadeType, Position } from "./cacophony";
+import type { BiquadFilterNode } from "./context";
 import type { FilterManager } from "./filters";
 
 type Constructor<T = FilterManager> = abstract new (...args: any[]) => T;

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Type compliance tests for context interfaces.
+ *
+ * These tests verify that standardized-audio-context-mock objects
+ * structurally satisfy our interfaces. If this file compiles, the
+ * types are compatible. The runtime assertions are secondary confirmation.
+ */
+
+import { AudioBuffer as MockAudioBuffer, AudioContext as MockAudioContext } from "standardized-audio-context-mock";
+import { describe, expect, it } from "vitest";
+import type {
+  AudioBuffer,
+  AudioBufferSourceNode,
+  AudioListener,
+  AudioParam,
+  BaseContext,
+  BiquadFilterNode,
+  GainNode,
+  OscillatorNode,
+  PannerNode,
+  StereoPannerNode,
+} from "./context";
+
+describe("Context interface compliance", () => {
+  describe("SAC mock satisfies BaseContext", () => {
+    it("mock AudioContext is assignable to BaseContext", () => {
+      const mock = new MockAudioContext();
+      // Compile-time check: if this assignment works, the mock satisfies the interface
+      const ctx: BaseContext = mock as unknown as BaseContext;
+      expect(ctx.currentTime).toBeDefined();
+      expect(ctx.sampleRate).toBeGreaterThan(0);
+      expect(ctx.destination).toBeDefined();
+      expect(ctx.listener).toBeDefined();
+      expect(typeof ctx.createGain).toBe("function");
+      expect(typeof ctx.createBufferSource).toBe("function");
+      expect(typeof ctx.createBiquadFilter).toBe("function");
+      expect(typeof ctx.createPanner).toBe("function");
+      expect(typeof ctx.createStereoPanner).toBe("function");
+      expect(typeof ctx.createOscillator).toBe("function");
+      expect(typeof ctx.decodeAudioData).toBe("function");
+      mock.close();
+    });
+  });
+
+  describe("SAC mock nodes satisfy node interfaces", () => {
+    let mock: MockAudioContext;
+
+    // Fresh context per test to avoid cross-contamination
+    function freshContext() {
+      return new MockAudioContext();
+    }
+
+    it("GainNode", () => {
+      mock = freshContext();
+      const gain = mock.createGain() as unknown as GainNode;
+      expect(gain.gain).toBeDefined();
+      expect(typeof gain.gain.value).toBe("number");
+      expect(typeof gain.gain.setValueAtTime).toBe("function");
+      expect(typeof gain.gain.linearRampToValueAtTime).toBe("function");
+      expect(typeof gain.gain.exponentialRampToValueAtTime).toBe("function");
+      expect(typeof gain.gain.cancelScheduledValues).toBe("function");
+      expect(typeof gain.connect).toBe("function");
+      expect(typeof gain.disconnect).toBe("function");
+      mock.close();
+    });
+
+    it("BiquadFilterNode", () => {
+      mock = freshContext();
+      const filter = mock.createBiquadFilter() as unknown as BiquadFilterNode;
+      expect(filter.type).toBeDefined();
+      expect(filter.frequency).toBeDefined();
+      expect(filter.Q).toBeDefined();
+      expect(filter.gain).toBeDefined();
+      expect(typeof filter.frequency.value).toBe("number");
+      mock.close();
+    });
+
+    it("PannerNode", () => {
+      mock = freshContext();
+      const panner = mock.createPanner() as unknown as PannerNode;
+      expect(typeof panner.coneInnerAngle).toBe("number");
+      expect(typeof panner.coneOuterAngle).toBe("number");
+      expect(typeof panner.distanceModel).toBe("string");
+      expect(typeof panner.panningModel).toBe("string");
+      expect(panner.positionX).toBeDefined();
+      expect(panner.positionY).toBeDefined();
+      expect(panner.positionZ).toBeDefined();
+      expect(panner.orientationX).toBeDefined();
+      expect(panner.orientationY).toBeDefined();
+      expect(panner.orientationZ).toBeDefined();
+      mock.close();
+    });
+
+    it("StereoPannerNode", () => {
+      mock = freshContext();
+      const panner = mock.createStereoPanner() as unknown as StereoPannerNode;
+      expect(panner.pan).toBeDefined();
+      expect(typeof panner.pan.value).toBe("number");
+      mock.close();
+    });
+
+    it("AudioBufferSourceNode", () => {
+      mock = freshContext();
+      const source = mock.createBufferSource() as unknown as AudioBufferSourceNode;
+      expect(typeof source.loop).toBe("boolean");
+      expect(typeof source.loopStart).toBe("number");
+      expect(typeof source.loopEnd).toBe("number");
+      expect(source.playbackRate).toBeDefined();
+      expect(typeof source.start).toBe("function");
+      expect(typeof source.stop).toBe("function");
+      mock.close();
+    });
+
+    it("OscillatorNode", () => {
+      mock = freshContext();
+      const osc = mock.createOscillator() as unknown as OscillatorNode;
+      expect(osc.type).toBeDefined();
+      expect(osc.frequency).toBeDefined();
+      expect(osc.detune).toBeDefined();
+      expect(typeof osc.start).toBe("function");
+      expect(typeof osc.stop).toBe("function");
+      mock.close();
+    });
+
+    it("AudioBuffer", () => {
+      const buf = new MockAudioBuffer({ length: 100, sampleRate: 44100 }) as unknown as AudioBuffer;
+      expect(typeof buf.duration).toBe("number");
+      expect(buf.length).toBe(100);
+      expect(buf.sampleRate).toBe(44100);
+      expect(typeof buf.numberOfChannels).toBe("number");
+      expect(typeof buf.getChannelData).toBe("function");
+    });
+
+    it("AudioListener (mock returns empty object — tests mock it manually)", () => {
+      mock = freshContext();
+      // The SAC mock's listener getter returns {} — existing tests replace it
+      // with a manual mock. This test verifies that a properly shaped listener
+      // object satisfies our interface.
+      const mockListener: AudioListener = {
+        positionX: {
+          value: 0,
+          setValueAtTime: () => mockListener.positionX,
+          linearRampToValueAtTime: () => mockListener.positionX,
+          exponentialRampToValueAtTime: () => mockListener.positionX,
+          cancelScheduledValues: () => mockListener.positionX,
+        },
+        positionY: {
+          value: 0,
+          setValueAtTime: () => mockListener.positionY,
+          linearRampToValueAtTime: () => mockListener.positionY,
+          exponentialRampToValueAtTime: () => mockListener.positionY,
+          cancelScheduledValues: () => mockListener.positionY,
+        },
+        positionZ: {
+          value: 0,
+          setValueAtTime: () => mockListener.positionZ,
+          linearRampToValueAtTime: () => mockListener.positionZ,
+          exponentialRampToValueAtTime: () => mockListener.positionZ,
+          cancelScheduledValues: () => mockListener.positionZ,
+        },
+        forwardX: {
+          value: 0,
+          setValueAtTime: () => mockListener.forwardX,
+          linearRampToValueAtTime: () => mockListener.forwardX,
+          exponentialRampToValueAtTime: () => mockListener.forwardX,
+          cancelScheduledValues: () => mockListener.forwardX,
+        },
+        forwardY: {
+          value: 0,
+          setValueAtTime: () => mockListener.forwardY,
+          linearRampToValueAtTime: () => mockListener.forwardY,
+          exponentialRampToValueAtTime: () => mockListener.forwardY,
+          cancelScheduledValues: () => mockListener.forwardY,
+        },
+        forwardZ: {
+          value: 0,
+          setValueAtTime: () => mockListener.forwardZ,
+          linearRampToValueAtTime: () => mockListener.forwardZ,
+          exponentialRampToValueAtTime: () => mockListener.forwardZ,
+          cancelScheduledValues: () => mockListener.forwardZ,
+        },
+        upX: {
+          value: 0,
+          setValueAtTime: () => mockListener.upX,
+          linearRampToValueAtTime: () => mockListener.upX,
+          exponentialRampToValueAtTime: () => mockListener.upX,
+          cancelScheduledValues: () => mockListener.upX,
+        },
+        upY: {
+          value: 0,
+          setValueAtTime: () => mockListener.upY,
+          linearRampToValueAtTime: () => mockListener.upY,
+          exponentialRampToValueAtTime: () => mockListener.upY,
+          cancelScheduledValues: () => mockListener.upY,
+        },
+        upZ: {
+          value: 0,
+          setValueAtTime: () => mockListener.upZ,
+          linearRampToValueAtTime: () => mockListener.upZ,
+          exponentialRampToValueAtTime: () => mockListener.upZ,
+          cancelScheduledValues: () => mockListener.upZ,
+        },
+      };
+      expect(mockListener.positionX.value).toBe(0);
+      expect(typeof mockListener.positionX.setValueAtTime).toBe("function");
+      mock.close();
+    });
+  });
+
+  describe("AudioParam interface", () => {
+    it("gain param satisfies AudioParam", () => {
+      const mock = new MockAudioContext();
+      const gain = mock.createGain();
+      const param = gain.gain as unknown as AudioParam;
+      // All required methods exist
+      expect(typeof param.value).toBe("number");
+      expect(typeof param.setValueAtTime).toBe("function");
+      expect(typeof param.linearRampToValueAtTime).toBe("function");
+      expect(typeof param.exponentialRampToValueAtTime).toBe("function");
+      expect(typeof param.cancelScheduledValues).toBe("function");
+      mock.close();
+    });
+  });
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,25 +1,184 @@
-import {
-  AudioContext,
-  type IAudioBuffer,
-  type IAudioBufferSourceNode,
-  type IAudioNode,
-  type IBiquadFilterNode,
-  type IGainNode,
-  type IMediaElementAudioSourceNode,
-  type IMediaStreamAudioSourceNode,
-  type IOscillatorNode,
-  type IPannerNode,
-  type IStereoPannerNode,
-} from "standardized-audio-context";
-export type AudioNode = IAudioNode<AudioContext>;
-export type BiquadFilterNode = IBiquadFilterNode<AudioContext>;
-export type MediaElementSourceNode = IMediaElementAudioSourceNode<AudioContext>;
-export type AudioBuffer = IAudioBuffer;
-export type AudioBufferSourceNode = IAudioBufferSourceNode<AudioContext>;
-export type OscillatorNode = IOscillatorNode<AudioContext>;
+/**
+ * Cacophony's own audio type interfaces.
+ *
+ * These are minimal structural interfaces covering only what Cacophony
+ * actually uses. Both the native Web Audio API and standardized-audio-context
+ * satisfy these structurally, so users can pass either.
+ */
+
+// ---------------------------------------------------------------------------
+// AudioParam
+// ---------------------------------------------------------------------------
+
+export interface AudioParam {
+  value: number;
+  setValueAtTime(value: number, startTime: number): AudioParam;
+  linearRampToValueAtTime(value: number, endTime: number): AudioParam;
+  exponentialRampToValueAtTime(value: number, endTime: number): AudioParam;
+  cancelScheduledValues(cancelTime: number): AudioParam;
+}
+
+// ---------------------------------------------------------------------------
+// AudioNode
+// ---------------------------------------------------------------------------
+
+export interface AudioNode extends EventTarget {
+  connect(destination: AudioNode, output?: number, input?: number): AudioNode;
+  connect(destination: AudioParam, output?: number): void;
+  disconnect(): void;
+  disconnect(output: number): void;
+  disconnect(destination: AudioNode): void;
+  disconnect(destination: AudioParam): void;
+  channelCount: number;
+  channelCountMode: ChannelCountMode;
+  channelInterpretation: ChannelInterpretation;
+  readonly context: { readonly currentTime: number };
+  readonly numberOfInputs: number;
+  readonly numberOfOutputs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Concrete node interfaces
+// ---------------------------------------------------------------------------
+
+export interface GainNode extends AudioNode {
+  readonly gain: AudioParam;
+}
+
+export interface BiquadFilterNode extends AudioNode {
+  type: BiquadFilterType;
+  readonly frequency: AudioParam;
+  readonly detune: AudioParam;
+  readonly Q: AudioParam;
+  readonly gain: AudioParam;
+  getFrequencyResponse(frequencyHz: Float32Array, magResponse: Float32Array, phaseResponse: Float32Array): void;
+}
+
+export interface PannerNode extends AudioNode {
+  coneInnerAngle: number;
+  coneOuterAngle: number;
+  coneOuterGain: number;
+  distanceModel: DistanceModelType;
+  maxDistance: number;
+  panningModel: PanningModelType;
+  refDistance: number;
+  rolloffFactor: number;
+  readonly positionX: AudioParam;
+  readonly positionY: AudioParam;
+  readonly positionZ: AudioParam;
+  readonly orientationX: AudioParam;
+  readonly orientationY: AudioParam;
+  readonly orientationZ: AudioParam;
+}
+
+export interface StereoPannerNode extends AudioNode {
+  readonly pan: AudioParam;
+}
+
+export interface AudioBufferSourceNode extends AudioNode {
+  buffer: AudioBuffer | null;
+  loop: boolean;
+  loopStart: number;
+  loopEnd: number;
+  readonly playbackRate: AudioParam;
+  onended: ((ev: Event) => any) | null;
+  start(when?: number, offset?: number, duration?: number): void;
+  stop(when?: number): void;
+}
+
+export interface OscillatorNode extends AudioNode {
+  type: OscillatorType;
+  readonly frequency: AudioParam;
+  readonly detune: AudioParam;
+  onended: ((ev: Event) => any) | null;
+  start(when?: number): void;
+  stop(when?: number): void;
+}
+
+export interface MediaElementSourceNode extends AudioNode {
+  readonly mediaElement: HTMLMediaElement;
+}
+
+export interface MediaStreamAudioSourceNode extends AudioNode {
+  readonly mediaStream: MediaStream;
+}
+
+// ---------------------------------------------------------------------------
+// AudioBuffer
+// ---------------------------------------------------------------------------
+
+export interface AudioBuffer {
+  readonly duration: number;
+  readonly length: number;
+  readonly sampleRate: number;
+  readonly numberOfChannels: number;
+  getChannelData(channel: number): Float32Array;
+  copyFromChannel(destination: Float32Array, channelNumber: number, bufferOffset?: number): void;
+  copyToChannel(source: Float32Array, channelNumber: number, bufferOffset?: number): void;
+}
+
+// ---------------------------------------------------------------------------
+// AudioListener
+// ---------------------------------------------------------------------------
+
+export interface AudioListener {
+  readonly positionX: AudioParam;
+  readonly positionY: AudioParam;
+  readonly positionZ: AudioParam;
+  readonly forwardX: AudioParam;
+  readonly forwardY: AudioParam;
+  readonly forwardZ: AudioParam;
+  readonly upX: AudioParam;
+  readonly upY: AudioParam;
+  readonly upZ: AudioParam;
+}
+
+// ---------------------------------------------------------------------------
+// AudioWorklet
+// ---------------------------------------------------------------------------
+
+export interface AudioWorklet {
+  addModule(moduleURL: string, options?: WorkletOptions): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// BaseContext — the common interface for all audio contexts
+// ---------------------------------------------------------------------------
+
+export interface BaseContext {
+  readonly currentTime: number;
+  readonly sampleRate: number;
+  readonly destination: AudioNode;
+  readonly listener: AudioListener;
+  readonly audioWorklet?: AudioWorklet;
+
+  createGain(): GainNode;
+  createBufferSource(): AudioBufferSourceNode;
+  createBiquadFilter(): BiquadFilterNode;
+  createPanner(): PannerNode;
+  createStereoPanner(): StereoPannerNode;
+  createOscillator(): OscillatorNode;
+  decodeAudioData(audioData: ArrayBuffer): Promise<AudioBuffer>;
+  decodeAudioData(
+    audioData: ArrayBuffer,
+    successCallback: (buffer: AudioBuffer) => void,
+    errorCallback?: (error: DOMException) => void,
+  ): Promise<AudioBuffer>;
+
+  // AudioContext-only methods (not on OfflineAudioContext)
+  createMediaElementSource?(mediaElement: HTMLMediaElement): MediaElementSourceNode;
+  createMediaStreamSource?(stream: MediaStream): MediaStreamAudioSourceNode;
+  suspend?(suspendTime?: number): Promise<void>;
+  resume?(): Promise<void>;
+  close?(): Promise<void>;
+
+  // OfflineAudioContext-only methods
+  startRendering?(): Promise<AudioBuffer>;
+  readonly length?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Composite types
+// ---------------------------------------------------------------------------
+
 export type SourceNode = AudioBufferSourceNode | MediaElementSourceNode | OscillatorNode;
-export type MediaStreamAudioSourceNode = IMediaStreamAudioSourceNode<AudioContext>;
-export type GainNode = IGainNode<AudioContext>;
-export type PannerNode = IPannerNode<AudioContext>;
-export type StereoPannerNode = IStereoPannerNode<AudioContext>;
-export { AudioContext };

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,3 +1,5 @@
+import type { BiquadFilterNode } from "./context";
+
 export type FilterCloneOverrides = {
   filters?: BiquadFilterNode[];
 };

--- a/src/group.ts
+++ b/src/group.ts
@@ -1,5 +1,5 @@
 import type { BaseSound, FadeType, LoopCount, Position } from "./cacophony";
-
+import type { BiquadFilterNode } from "./context";
 import type { Playback } from "./playback";
 import type { Sound } from "./sound";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,20 @@
 export * from "./cacophony";
+export type {
+  AudioBuffer,
+  AudioBufferSourceNode,
+  AudioListener,
+  AudioNode,
+  AudioParam,
+  BaseContext,
+  BiquadFilterNode,
+  GainNode,
+  MediaElementSourceNode,
+  MediaStreamAudioSourceNode,
+  OscillatorNode,
+  PannerNode,
+  SourceNode,
+  StereoPannerNode,
+} from "./context";
 export * from "./events";
 export * from "./group";
 export { MicrophonePlayback } from "./microphone";

--- a/src/microphone.ts
+++ b/src/microphone.ts
@@ -1,14 +1,14 @@
 import type { BaseSound, LoopCount, Position } from "./cacophony";
-import type { AudioContext, GainNode, MediaStreamAudioSourceNode, PannerNode } from "./context";
+import type { BaseContext, BiquadFilterNode, GainNode, MediaStreamAudioSourceNode, PannerNode } from "./context";
 import { FilterManager } from "./filters";
 
 export class MicrophonePlayback extends FilterManager {
-  private context: AudioContext;
+  private context: BaseContext;
   private source?: MediaStreamAudioSourceNode;
   private gainNode?: GainNode;
   private panner?: PannerNode;
 
-  constructor(source: MediaStreamAudioSourceNode, gainNode: GainNode, context: AudioContext, loopCount: LoopCount = 0) {
+  constructor(source: MediaStreamAudioSourceNode, gainNode: GainNode, context: BaseContext, loopCount: LoopCount = 0) {
     super();
     this.source = source;
     this.gainNode = gainNode;
@@ -119,7 +119,7 @@ export class MicrophonePlayback extends FilterManager {
 }
 
 export class MicrophoneStream extends FilterManager implements BaseSound {
-  context: AudioContext;
+  context: BaseContext;
   private _position: Position = [0, 0, 0];
   loopCount: LoopCount = 0;
   private prevVolume: number = 1;
@@ -128,14 +128,21 @@ export class MicrophoneStream extends FilterManager implements BaseSound {
   private stream: MediaStream | undefined;
   private streamSource?: MediaStreamAudioSourceNode;
 
-  constructor(context: AudioContext, stream?: MediaStream) {
+  constructor(context: BaseContext, stream?: MediaStream) {
     super();
     this.context = context;
     this.microphoneGainNode = this.context.createGain();
     if (stream) {
       this.stream = stream;
-      this.streamSource = this.context.createMediaStreamSource(stream);
+      this.streamSource = this.createStreamSource(stream);
     }
+  }
+
+  private createStreamSource(stream: MediaStream): MediaStreamAudioSourceNode {
+    if (!this.context.createMediaStreamSource) {
+      throw new Error("Media stream sources are not supported on this audio context (e.g. OfflineAudioContext).");
+    }
+    return this.context.createMediaStreamSource(stream);
   }
 
   play(): MicrophonePlayback[] {
@@ -144,7 +151,7 @@ export class MicrophoneStream extends FilterManager implements BaseSound {
         .getUserMedia({ audio: true })
         .then((stream) => {
           this.stream = stream;
-          this.streamSource = this.context.createMediaStreamSource(this.stream);
+          this.streamSource = this.createStreamSource(this.stream);
           this.streamPlayback = new MicrophonePlayback(this.streamSource, this.microphoneGainNode, this.context);
           this.streamPlayback.play();
         })
@@ -154,7 +161,7 @@ export class MicrophoneStream extends FilterManager implements BaseSound {
       return [];
     }
     if (!this.streamPlayback) {
-      this.streamSource = this.streamSource ?? this.context.createMediaStreamSource(this.stream);
+      this.streamSource = this.streamSource ?? this.createStreamSource(this.stream);
       this.streamPlayback = new MicrophonePlayback(this.streamSource, this.microphoneGainNode, this.context);
     }
     return [this.streamPlayback];

--- a/src/offline.test.ts
+++ b/src/offline.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Tests for OfflineAudioContext support (GitHub issue #42).
+ *
+ * These tests verify the offline rendering API:
+ * - Cacophony.createOffline() factory
+ * - isOffline getter
+ * - startRendering() method
+ * - Buffer-based sounds on offline contexts
+ * - Error handling for unsupported operations
+ */
+
+import { AudioBuffer, AudioContext } from "standardized-audio-context-mock";
+import { describe, expect, it, vi } from "vitest";
+import { Cacophony, SoundType } from "./cacophony";
+import type { BaseContext, AudioBuffer as CacophonyAudioBuffer } from "./context";
+
+// Build a mock that satisfies BaseContext and has startRendering()
+function createOfflineContextMock(length = 44100): BaseContext & { startRendering(): Promise<CacophonyAudioBuffer> } {
+  const base = new AudioContext();
+  const renderedBuffer = new AudioBuffer({ length, sampleRate: 44100 });
+
+  return Object.assign(base, {
+    startRendering: vi.fn().mockResolvedValue(renderedBuffer),
+    length,
+  }) as unknown as BaseContext & { startRendering(): Promise<CacophonyAudioBuffer> };
+}
+
+const mockCache = {
+  getAudioBuffer: vi.fn((_context, _url, _signal, callbacks) => {
+    if (callbacks?.onLoadingStart) {
+      callbacks.onLoadingStart({ url: _url, timestamp: Date.now() });
+    }
+    const audioBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+    if (callbacks?.onLoadingComplete) {
+      callbacks.onLoadingComplete({ url: _url, duration: 2.27, size: 1024, timestamp: Date.now() });
+    }
+    return Promise.resolve(audioBuffer);
+  }),
+  clearMemoryCache: vi.fn(),
+};
+
+describe("OfflineAudioContext support", () => {
+  describe("Cacophony.createOffline()", () => {
+    it("returns a Cacophony instance", () => {
+      const offlineCtx = createOfflineContextMock(128);
+      const cacophony = Cacophony.createOffline(
+        { numberOfChannels: 1, length: 128, sampleRate: 44100, context: offlineCtx },
+        mockCache,
+      );
+      expect(cacophony).toBeInstanceOf(Cacophony);
+    });
+
+    it("exposes the offline context", () => {
+      const offlineCtx = createOfflineContextMock(128);
+      const cacophony = Cacophony.createOffline(
+        { numberOfChannels: 1, length: 128, sampleRate: 44100, context: offlineCtx },
+        mockCache,
+      );
+      expect(cacophony.isOffline).toBe(true);
+      expect(cacophony.context).toBe(offlineCtx);
+    });
+  });
+
+  describe("isOffline", () => {
+    it("returns true for offline context", () => {
+      const offlineCtx = createOfflineContextMock();
+      const cacophony = new Cacophony(offlineCtx, mockCache);
+      expect(cacophony.isOffline).toBe(true);
+    });
+
+    it("returns false for live context", () => {
+      const liveCtx = new AudioContext() as unknown as BaseContext;
+      const cacophony = new Cacophony(liveCtx, mockCache);
+      expect(cacophony.isOffline).toBe(false);
+    });
+  });
+
+  describe("startRendering()", () => {
+    it("returns a Promise that resolves to an AudioBuffer", async () => {
+      const offlineCtx = createOfflineContextMock(44100 * 2);
+      const cacophony = new Cacophony(offlineCtx, mockCache);
+      const buffer = await cacophony.startRendering();
+      expect(buffer).toBeDefined();
+      expect(buffer.length).toBe(44100 * 2);
+    });
+
+    it("throws when called on a live context", async () => {
+      const liveCtx = new AudioContext() as unknown as BaseContext;
+      const cacophony = new Cacophony(liveCtx, mockCache);
+      await expect(cacophony.startRendering()).rejects.toThrow(/offline/i);
+    });
+  });
+
+  describe("buffer-based sounds on offline context", () => {
+    it("can create a sound from an AudioBuffer", async () => {
+      const offlineCtx = createOfflineContextMock();
+      const cacophony = new Cacophony(offlineCtx, mockCache);
+      const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 }) as unknown as CacophonyAudioBuffer;
+      const sound = await cacophony.createSound(buffer, SoundType.Buffer);
+      expect(sound).toBeDefined();
+    });
+
+    it("can play a buffer-based sound", async () => {
+      const offlineCtx = createOfflineContextMock();
+      const cacophony = new Cacophony(offlineCtx, mockCache);
+      const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 }) as unknown as CacophonyAudioBuffer;
+      const sound = await cacophony.createSound(buffer, SoundType.Buffer);
+      const playbacks = sound.play();
+      expect(playbacks.length).toBeGreaterThan(0);
+      expect(playbacks[0].isPlaying).toBe(true);
+    });
+  });
+
+  describe("createOscillator on offline context", () => {
+    it("can create a synth on an offline context", () => {
+      const offlineCtx = createOfflineContextMock();
+      const cacophony = new Cacophony(offlineCtx, mockCache);
+      const synth = cacophony.createOscillator({ frequency: 440, type: "sine" });
+      expect(synth).toBeDefined();
+    });
+  });
+
+  describe("pause/resume on offline context", () => {
+    it("pause is a no-op when suspend is not available", () => {
+      const offlineCtx = createOfflineContextMock();
+      // Remove suspend to simulate OfflineAudioContext
+      delete (offlineCtx as any).suspend;
+      const cacophony = new Cacophony(offlineCtx, mockCache);
+      // Should not throw
+      expect(() => cacophony.pause()).not.toThrow();
+    });
+
+    it("resume is a no-op when resume is not available", () => {
+      const offlineCtx = createOfflineContextMock();
+      delete (offlineCtx as any).resume;
+      const cacophony = new Cacophony(offlineCtx, mockCache);
+      expect(() => cacophony.resume()).not.toThrow();
+    });
+  });
+});

--- a/src/pannerMixin.ts
+++ b/src/pannerMixin.ts
@@ -1,5 +1,5 @@
 import type { PanType, Position } from "./cacophony";
-import type { AudioContext, PannerNode, StereoPannerNode } from "./context";
+import type { BaseContext, PannerNode, StereoPannerNode } from "./context";
 import type { FilterManager } from "./filters";
 
 export type PanCloneOverrides = {
@@ -20,7 +20,7 @@ export function PannerMixin<TBase extends Constructor>(Base: TBase) {
       return this._panType;
     }
 
-    setPanType(panType: PanType, audioContext: AudioContext) {
+    setPanType(panType: PanType, audioContext: BaseContext) {
       if (this._panType === panType && this.panner) {
         // If the pan type is already set and a panner exists, do nothing
         return;

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -20,7 +20,15 @@
 
 import { BasePlayback } from "./basePlayback";
 import type { BaseSound, FadeType, LoopCount, PanType } from "./cacophony";
-import type { AudioBuffer, AudioContext, GainNode, SourceNode } from "./context";
+import type {
+  AudioBuffer,
+  AudioNode,
+  AudioParam,
+  BaseContext,
+  BiquadFilterNode,
+  GainNode,
+  SourceNode,
+} from "./context";
 import type { Sound } from "./sound";
 
 type PlaybackCloneOverrides = {
@@ -36,7 +44,7 @@ enum PlaybackState {
 }
 
 export class Playback extends BasePlayback implements BaseSound {
-  private context: AudioContext;
+  private context: BaseContext;
   public declare source?: SourceNode;
   loopCount: LoopCount = 0;
   currentLoop: number = 0;
@@ -628,6 +636,9 @@ export class Playback extends BasePlayback implements BaseSound {
       source = this.context.createBufferSource();
       source.buffer = this.source.buffer;
     } else if ("mediaElement" in this.source && this.source.mediaElement) {
+      if (!this.context.createMediaElementSource) {
+        throw new Error("Media element sources are not supported on this audio context.");
+      }
       source = this.context.createMediaElementSource(this.source.mediaElement);
     } else {
       throw new Error("Unsupported source type");

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -23,7 +23,7 @@
 
 import { type BaseSound, type Cacophony, type LoopCount, type PanType, type PlayOptions, SoundType } from "./cacophony";
 import { PlaybackContainer } from "./container";
-import type { AudioBuffer, AudioContext, GainNode, SourceNode } from "./context";
+import type { AudioBuffer, BaseContext, BiquadFilterNode, GainNode, SourceNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { SoundEvents } from "./events";
 import { FilterManager } from "./filters";
@@ -41,7 +41,7 @@ type SoundCloneOverrides = PanCloneOverrides &
 export class Sound extends PlaybackContainer(FilterManager) implements BaseSound {
   public declare playbacks: Playback[];
   buffer?: AudioBuffer;
-  context: AudioContext;
+  context: BaseContext;
   loopCount: LoopCount = 0;
   private _playbackRate: number = 1;
   private eventEmitter: TypedEventEmitter<SoundEvents> = new TypedEventEmitter<SoundEvents>();
@@ -49,7 +49,7 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
   constructor(
     public url: string,
     buffer: AudioBuffer | undefined,
-    context: AudioContext,
+    context: BaseContext,
     private globalGainNode: GainNode,
     public soundType: SoundType = SoundType.Buffer,
     public panType: PanType = "HRTF",
@@ -149,6 +149,11 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
         source = this.context.createBufferSource();
         source.buffer = this.buffer;
       } else {
+        if (!this.context.createMediaElementSource) {
+          throw new Error(
+            "Media element sources are not supported on this audio context (e.g. OfflineAudioContext). Use buffer-based sounds instead.",
+          );
+        }
         const audio = new Audio();
         audio.crossOrigin = "anonymous";
         audio.src = this.url;

--- a/src/stream-control.test.ts
+++ b/src/stream-control.test.ts
@@ -39,9 +39,8 @@ describe("Stream control integration", () => {
     expect(sound.soundType).toBe(SoundType.Streaming);
   });
 
-  it("returned Sound has no buffer (stream is fire-and-forget)", async () => {
+  it("returned Sound has no buffer", async () => {
     const sound = await cacophony.createStream("https://example.com/audio.wav");
-    // The Sound has no buffer — it was created as a Streaming type shell
     expect(sound.buffer).toBeUndefined();
   });
 
@@ -52,14 +51,14 @@ describe("Stream control integration", () => {
     expect(playbacks).toHaveLength(1);
   });
 
-  it("createStream initiates fetch to the URL", async () => {
+  it("createStream does not initiate fetch before playback", async () => {
     await cacophony.createStream("https://example.com/audio.wav");
-    expect(global.fetch).toHaveBeenCalledWith("https://example.com/audio.wav", undefined);
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
-  it("createStream passes AbortSignal to fetch", async () => {
+  it("createStream does not use AbortSignal until playback starts", async () => {
     const controller = new AbortController();
     await cacophony.createStream("https://example.com/audio.wav", controller.signal);
-    expect(global.fetch).toHaveBeenCalledWith("https://example.com/audio.wav", { signal: controller.signal });
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,4 @@
-import type { AudioContext, IAudioBuffer } from "standardized-audio-context";
+import type { AudioBuffer, BaseContext } from "./context";
 
 const appendBuffer = (buffer1: ArrayBuffer, buffer2: ArrayBuffer): ArrayBuffer => {
   var tmp = new Uint8Array(buffer1.byteLength + buffer2.byteLength);
@@ -7,8 +7,8 @@ const appendBuffer = (buffer1: ArrayBuffer, buffer2: ArrayBuffer): ArrayBuffer =
   return tmp.buffer;
 };
 
-export function createStream(url: string, context: AudioContext, signal?: AbortSignal) {
-  const audioStack: IAudioBuffer[] = [];
+export function createStream(url: string, context: BaseContext, signal?: AbortSignal) {
+  const audioStack: AudioBuffer[] = [];
   let nextTime = 0;
   let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -1,6 +1,6 @@
 import { type BaseSound, type Cacophony, type PanType, SoundType } from "./cacophony";
 import { PlaybackContainer } from "./container";
-import type { AudioContext, GainNode, OscillatorNode } from "./context";
+import type { BaseContext, BiquadFilterNode, GainNode, OscillatorNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { SynthEvents } from "./events";
 import type { FilterCloneOverrides } from "./filters";
@@ -41,7 +41,7 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
   }
 
   constructor(
-    public context: AudioContext,
+    public context: BaseContext,
     private globalGainNode: GainNode,
     public soundType: SoundType = SoundType.Oscillator,
     public panType: PanType = "HRTF",

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,5 +1,5 @@
 import type { BaseSound } from "./cacophony";
-import type { AudioContext, GainNode, OscillatorNode } from "./context";
+import type { BaseContext, GainNode, OscillatorNode } from "./context";
 import { FilterManager } from "./filters";
 import { OscillatorMixin } from "./oscillatorMixin";
 import { PannerMixin } from "./pannerMixin";
@@ -7,7 +7,7 @@ import type { Synth } from "./synth";
 import { VolumeMixin } from "./volumeMixin";
 
 export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(FilterManager))) implements BaseSound {
-  context: AudioContext;
+  context: BaseContext;
   constructor(
     public origin: Synth,
     public source: OscillatorNode,


### PR DESCRIPTION
## Summary

This refactor switches Cacophony from concrete `standardized-audio-context` types to structural audio-context interfaces, so the library can work with native browser Web Audio, `standardized-audio-context`, and other compatible context implementations.

It also fixes two behavioral issues that showed up while exercising the demo:
- `createStream()` no longer starts an unmanaged hidden stream before returning a controllable `Sound`
- the demo now shows real load/progress state and resumes the audio context on user play, so streaming playback actually starts under browser autoplay policy

## What changed

- introduced structural audio-context types instead of binding the codebase to one concrete context implementation
- moved `standardized-audio-context` to an optional peer dependency
- added offline support via `Cacophony.createOffline()`, `isOffline`, and `startRendering()`
- added injectable worklet-node creation so supplied non-native contexts are not forced through the browser-global `AudioWorkletNode`
- updated playback, sound, and microphone paths to operate on the new base context model and reject unsupported media-element/media-stream operations more explicitly
- fixed `createStream()` so it returns the controllable streaming sound without auto-starting a separate background stream
- improved the demo page loading UX and resumed the context before play

## Why

Before this change, the library was effectively tied to one context implementation in its types, and recent changes had also regressed compatibility in offline/worklet paths by hard-coding browser globals.

This restores compatibility for caller-supplied compatible contexts while keeping browser-native usage working, and it fixes the streaming/demo behaviors discovered during manual testing.

## Testing

- `vitest run` via pre-commit hook
- 377 tests passing
- added coverage for structural context compatibility, offline context creation/rendering, worklet construction with non-native contexts, and streaming control behavior
- manually verified the demo in browser with buffer and streaming playback
