### PR TITLE
Add live MediaStream sound support

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,3 @@
 npx biome ci .
+npm run typecheck
 npm test

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -15,6 +15,7 @@ import type {
 import { TypedEventEmitter } from "./eventEmitter";
 import type { CacophonyEvents } from "./events";
 import { Group } from "./group";
+import { MediaStreamSound, type MediaStreamSoundOptions } from "./mediaStream";
 import { MicrophoneStream } from "./microphone";
 import { Sound } from "./sound";
 import { Synth } from "./synth";
@@ -495,6 +496,10 @@ export class Cacophony {
    */
   async createStream(url: string, signal?: AbortSignal): Promise<Sound> {
     return this.createMediaSound(url, SoundType.Streaming, "HRTF", signal);
+  }
+
+  createMediaStreamSound(stream: MediaStream, options?: MediaStreamSoundOptions): MediaStreamSound {
+    return new MediaStreamSound(stream, this.context, this.globalGainNode, options, this);
   }
 
   createBiquadFilter = ({ type, frequency, gain, Q }: BiquadFilterOptions): BiquadFilterNode => {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,4 +1,5 @@
 import type { BasePlayback } from "./basePlayback";
+import type { BaseSound } from "./cacophony";
 import type { Sound } from "./sound";
 import type { Synth } from "./synth";
 import type { SynthPlayback } from "./synthPlayback";
@@ -52,10 +53,10 @@ export interface SynthEvents extends Omit<BaseAudioEvents, "play"> {
 }
 
 /**
- * Global playback event fired when any Sound or Synth plays/stops/pauses.
+ * Global playback event fired when any sound-producing entity plays/stops/pauses.
  */
 export interface GlobalPlaybackEvent {
-  source: Sound | Synth;
+  source: BaseSound | Sound | Synth;
   timestamp: number;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export type {
 } from "./context";
 export * from "./events";
 export * from "./group";
+export * from "./mediaStream";
 export { MicrophonePlayback } from "./microphone";
 export * from "./playback";
 export { Sound } from "./sound";

--- a/src/mediaStream.test.ts
+++ b/src/mediaStream.test.ts
@@ -1,0 +1,129 @@
+import { AudioContext } from "standardized-audio-context-mock";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Cacophony } from "./cacophony";
+import { MediaStreamPlayback, MediaStreamSound } from "./mediaStream";
+
+function createMockTrack(): MediaStreamTrack {
+  return {
+    enabled: true,
+    stop: vi.fn(),
+  } as unknown as MediaStreamTrack;
+}
+
+function createMockStream(tracks: MediaStreamTrack[]): MediaStream {
+  return {
+    getTracks: () => tracks,
+  } as unknown as MediaStream;
+}
+
+function createMockMediaStreamSource(stream: MediaStream) {
+  return {
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    mediaStream: stream,
+    numberOfInputs: 1,
+    numberOfOutputs: 1,
+  };
+}
+
+describe("MediaStreamSound", () => {
+  let context: AudioContext;
+  let track: MediaStreamTrack;
+  let stream: MediaStream;
+  let source: ReturnType<typeof createMockMediaStreamSource>;
+  let globalGainNode: ReturnType<AudioContext["createGain"]>;
+
+  beforeEach(() => {
+    context = new AudioContext();
+    track = createMockTrack();
+    stream = createMockStream([track]);
+    source = createMockMediaStreamSource(stream);
+    globalGainNode = context.createGain();
+    vi.spyOn(context as any, "createMediaStreamSource").mockReturnValue(source);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    context.close();
+  });
+
+  it("creates one reusable playback for a live MediaStream", () => {
+    const sound = new MediaStreamSound(stream, context, globalGainNode);
+
+    const firstPlay = sound.play();
+    const secondPlay = sound.play();
+
+    expect(firstPlay).toHaveLength(1);
+    expect(firstPlay[0]).toBeInstanceOf(MediaStreamPlayback);
+    expect(secondPlay[0]).toBe(firstPlay[0]);
+    expect(context.createMediaStreamSource).toHaveBeenCalledTimes(1);
+    expect(sound.isPlaying).toBe(true);
+  });
+
+  it("applies volume and HRTF position to the live playback", () => {
+    const sound = new MediaStreamSound(stream, context, globalGainNode);
+    sound.volume = 0.25;
+    sound.position = [1, 2, 3];
+
+    const [playback] = sound.play();
+
+    expect(playback.volume).toBe(0.25);
+    expect(playback.position).toEqual([1, 2, 3]);
+  });
+
+  it("can leave externally owned tracks running when stopped", () => {
+    const sound = new MediaStreamSound(stream, context, globalGainNode, {
+      stopTracksOnStop: false,
+    });
+
+    sound.play();
+    sound.stop();
+
+    expect(track.stop).not.toHaveBeenCalled();
+    expect(source.disconnect).toHaveBeenCalled();
+    expect(sound.isPlaying).toBe(false);
+  });
+
+  it("stops owned tracks by default", () => {
+    const sound = new MediaStreamSound(stream, context, globalGainNode);
+
+    sound.play();
+    sound.stop();
+
+    expect(track.stop).toHaveBeenCalledOnce();
+  });
+
+  it("pauses and resumes by toggling track enabled state", () => {
+    const sound = new MediaStreamSound(stream, context, globalGainNode, {
+      stopTracksOnStop: false,
+    });
+
+    sound.play();
+    sound.pause();
+    expect(track.enabled).toBe(false);
+
+    sound.resume();
+    expect(track.enabled).toBe(true);
+  });
+
+  it("emits global playback events through the owning Cacophony instance", () => {
+    const cacophony = new Cacophony(context as any);
+    vi.spyOn(context as any, "createMediaStreamSource").mockReturnValue(source);
+    const sound = cacophony.createMediaStreamSound(stream, {
+      stopTracksOnStop: false,
+    });
+    const events: string[] = [];
+
+    cacophony.on("globalPlay", () => events.push("play"));
+    cacophony.on("globalPause", () => events.push("pause"));
+    cacophony.on("globalStop", () => events.push("stop"));
+
+    sound.play();
+    sound.pause();
+    sound.stop();
+
+    expect(sound).toBeInstanceOf(MediaStreamSound);
+    expect(events).toEqual(["play", "pause", "stop"]);
+  });
+});

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -1,0 +1,241 @@
+import { BasePlayback } from "./basePlayback";
+import type { BaseSound, Cacophony, LoopCount, PanType } from "./cacophony";
+import { PlaybackContainer } from "./container";
+import type {
+  AudioNode,
+  AudioParam,
+  BaseContext,
+  BiquadFilterNode,
+  GainNode,
+  MediaStreamAudioSourceNode,
+} from "./context";
+import { FilterManager } from "./filters";
+
+export interface MediaStreamSoundOptions {
+  panType?: PanType;
+  stopTracksOnStop?: boolean;
+}
+
+export class MediaStreamPlayback extends BasePlayback {
+  public declare origin: MediaStreamSound;
+  private context: BaseContext;
+  private stopTracksOnStop: boolean;
+
+  constructor(
+    origin: MediaStreamSound,
+    source: MediaStreamAudioSourceNode,
+    gainNode: GainNode,
+    context: BaseContext,
+    outputNode: AudioNode,
+    panType: PanType,
+    stopTracksOnStop: boolean,
+  ) {
+    super();
+    this.origin = origin;
+    this.context = context;
+    this.stopTracksOnStop = stopTracksOnStop;
+    this.source = source;
+    this.setPanType(panType, context);
+    this.setGainNode(gainNode);
+    this.source.connect(this.panner!);
+    this.panner!.connect(this.gainNode!);
+    this.gainNode!.connect(outputNode);
+    this.refreshFilters();
+  }
+
+  get duration(): number {
+    return 0;
+  }
+
+  play(): [this] {
+    if (!this.source) {
+      throw new Error("Cannot play a media stream that has been cleaned up");
+    }
+    if (this._playing) {
+      return [this];
+    }
+    this.source.mediaStream.getTracks().forEach((track) => (track.enabled = true));
+    this._playing = true;
+    this.emit("play", this);
+    this.origin.cacophony?.emit("globalPlay", {
+      source: this.origin,
+      timestamp: Date.now(),
+    });
+    return [this];
+  }
+
+  pause(): void {
+    if (!this.source || !this._playing) {
+      return;
+    }
+    this.source.mediaStream.getTracks().forEach((track) => (track.enabled = false));
+    this._playing = false;
+    this.emit("pause", undefined);
+    this.origin.cacophony?.emit("globalPause", {
+      source: this.origin,
+      timestamp: Date.now(),
+    });
+  }
+
+  resume(): void {
+    this.play();
+  }
+
+  stop(): void {
+    if (!this.source) {
+      throw new Error("Cannot stop a media stream that has been cleaned up");
+    }
+    if (this.stopTracksOnStop) {
+      this.source.mediaStream.getTracks().forEach((track) => track.stop());
+    }
+    if (this._playing) {
+      this._playing = false;
+      this.emit("stop", undefined);
+      this.origin.cacophony?.emit("globalStop", {
+        source: this.origin,
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  get playbackRate(): number {
+    return 1;
+  }
+
+  set playbackRate(_rate: number) {}
+
+  addFilter(filter: BiquadFilterNode): void {
+    if (!this.source) {
+      throw new Error("Cannot add a filter to a media stream that has been cleaned up");
+    }
+    super.addFilter(filter);
+    this.refreshFilters();
+  }
+
+  removeFilter(filter: BiquadFilterNode): void {
+    if (!this.source) {
+      throw new Error("Cannot remove a filter from a media stream that has been cleaned up");
+    }
+    super.removeFilter(filter);
+    this.refreshFilters();
+  }
+
+  private refreshFilters(): void {
+    if (!this.panner || !this.gainNode) {
+      throw new Error("Cannot update filters on a media stream that has been cleaned up");
+    }
+    let connection = this.panner;
+    connection.disconnect();
+    connection = this.applyFilters(connection);
+    connection.connect(this.gainNode);
+  }
+
+  get outputNode(): GainNode {
+    if (!this.gainNode) {
+      throw new Error("Cannot access output node of a media stream that has been cleaned up");
+    }
+    return this.gainNode;
+  }
+
+  connect(destination: AudioNode | AudioParam): AudioNode {
+    return this.outputNode.connect(destination as any);
+  }
+
+  disconnect(destination?: AudioNode | AudioParam): void {
+    if (destination) {
+      this.outputNode.disconnect(destination as any);
+    } else {
+      this.outputNode.disconnect();
+    }
+  }
+
+  cleanup(): void {
+    if (!this.source) {
+      return;
+    }
+    this._playing = false;
+    this.source.disconnect();
+    this.source = undefined;
+    super.cleanup();
+  }
+}
+
+export class MediaStreamSound extends PlaybackContainer(FilterManager) implements BaseSound {
+  public declare playbacks: MediaStreamPlayback[];
+  private context: BaseContext;
+  private globalGainNode: GainNode;
+  private stream: MediaStream;
+  private stopTracksOnStop: boolean;
+  private panType: PanType;
+
+  constructor(
+    stream: MediaStream,
+    context: BaseContext,
+    globalGainNode: GainNode,
+    options: MediaStreamSoundOptions = {},
+    private _cacophony?: Cacophony,
+  ) {
+    super();
+    this.stream = stream;
+    this.context = context;
+    this.globalGainNode = globalGainNode;
+    this.panType = options.panType ?? "HRTF";
+    this.stopTracksOnStop = options.stopTracksOnStop ?? true;
+  }
+
+  get cacophony(): Cacophony | undefined {
+    return this._cacophony;
+  }
+
+  private createStreamSource(stream: MediaStream): MediaStreamAudioSourceNode {
+    if (!this.context.createMediaStreamSource) {
+      throw new Error("Media stream sources are not supported on this audio context (e.g. OfflineAudioContext).");
+    }
+    return this.context.createMediaStreamSource(stream);
+  }
+
+  preplay(): MediaStreamPlayback[] {
+    if (this.playbacks[0]) {
+      return [this.playbacks[0]];
+    }
+
+    const source = this.createStreamSource(this.stream);
+    const gainNode = this.context.createGain();
+    const playback = new MediaStreamPlayback(
+      this,
+      source,
+      gainNode,
+      this.context,
+      this.globalGainNode,
+      this.panType,
+      this.stopTracksOnStop,
+    );
+    playback.volume = this.volume;
+    if (this.panType === "HRTF") {
+      playback.threeDOptions = this.threeDOptions;
+      playback.position = this.position;
+    } else {
+      playback.stereoPan = this.stereoPan ?? 0;
+    }
+    this._filters.forEach((filter) => playback.addFilter(filter));
+    this.playbacks.push(playback);
+    return [playback];
+  }
+
+  seek(_time: number): void {}
+
+  loop(_loopCount?: LoopCount): LoopCount {
+    return 0;
+  }
+
+  get playbackRate(): number {
+    return 1;
+  }
+
+  set playbackRate(_rate: number) {}
+
+  cleanup(): void {
+    this.stop();
+    this._filters = [];
+  }
+}

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -18,7 +18,7 @@ export interface MediaStreamSoundOptions {
 
 export class MediaStreamPlayback extends BasePlayback {
   public declare origin: MediaStreamSound;
-  private context: BaseContext;
+  private hasStarted: boolean = false;
   private stopTracksOnStop: boolean;
 
   constructor(
@@ -32,7 +32,6 @@ export class MediaStreamPlayback extends BasePlayback {
   ) {
     super();
     this.origin = origin;
-    this.context = context;
     this.stopTracksOnStop = stopTracksOnStop;
     this.source = source;
     this.setPanType(panType, context);
@@ -55,6 +54,7 @@ export class MediaStreamPlayback extends BasePlayback {
       return [this];
     }
     this.source.mediaStream.getTracks().forEach((track) => (track.enabled = true));
+    this.hasStarted = true;
     this._playing = true;
     this.emit("play", this);
     this.origin.cacophony?.emit("globalPlay", {
@@ -85,11 +85,13 @@ export class MediaStreamPlayback extends BasePlayback {
     if (!this.source) {
       throw new Error("Cannot stop a media stream that has been cleaned up");
     }
+    const shouldEmitStop = this.hasStarted;
     if (this.stopTracksOnStop) {
       this.source.mediaStream.getTracks().forEach((track) => track.stop());
     }
-    if (this._playing) {
-      this._playing = false;
+    this.hasStarted = false;
+    this._playing = false;
+    if (shouldEmitStop) {
       this.emit("stop", undefined);
       this.origin.cacophony?.emit("globalStop", {
         source: this.origin,
@@ -236,6 +238,6 @@ export class MediaStreamSound extends PlaybackContainer(FilterManager) implement
 
   cleanup(): void {
     this.stop();
-    this._filters = [];
+    super.cleanup();
   }
 }

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -226,6 +226,10 @@ export class MediaStreamSound extends PlaybackContainer(FilterManager) implement
 
   seek(_time: number): void {}
 
+  resume(): void {
+    this.playbacks.forEach((playback) => playback.resume());
+  }
+
   loop(_loopCount?: LoopCount): LoopCount {
     return 0;
   }

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -18,6 +18,7 @@ export interface MediaStreamSoundOptions {
 
 export class MediaStreamPlayback extends BasePlayback {
   public declare origin: MediaStreamSound;
+  public declare source?: MediaStreamAudioSourceNode;
   private hasStarted: boolean = false;
   private stopTracksOnStop: boolean;
 


### PR DESCRIPTION
## Summary
- add MediaStreamSound/MediaStreamPlayback for live MediaStream audio sources
- expose Cacophony.createMediaStreamSound(stream, options) and export the new API
- cover reusable playback, spatial positioning, pause/resume, stop ownership, cleanup, and global events

## Tests
- pre-commit hook ran full Vitest suite: 20 files passed, 432 tests passed

Note: existing Biome warning remains in src/context.test.ts for unused imports; this PR does not touch it.