### PR TITLE
fix: routing bugs in stream and microphone signal paths

### DIFF
--- a/src/microphone.test.ts
+++ b/src/microphone.test.ts
@@ -231,4 +231,34 @@ describe("MicrophoneStream", () => {
     mic.playbackRate = 2;
     expect(mic.playbackRate).toBe(1);
   });
+
+  it("connects the internal microphoneGainNode to the provided outputNode", () => {
+    // Regression test for routing bug: MicrophoneStream previously created
+    // a microphoneGainNode that was never connected to anything downstream,
+    // so volume/mute on the chain were inaudible. The fix wires the gain
+    // node through an optional outputNode in the constructor.
+    // See notes/scout-routing-graph.md ("MicrophonePlayback" / dangling
+    // gain node observation).
+    const outputNode = context.createGain();
+    const gainConnectSpy = vi.fn();
+    const realCreateGain = (context as any).createGain.bind(context);
+    let firstGain: any;
+    vi.spyOn(context as any, "createGain").mockImplementation(() => {
+      const node = realCreateGain();
+      if (!firstGain) {
+        firstGain = node;
+        const realConnect = node.connect.bind(node);
+        node.connect = (...args: any[]) => {
+          gainConnectSpy(...args);
+          return realConnect(...args);
+        };
+      }
+      return node;
+    });
+
+    const _mic = new MicrophoneStream(context, mockStream, outputNode);
+
+    expect(gainConnectSpy).toHaveBeenCalled();
+    expect(gainConnectSpy.mock.calls.some((call) => call[0] === outputNode)).toBe(true);
+  });
 });

--- a/src/microphone.ts
+++ b/src/microphone.ts
@@ -134,10 +134,16 @@ export class MicrophoneStream extends FilterManager implements BaseSound {
   private stream: MediaStream | undefined;
   private streamSource?: MediaStreamAudioSourceNode;
 
-  constructor(context: BaseContext, stream?: MediaStream) {
+  constructor(context: BaseContext, stream?: MediaStream, outputNode?: AudioNode) {
     super();
     this.context = context;
     this.microphoneGainNode = this.context.createGain();
+    // Wire the microphone gain node into the audio graph. Without this
+    // connection the gain node is dangling and volume/mute on the chain
+    // have no audible effect. Callers should pass the shared
+    // `globalGainNode` so global volume applies; otherwise we fall back
+    // to `context.destination` so the chain is at least reachable.
+    this.microphoneGainNode.connect(outputNode ?? this.context.destination);
     if (stream) {
       this.stream = stream;
       this.streamSource = this.createStreamSource(stream);

--- a/src/stream.test.ts
+++ b/src/stream.test.ts
@@ -128,6 +128,54 @@ describe("Stream operations with AbortController", () => {
     expect(mockResponse.body.getReader).toHaveBeenCalled();
   });
 
+  it("routes decoded BufferSource through outputNode (not context.destination) when outputNode is provided", async () => {
+    // Regression test for routing bug: stream.ts previously connected the
+    // decoded BufferSource directly to context.destination, bypassing the
+    // library's globalGainNode. Now the function accepts an optional
+    // outputNode so callers can route streamed audio through their shared
+    // gain node. See notes/scout-routing-graph.md.
+    const sourceConnectSpy = vi.fn();
+    const originalCreateBufferSource = audioContextMock.createBufferSource.bind(audioContextMock);
+    vi.spyOn(audioContextMock, "createBufferSource").mockImplementation(() => {
+      const realSource = originalCreateBufferSource();
+      const wrapped = new Proxy(realSource, {
+        get(target, prop, receiver) {
+          if (prop === "connect") {
+            return (...args: any[]) => {
+              sourceConnectSpy(...args);
+              return (target as any).connect(...args);
+            };
+          }
+          return Reflect.get(target, prop, receiver);
+        },
+        set(target, prop, value, receiver) {
+          return Reflect.set(target, prop, value, receiver);
+        },
+      });
+      return wrapped as any;
+    });
+
+    const outputNode = audioContextMock.createGain();
+    const chunk = new Uint8Array(48);
+    chunk.set([82, 73, 70, 70], 0);
+    chunk.set([87, 65, 86, 69], 8);
+
+    mockReader.read
+      .mockResolvedValueOnce({ value: chunk, done: false })
+      .mockResolvedValueOnce({ value: undefined, done: true });
+
+    createStream("https://example.com/audio.wav", audioContextMock, undefined, outputNode);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(sourceConnectSpy).toHaveBeenCalled();
+    // Every call must target outputNode, never the raw context.destination.
+    for (const call of sourceConnectSpy.mock.calls) {
+      expect(call[0]).toBe(outputNode);
+      expect(call[0]).not.toBe(audioContextMock.destination);
+    }
+  });
+
   it("should prepend the WAV header when decoding chunks after the first", async () => {
     const firstChunk = new Uint8Array(48);
     firstChunk.set([82, 73, 70, 70], 0);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -1,4 +1,4 @@
-import type { AudioBuffer, BaseContext } from "./context";
+import type { AudioBuffer, AudioNode, BaseContext } from "./context";
 
 /**
  * Copy a typed-array view into a freshly allocated ArrayBuffer.
@@ -26,8 +26,13 @@ const appendBuffer = (buffer1: ArrayBuffer, buffer2: ArrayBuffer): ArrayBuffer =
  *
  * Fire-and-forget: errors are reported via `console.error`. Pass an
  * `AbortSignal` to cancel the in-flight stream.
+ *
+ * Pass `outputNode` to route the decoded audio through a shared gain node
+ * (typically the library's `globalGainNode`) so global volume / mute apply.
+ * If omitted, audio connects directly to `context.destination` and bypasses
+ * any global gain — preserved only for backward compatibility.
  */
-export function createStream(url: string, context: BaseContext, signal?: AbortSignal): void {
+export function createStream(url: string, context: BaseContext, signal?: AbortSignal, outputNode?: AudioNode): void {
   const audioStack: AudioBuffer[] = [];
   let nextTime = 0;
 
@@ -139,7 +144,7 @@ export function createStream(url: string, context: BaseContext, signal?: AbortSi
         return;
       }
       source.buffer = buffer;
-      source.connect(context.destination);
+      source.connect(outputNode ?? context.destination);
       if (nextTime === 0) nextTime = context.currentTime + 0.02; /// add 50ms latency to work well across systems - tune this if you like
       source.start(nextTime);
       nextTime += source.buffer.duration; // Make the next buffer wait the length of the last buffer before being played


### PR DESCRIPTION
## Summary

Two routing bugs identified by a code scout, fixed in two atomic commits.

- **stream.ts** — decoded `BufferSource` was connected directly to `context.destination`, bypassing `globalGainNode` (global volume/mute had no effect on streamed audio). Added optional `outputNode?: AudioNode` parameter to `createStream`; line now reads `source.connect(outputNode ?? context.destination)`.
- **microphone.ts** — `microphoneGainNode` was created but never connected to any downstream node, leaving the chain terminating at a dangling gain. Added optional `outputNode?: AudioNode` parameter to `MicrophoneStream`; connects internally on construction.

Both fixes default to `context.destination` so existing callers are unaffected. The `cacophony.ts` callsites continue to work; wiring them to actually pass `globalGainNode` is a separate followup PR.

## Tests

Two new regression tests (one per bug), one in `src/stream.test.ts`, one in `src/microphone.test.ts`. Each verified RED → GREEN against the prior buggy code.

Suite: 453/453 pass (was 451 + 2 new).

## Review

Codex review: **APPROVED**. Recommendation "merge as-is."