### PR TITLE
Wire up FinalizationRegistry for automatic Sound cleanup

### DIFF
--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -5,7 +5,6 @@ import { TypedEventEmitter } from "./eventEmitter";
 import type { CacophonyEvents } from "./events";
 import { Group } from "./group";
 import { MicrophoneStream } from "./microphone";
-import type { Playback } from "./playback";
 import { Sound } from "./sound";
 import { Synth } from "./synth";
 
@@ -97,12 +96,25 @@ export interface RuntimeOptions {
   createAudioWorkletNode?: (context: BaseContext, name: string) => any;
 }
 
+/**
+ * Resources belonging to a Sound that must be released when the Sound is
+ * garbage collected without an explicit cleanup() call. The record is a plain
+ * data bag with no back-references to the Sound or its Playbacks — a
+ * FinalizationRegistry strongly retains its held value, so holding the Sound
+ * itself would prevent the target from ever becoming collectable.
+ */
+export interface SoundCleanupHoldings {
+  sources: Array<{ disconnect(): void }>;
+  gainNodes: GainNode[];
+  mediaElements: HTMLMediaElement[];
+}
+
 export class Cacophony {
   context: BaseContext;
   globalGainNode: GainNode;
   listener: AudioListener;
   private prevVolume: number = 1;
-  private finalizationRegistry: FinalizationRegistry<Playback>;
+  private finalizationRegistry: FinalizationRegistry<SoundCleanupHoldings>;
   private eventEmitter: TypedEventEmitter<CacophonyEvents> = new TypedEventEmitter<CacophonyEvents>();
   private cache: ICache;
   private createAudioWorkletNode: (context: BaseContext, name: string) => any;
@@ -117,10 +129,29 @@ export class Cacophony {
       runtimeOptions.createAudioWorkletNode ||
       ((workletContext, name) => new AudioWorkletNode(workletContext as any, name));
 
-    this.finalizationRegistry = new FinalizationRegistry((heldValue) => {
-      // Cleanup callback for Playbacks
-      heldValue.cleanup();
+    this.finalizationRegistry = new FinalizationRegistry((holdings) => {
+      for (const source of holdings.sources) {
+        source.disconnect();
+      }
+      for (const gainNode of holdings.gainNodes) {
+        gainNode.disconnect();
+      }
+      for (const media of holdings.mediaElements) {
+        media.pause();
+        media.removeAttribute("src");
+        media.load();
+      }
     });
+  }
+
+  /** @internal */
+  registerSoundForCleanup(sound: object, holdings: SoundCleanupHoldings, unregisterToken: object): void {
+    this.finalizationRegistry.register(sound, holdings, unregisterToken);
+  }
+
+  /** @internal */
+  unregisterSoundCleanup(unregisterToken: object): void {
+    this.finalizationRegistry.unregister(unregisterToken);
   }
 
   /**

--- a/src/sound.test.ts
+++ b/src/sound.test.ts
@@ -1229,3 +1229,103 @@ describe("Sound.play with fade options", () => {
     expect(pb._fadeOutConfig!.duration).toBe(500);
   });
 });
+
+describe("Sound FinalizationRegistry wire-up", () => {
+  let buffer: AudioBuffer;
+
+  beforeEach(() => {
+    buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers newly constructed Sounds with Cacophony for automatic cleanup", () => {
+    const registerSpy = vi.spyOn(cacophony, "registerSoundForCleanup");
+    const sound = new Sound(
+      "test-url",
+      buffer,
+      audioContextMock,
+      audioContextMock.createGain(),
+      SoundType.Buffer,
+      "HRTF",
+      cacophony,
+    );
+    expect(registerSpy).toHaveBeenCalledTimes(1);
+    const [target, holdings, token] = registerSpy.mock.calls[0];
+    expect(target).toBe(sound);
+    expect(holdings).toEqual({ sources: [], gainNodes: [], mediaElements: [] });
+    expect(token).toBeTypeOf("object");
+    expect(token).not.toBe(sound); // decoupled from the target
+  });
+
+  it("populates cleanup holdings when playbacks are created", () => {
+    const registerSpy = vi.spyOn(cacophony, "registerSoundForCleanup");
+    const sound = new Sound(
+      "test-url",
+      buffer,
+      audioContextMock,
+      audioContextMock.createGain(),
+      SoundType.Buffer,
+      "HRTF",
+      cacophony,
+    );
+    const [, holdings] = registerSpy.mock.calls[0];
+
+    expect(holdings.sources.length).toBe(0);
+    expect(holdings.gainNodes.length).toBe(0);
+
+    sound.preplay();
+    expect(holdings.sources.length).toBe(1);
+    expect(holdings.gainNodes.length).toBe(1);
+
+    sound.preplay();
+    expect(holdings.sources.length).toBe(2);
+    expect(holdings.gainNodes.length).toBe(2);
+  });
+
+  it("unregisters from the cleanup registry on explicit cleanup()", () => {
+    const registerSpy = vi.spyOn(cacophony, "registerSoundForCleanup");
+    const unregisterSpy = vi.spyOn(cacophony, "unregisterSoundCleanup");
+    const sound = new Sound(
+      "test-url",
+      buffer,
+      audioContextMock,
+      audioContextMock.createGain(),
+      SoundType.Buffer,
+      "HRTF",
+      cacophony,
+    );
+    const registrationToken = registerSpy.mock.calls[0][2];
+
+    sound.preplay();
+    sound.cleanup();
+
+    expect(unregisterSpy).toHaveBeenCalledTimes(1);
+    expect(unregisterSpy.mock.calls[0][0]).toBe(registrationToken);
+  });
+
+  it("clears holdings on stop() so repeated play/stop does not grow memory", () => {
+    const registerSpy = vi.spyOn(cacophony, "registerSoundForCleanup");
+    const sound = new Sound(
+      "test-url",
+      buffer,
+      audioContextMock,
+      audioContextMock.createGain(),
+      SoundType.Buffer,
+      "HRTF",
+      cacophony,
+    );
+    const [, holdings] = registerSpy.mock.calls[0];
+
+    sound.play();
+    sound.play();
+    expect(holdings.sources.length).toBe(2);
+
+    sound.stop();
+    expect(holdings.sources.length).toBe(0);
+    expect(holdings.gainNodes.length).toBe(0);
+    expect(holdings.mediaElements.length).toBe(0);
+  });
+});

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -21,7 +21,15 @@
  * instances of a sound with different settings, without requiring the user to manually manage each playback instance.
  */
 
-import { type BaseSound, type Cacophony, type LoopCount, type PanType, type PlayOptions, SoundType } from "./cacophony";
+import {
+  type BaseSound,
+  type Cacophony,
+  type LoopCount,
+  type PanType,
+  type PlayOptions,
+  type SoundCleanupHoldings,
+  SoundType,
+} from "./cacophony";
 import { PlaybackContainer } from "./container";
 import type { AudioBuffer, BaseContext, BiquadFilterNode, GainNode, SourceNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
@@ -45,6 +53,8 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
   loopCount: LoopCount = 0;
   private _playbackRate: number = 1;
   private eventEmitter: TypedEventEmitter<SoundEvents> = new TypedEventEmitter<SoundEvents>();
+  private _holdings: SoundCleanupHoldings = { sources: [], gainNodes: [], mediaElements: [] };
+  private _unregisterToken: object = {};
 
   constructor(
     public url: string,
@@ -58,6 +68,7 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
     super();
     this.buffer = buffer;
     this.context = context;
+    this._cacophony?.registerSoundForCleanup(this, this._holdings, this._unregisterToken);
   }
 
   get cacophony(): Cacophony | undefined {
@@ -164,7 +175,11 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
       const gainNode = this.context.createGain();
       gainNode.connect(this.globalGainNode);
       const playback = new Playback(this, source, gainNode);
-      // this.finalizationRegistry.register(playback, playback);
+      this._holdings.sources.push(source);
+      this._holdings.gainNodes.push(gainNode);
+      if ("mediaElement" in source && source.mediaElement) {
+        this._holdings.mediaElements.push(source.mediaElement);
+      }
       playback.setGainNode(gainNode);
       playback.volume = this.volume;
       playback.playbackRate = this.playbackRate;
@@ -254,6 +269,9 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
   }
 
   stop(): void {
+    this._holdings.sources.length = 0;
+    this._holdings.gainNodes.length = 0;
+    this._holdings.mediaElements.length = 0;
     super.stop();
     this.emit("stop", undefined);
   }
@@ -326,6 +344,10 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
   }
 
   cleanup(): void {
+    this._cacophony?.unregisterSoundCleanup(this._unregisterToken);
+    this._holdings.sources.length = 0;
+    this._holdings.gainNodes.length = 0;
+    this._holdings.mediaElements.length = 0;
     this.playbacks.forEach((p) => p.cleanup());
     this.playbacks = [];
     this.eventEmitter.removeAllListeners();


### PR DESCRIPTION
Closes #64.

## Summary
- README documented automatic cleanup via `FinalizationRegistry`, but the registration path was commented out (`src/sound.ts:167`) and the registry was typed to hold a `Playback` — a shape that would have strongly retained the target and prevented collection.
- Register `Sound` instances (not Playbacks) with a decoupled `SoundCleanupHoldings` record containing sources, gain nodes, and media elements. The callback disconnects those nodes without touching the dead Sound or its Playbacks.
- Explicit `cleanup()` unregisters from the registry and clears holdings; `stop()` also clears holdings so repeated play/stop churn does not grow memory.

## Why the old shape was broken
- `register(playback, playback)` — using the target as its own held value — makes `FinalizationRegistry` strongly retain the held value, so the target can never be collected. The callback would never fire.
- `Sound.playbacks.push(playback)` also keeps strong refs to playbacks for the Sound's lifetime, so per-Playback GC tracking was pointless. The Sound itself is the right registration granularity.
- The held value must be a plain data record with no back-references to the target — hence `SoundCleanupHoldings`.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` — 414/414 pass
- [x] `npm run lint` — clean
- [x] 4 new focused tests in `src/sound.test.ts` under `Sound FinalizationRegistry wire-up`:
  - Registration happens at construction with `sound` as target, empty holdings, and a token decoupled from the target
  - `preplay()` populates holdings with the new source and gain node
  - `cleanup()` calls `unregisterSoundCleanup` with the matching token
  - `stop()` clears holdings so play/stop cycles do not grow memory
- [ ] **Not testable in-process:** actual GC-driven callback firing. `FinalizationRegistry` callbacks are non-deterministic and Node/Vitest cannot force them reliably. The tests verify the wire-up end-to-end; real GC behaviour relies on the engine.