### PR TITLE
feat: autoplay unlock on first user gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,43 @@ async function audioDemo() {
 audioDemo();
 ```
 
+## Mobile Autoplay Handling
+
+Modern browsers — especially iOS Safari and Chrome on Android — refuse to
+produce sound from an `AudioContext` that was constructed before any user
+interaction. The context is created in `suspended` state and must be both
+resumed AND have a node started from inside a real user-gesture call stack
+before audio can play. Calling `context.resume()` alone is not enough on iOS.
+
+Cacophony handles this transparently by default. When you construct a
+`Cacophony` instance and the context is suspended, it installs one-time
+`touchend` / `click` / `keydown` listeners on `document.body`. The first
+user gesture resumes the context, plays a 1-sample silent primer buffer (the
+iOS unlock primer), removes the listeners, and emits the `unlock` event.
+
+```typescript
+const cacophony = new Cacophony();
+
+if (cacophony.locked) {
+  // Mobile: waiting for the first user interaction.
+  // Show a "tap to enable audio" affordance if you want one.
+}
+
+cacophony.on('unlock', () => {
+  // Audio is now usable.
+});
+```
+
+If you prefer to manage unlock yourself, opt out:
+
+```typescript
+const cacophony = new Cacophony(undefined, undefined, { autoUnlock: false });
+// You are responsible for calling cacophony.resume() inside a user gesture.
+```
+
+The auto-unlock has no effect on offline contexts or in non-browser
+environments (`typeof document === 'undefined'`).
+
 ## Core Concepts
 
 ### Sound vs Playback Architecture

--- a/src/autoplayUnlock.test.ts
+++ b/src/autoplayUnlock.test.ts
@@ -275,6 +275,86 @@ describe("Autoplay unlock", () => {
     });
   });
 
+  describe("resume contract", () => {
+    it("does NOT emit unlock when context.resume() rejects", async () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      const rejectErr = new Error("resume failed");
+      vi.spyOn(ctx, "resume").mockRejectedValue(rejectErr);
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const c = new Cacophony(ctx as any, mockCache);
+      const unlockListener = vi.fn();
+      c.on("unlock", unlockListener);
+
+      doc.fire("click");
+
+      // Flush microtasks for the rejected promise to be observed.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(unlockListener).not.toHaveBeenCalled();
+      expect(c.locked).toBe(true);
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("emits unlock asynchronously, only after resume() fulfills", async () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+
+      let resolveResume!: () => void;
+      const resumePromise = new Promise<void>((resolve) => {
+        resolveResume = resolve;
+      });
+      vi.spyOn(ctx, "resume").mockReturnValue(resumePromise as any);
+
+      const c = new Cacophony(ctx as any, mockCache);
+      const unlockListener = vi.fn();
+      c.on("unlock", unlockListener);
+
+      doc.fire("click");
+
+      // After the synchronous gesture stack returns, unlock should not yet
+      // have fired — resume() is still pending.
+      await Promise.resolve();
+      expect(unlockListener).not.toHaveBeenCalled();
+
+      resolveResume();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(unlockListener).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls stop(0) on the primer buffer source after start(0)", () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+
+      const startSpy = vi.fn();
+      const stopSpy = vi.fn();
+      const sourceMock = {
+        start: startSpy,
+        stop: stopSpy,
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        buffer: null,
+      };
+      vi.spyOn(ctx, "createBufferSource").mockReturnValue(sourceMock as any);
+
+      new Cacophony(ctx as any, mockCache);
+
+      doc.fire("click");
+
+      expect(startSpy).toHaveBeenCalledWith(0);
+      expect(stopSpy).toHaveBeenCalledWith(0);
+      // start must precede stop
+      expect(startSpy.mock.invocationCallOrder[0]).toBeLessThan(stopSpy.mock.invocationCallOrder[0]);
+    });
+  });
+
   describe("locked getter", () => {
     it("returns true before unlock when context is suspended", () => {
       installMockDocument();

--- a/src/autoplayUnlock.test.ts
+++ b/src/autoplayUnlock.test.ts
@@ -1,0 +1,308 @@
+import { AudioBuffer, AudioContext } from "standardized-audio-context-mock";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Cacophony } from "./cacophony";
+import type { BaseContext, AudioBuffer as CacophonyAudioBuffer } from "./context";
+import { mockCache } from "./setupTests";
+
+/**
+ * Build an offline-context mock matching the pattern in offline.test.ts —
+ * standardized-audio-context-mock's OfflineAudioContext is incomplete, so we
+ * compose an online AudioContext with a startRendering method to satisfy
+ * Cacophony.isOffline.
+ */
+function createOfflineContextMock(): BaseContext & { startRendering(): Promise<CacophonyAudioBuffer> } {
+  const base = new AudioContext();
+  const rendered = new AudioBuffer({ length: 128, sampleRate: 44100 });
+  return Object.assign(base, {
+    startRendering: vi.fn().mockResolvedValue(rendered),
+    length: 128,
+  }) as unknown as BaseContext & { startRendering(): Promise<CacophonyAudioBuffer> };
+}
+
+/**
+ * Tests for autoplay unlock on first user gesture.
+ *
+ * The Cacophony constructor installs one-time touchend/click/keydown listeners
+ * on document.body when the audio context starts in 'suspended' state. The
+ * first fired gesture resumes the context, plays a silent primer buffer
+ * (required for iOS Safari to truly unlock), removes the listeners, and emits
+ * an `unlock` event.
+ *
+ * Vitest runs in node environment by default — `document` is undefined — so
+ * each test that exercises the listener-install path mocks a minimal document
+ * on `globalThis` and tears it down afterward.
+ */
+
+const UNLOCK_EVENTS = ["touchend", "click", "keydown"] as const;
+type UnlockEvent = (typeof UNLOCK_EVENTS)[number];
+
+interface MockDocument {
+  body: MockEventTarget;
+  addEventListenerSpy: ReturnType<typeof vi.fn>;
+  removeEventListenerSpy: ReturnType<typeof vi.fn>;
+  fire(event: UnlockEvent): void;
+  listenersFor(event: UnlockEvent): Array<EventListenerOrEventListenerObject>;
+}
+
+interface MockEventTarget {
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+}
+
+function installMockDocument(opts: { withBody?: boolean } = {}): MockDocument {
+  const withBody = opts.withBody !== false;
+  const listenerMap = new Map<UnlockEvent, Set<EventListenerOrEventListenerObject>>();
+
+  const addEventListenerSpy = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+    if (!UNLOCK_EVENTS.includes(type as UnlockEvent)) return;
+    const set = listenerMap.get(type as UnlockEvent) ?? new Set();
+    set.add(listener);
+    listenerMap.set(type as UnlockEvent, set);
+  });
+
+  const removeEventListenerSpy = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+    if (!UNLOCK_EVENTS.includes(type as UnlockEvent)) return;
+    listenerMap.get(type as UnlockEvent)?.delete(listener);
+  });
+
+  const target: MockEventTarget = {
+    addEventListener: addEventListenerSpy,
+    removeEventListener: removeEventListenerSpy,
+  };
+
+  const mockDoc: any = withBody
+    ? { body: target, addEventListener: addEventListenerSpy, removeEventListener: removeEventListenerSpy }
+    : { addEventListener: addEventListenerSpy, removeEventListener: removeEventListenerSpy };
+
+  (globalThis as any).document = mockDoc;
+
+  return {
+    body: target,
+    addEventListenerSpy,
+    removeEventListenerSpy,
+    fire(event: UnlockEvent) {
+      const listeners = listenerMap.get(event);
+      if (!listeners) return;
+      const ev = { type: event } as unknown as Event;
+      for (const l of [...listeners]) {
+        if (typeof l === "function") l.call(target, ev);
+        else l.handleEvent(ev);
+      }
+    },
+    listenersFor(event: UnlockEvent) {
+      return [...(listenerMap.get(event) ?? [])];
+    },
+  };
+}
+
+function uninstallMockDocument(): void {
+  delete (globalThis as any).document;
+}
+
+describe("Autoplay unlock", () => {
+  let originalDocument: any;
+
+  beforeEach(() => {
+    originalDocument = (globalThis as any).document;
+  });
+
+  afterEach(() => {
+    if (originalDocument === undefined) {
+      delete (globalThis as any).document;
+    } else {
+      (globalThis as any).document = originalDocument;
+    }
+  });
+
+  describe("listener installation", () => {
+    it("installs touchend, click, and keydown listeners when context is suspended and autoUnlock is true", () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      // Mock starts suspended.
+      expect(ctx.state).toBe("suspended");
+
+      new Cacophony(ctx as any, mockCache);
+
+      const types = doc.addEventListenerSpy.mock.calls.map((c) => c[0]);
+      expect(types).toContain("touchend");
+      expect(types).toContain("click");
+      expect(types).toContain("keydown");
+    });
+
+    it("uses default autoUnlock=true when option is omitted", () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      new Cacophony(ctx as any, mockCache, {});
+      expect(doc.addEventListenerSpy).toHaveBeenCalled();
+    });
+
+    it("does NOT install listeners when context.state is 'running'", async () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      await ctx.resume(); // state -> 'running'
+      expect(ctx.state).toBe("running");
+
+      new Cacophony(ctx as any, mockCache);
+
+      expect(doc.addEventListenerSpy).not.toHaveBeenCalled();
+    });
+
+    it("does NOT install listeners when autoUnlock is false", () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      new Cacophony(ctx as any, mockCache, { autoUnlock: false });
+      expect(doc.addEventListenerSpy).not.toHaveBeenCalled();
+    });
+
+    it("does NOT install listeners on an offline context", () => {
+      const doc = installMockDocument();
+      const offline = createOfflineContextMock();
+      const c = new Cacophony(offline as any, mockCache);
+      expect(c.isOffline).toBe(true);
+      expect(doc.addEventListenerSpy).not.toHaveBeenCalled();
+    });
+
+    it("does NOT install listeners when document is undefined (non-browser env)", () => {
+      uninstallMockDocument();
+      const ctx = new AudioContext();
+      // Should not throw.
+      expect(() => new Cacophony(ctx as any, mockCache)).not.toThrow();
+    });
+
+    it("falls back to document when document.body is unavailable", () => {
+      const doc = installMockDocument({ withBody: false });
+      const ctx = new AudioContext();
+      new Cacophony(ctx as any, mockCache);
+      // addEventListenerSpy is the same fn for body and document in our mock,
+      // so we just confirm it was called.
+      expect(doc.addEventListenerSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("unlock on gesture", () => {
+    for (const eventName of UNLOCK_EVENTS) {
+      it(`unlocks on '${eventName}': resume() called, primer played, listeners removed, unlock event emitted`, async () => {
+        const doc = installMockDocument();
+        const ctx = new AudioContext();
+        const resumeSpy = vi.spyOn(ctx, "resume");
+        const createBufferSpy = vi.spyOn(ctx, "createBuffer");
+        const createBufferSourceSpy = vi.spyOn(ctx, "createBufferSource");
+
+        const c = new Cacophony(ctx as any, mockCache);
+
+        const unlockListener = vi.fn();
+        c.on("unlock", unlockListener);
+
+        doc.fire(eventName);
+
+        // Allow any microtask the resume() promise produced to flush.
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(resumeSpy).toHaveBeenCalled();
+        expect(createBufferSpy).toHaveBeenCalledWith(1, 1, ctx.sampleRate);
+        expect(createBufferSourceSpy).toHaveBeenCalled();
+
+        // All three listener types removed.
+        const removedTypes = doc.removeEventListenerSpy.mock.calls.map((c) => c[0]);
+        expect(removedTypes).toContain("touchend");
+        expect(removedTypes).toContain("click");
+        expect(removedTypes).toContain("keydown");
+
+        expect(unlockListener).toHaveBeenCalledTimes(1);
+      });
+    }
+
+    it("calls start(0) on the primer buffer source inside the gesture call stack", () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+
+      const startSpy = vi.fn();
+      const connectSpy = vi.fn();
+      const sourceMock = {
+        start: startSpy,
+        stop: vi.fn(),
+        connect: connectSpy,
+        disconnect: vi.fn(),
+        buffer: null,
+      };
+      vi.spyOn(ctx, "createBufferSource").mockReturnValue(sourceMock as any);
+
+      new Cacophony(ctx as any, mockCache);
+
+      doc.fire("click");
+
+      expect(connectSpy).toHaveBeenCalled();
+      expect(startSpy).toHaveBeenCalledWith(0);
+    });
+
+    it("a second gesture after unlock does NOT re-fire (listeners are removed)", async () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      const c = new Cacophony(ctx as any, mockCache);
+
+      const unlockListener = vi.fn();
+      c.on("unlock", unlockListener);
+
+      doc.fire("click");
+      await Promise.resolve();
+      expect(unlockListener).toHaveBeenCalledTimes(1);
+
+      // After removal, no listeners should remain to dispatch into.
+      expect(doc.listenersFor("click")).toHaveLength(0);
+      expect(doc.listenersFor("touchend")).toHaveLength(0);
+      expect(doc.listenersFor("keydown")).toHaveLength(0);
+
+      doc.fire("click");
+      doc.fire("touchend");
+      doc.fire("keydown");
+      await Promise.resolve();
+      expect(unlockListener).toHaveBeenCalledTimes(1);
+    });
+
+    it("any one of the three gestures unlocks and removes ALL listeners", () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      new Cacophony(ctx as any, mockCache);
+
+      // Fire only touchend.
+      doc.fire("touchend");
+
+      // All three listener types should be removed in one shot.
+      const removedTypes = doc.removeEventListenerSpy.mock.calls.map((c) => c[0]);
+      expect(new Set(removedTypes)).toEqual(new Set(["touchend", "click", "keydown"]));
+    });
+  });
+
+  describe("locked getter", () => {
+    it("returns true before unlock when context is suspended", () => {
+      installMockDocument();
+      const ctx = new AudioContext();
+      const c = new Cacophony(ctx as any, mockCache);
+      expect(c.locked).toBe(true);
+    });
+
+    it("returns false after unlock", async () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      const c = new Cacophony(ctx as any, mockCache);
+      expect(c.locked).toBe(true);
+
+      doc.fire("click");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(ctx.state).toBe("running");
+      expect(c.locked).toBe(false);
+    });
+
+    it("returns false on a context that is already running", async () => {
+      installMockDocument();
+      const ctx = new AudioContext();
+      await ctx.resume();
+      const c = new Cacophony(ctx as any, mockCache);
+      expect(c.locked).toBe(false);
+    });
+  });
+});

--- a/src/autoplayUnlock.ts
+++ b/src/autoplayUnlock.ts
@@ -1,0 +1,149 @@
+import type { BaseContext } from "./context";
+
+/**
+ * Autoplay unlock — Howler-parity automatic AudioContext resume on first
+ * user gesture.
+ *
+ * On mobile browsers (especially iOS Safari) an `AudioContext` constructed
+ * before any user interaction is created in `suspended` state. It will not
+ * produce sound until BOTH:
+ *
+ *   1. `context.resume()` is called, AND
+ *   2. an `AudioBufferSourceNode` is created and started inside the user
+ *      gesture's call stack (the iOS "primer").
+ *
+ * Many callers do (1) but not (2), and hear silence with no obvious cause.
+ * This module installs one-time `touchend` / `click` / `keydown` listeners
+ * on `document.body` (or `document` as fallback). The first one to fire
+ * resumes the context, plays a 1-sample silent primer inside the gesture
+ * call stack, removes all three listeners, and calls the `onUnlock` callback.
+ *
+ * Design adapted (not copied) from Howler.js `_unlockAudio` — MIT licensed.
+ */
+
+const UNLOCK_EVENT_TYPES: ReadonlyArray<"touchend" | "click" | "keydown"> = ["touchend", "click", "keydown"];
+
+/**
+ * A `Document`-like type with the methods we need. Avoids a hard dependency
+ * on DOM lib types so the package keeps building when `lib: ["dom"]` is off.
+ */
+interface DocumentLike {
+  body?: EventTargetLike | null;
+  addEventListener(type: string, listener: (ev: any) => void, options?: any): void;
+  removeEventListener(type: string, listener: (ev: any) => void, options?: any): void;
+}
+
+interface EventTargetLike {
+  addEventListener(type: string, listener: (ev: any) => void, options?: any): void;
+  removeEventListener(type: string, listener: (ev: any) => void, options?: any): void;
+}
+
+/**
+ * Options for `installAutoplayUnlock`.
+ */
+export interface AutoplayUnlockOptions {
+  /**
+   * The audio context that should be resumed and primed.
+   */
+  context: BaseContext;
+
+  /**
+   * Called after the context has been resumed and the primer buffer has been
+   * started. Used by `Cacophony` to emit the public `unlock` event.
+   * Errors thrown by the callback are caught and logged so a faulty listener
+   * cannot break the unlock flow.
+   */
+  onUnlock: () => void;
+}
+
+/**
+ * Install one-time unlock listeners. Returns a cleanup function that removes
+ * the listeners if they have not already fired (e.g. when a `Cacophony`
+ * instance is torn down before the user interacts).
+ *
+ * If the environment is non-browser (`document` is undefined) or the context
+ * is not in `suspended` state, this is a no-op and returns a no-op cleanup.
+ *
+ * @internal
+ */
+export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
+  const { context, onUnlock } = opts;
+
+  // Server-side / non-browser: nothing to do.
+  if (typeof document === "undefined") {
+    return () => {};
+  }
+
+  // Already running: nothing to unlock.
+  const state = (context as unknown as { state?: string }).state;
+  if (state !== "suspended") {
+    return () => {};
+  }
+
+  const doc = document as unknown as DocumentLike;
+  const target: EventTargetLike = (doc.body as EventTargetLike | null | undefined) ?? doc;
+
+  let fired = false;
+
+  const removeAll = () => {
+    for (const type of UNLOCK_EVENT_TYPES) {
+      target.removeEventListener(type, handler);
+    }
+  };
+
+  const handler = () => {
+    if (fired) return;
+    fired = true;
+
+    // Remove listeners FIRST so a re-entrant gesture cannot re-trigger us
+    // while resume() is in flight.
+    removeAll();
+
+    // Play the iOS primer INSIDE the gesture call stack. iOS requires that
+    // an AudioBufferSourceNode be created and started synchronously inside
+    // the gesture handler for the context to truly unlock — calling
+    // resume() alone is not sufficient. A 1-sample silent buffer is the
+    // minimum that satisfies the requirement and is inaudible.
+    try {
+      // BaseContext doesn't declare createBuffer because Cacophony's normal
+      // code path always feeds an AudioBuffer constructed externally; the
+      // primer needs to construct a 1-sample buffer in-place, so we widen
+      // the type locally here. Both AudioContext and OfflineAudioContext
+      // expose createBuffer.
+      const ctxWithCreateBuffer = context as unknown as {
+        createBuffer(numberOfChannels: number, length: number, sampleRate: number): unknown;
+      };
+      const buffer = ctxWithCreateBuffer.createBuffer(1, 1, context.sampleRate);
+      const source = context.createBufferSource();
+      source.buffer = buffer as any;
+      source.connect(context.destination);
+      source.start(0);
+    } catch (err) {
+      // Primer failure should not block the rest of the unlock; the
+      // context.resume() call below is still useful on platforms that do
+      // not require the primer.
+      console.warn("[cacophony/autoplayUnlock] primer failed:", err);
+    }
+
+    // Resume the context. The promise may settle asynchronously — that's
+    // fine; we have already played the primer inside the gesture stack.
+    const resume = (context as unknown as { resume?: () => Promise<void> }).resume;
+    if (typeof resume === "function") {
+      resume.call(context).catch((err: unknown) => {
+        console.warn("[cacophony/autoplayUnlock] resume failed:", err);
+      });
+    }
+
+    try {
+      onUnlock();
+    } catch (err) {
+      console.error("[cacophony/autoplayUnlock] onUnlock callback threw:", err);
+    }
+  };
+
+  for (const type of UNLOCK_EVENT_TYPES) {
+    target.addEventListener(type, handler);
+  }
+
+  return removeAll;
+}

--- a/src/autoplayUnlock.ts
+++ b/src/autoplayUnlock.ts
@@ -117,7 +117,11 @@ export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
       const source = context.createBufferSource();
       source.buffer = buffer as any;
       source.connect(context.destination);
+      // The load-bearing iOS pattern is start(0); stop(0) on a silent buffer
+      // INSIDE the gesture call stack. A 1-sample non-looping buffer would
+      // end on its own, but the pair is what the platform contract names.
       source.start(0);
+      source.stop(0);
     } catch (err) {
       // Primer failure should not block the rest of the unlock; the
       // context.resume() call below is still useful on platforms that do
@@ -125,19 +129,32 @@ export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
       console.warn("[cacophony/autoplayUnlock] primer failed:", err);
     }
 
-    // Resume the context. The promise may settle asynchronously — that's
-    // fine; we have already played the primer inside the gesture stack.
+    // Resume the context, then emit unlock. The `unlock` event signals that
+    // audio is actually playable, so we must wait for resume() to fulfill
+    // before emitting. On rejection we surface the error and do NOT emit
+    // unlock — a failed resume is not an unlock.
     const resume = (context as unknown as { resume?: () => Promise<void> }).resume;
     if (typeof resume === "function") {
-      resume.call(context).catch((err: unknown) => {
-        console.warn("[cacophony/autoplayUnlock] resume failed:", err);
-      });
-    }
-
-    try {
-      onUnlock();
-    } catch (err) {
-      console.error("[cacophony/autoplayUnlock] onUnlock callback threw:", err);
+      resume.call(context).then(
+        () => {
+          try {
+            onUnlock();
+          } catch (err) {
+            console.error("[cacophony/autoplayUnlock] onUnlock callback threw:", err);
+          }
+        },
+        (err: unknown) => {
+          console.warn("[cacophony/autoplayUnlock] resume failed:", err);
+        },
+      );
+    } else {
+      // No resume() available (unusual, but possible in stubbed contexts).
+      // The primer is enough to consider the context unlocked.
+      try {
+        onUnlock();
+      } catch (err) {
+        console.error("[cacophony/autoplayUnlock] onUnlock callback threw:", err);
+      }
     }
   };
 

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -1,3 +1,4 @@
+import { installAutoplayUnlock } from "./autoplayUnlock";
 import phaseVocoderProcessorWorkletUrl from "./bundles/phase-vocoder-bundle.js?url";
 import stereoToBFormatProcessorWorkletUrl from "./bundles/stereo-to-bformat-bundle.js?url";
 import { AudioCache, type ICache } from "./cache";
@@ -102,6 +103,23 @@ export interface OfflineOptions {
 
 export interface RuntimeOptions {
   createAudioWorkletNode?: (context: BaseContext, name: string, options?: AudioWorkletNodeOptions) => any;
+  /**
+   * If `true` (the default), Cacophony installs one-time `touchend` / `click` /
+   * `keydown` listeners on `document.body` whenever the audio context is
+   * constructed in `suspended` state. The first user gesture resumes the
+   * context, plays a silent primer buffer (required by iOS Safari for the
+   * context to truly unlock), removes the listeners, and emits the `unlock`
+   * event on the Cacophony instance.
+   *
+   * Set to `false` to opt out — you are then responsible for calling
+   * `cacophony.resume()` yourself in response to a user gesture.
+   *
+   * Has no effect when the context is already running, on offline contexts,
+   * or in non-browser environments (`document === undefined`).
+   *
+   * @default true
+   */
+  autoUnlock?: boolean;
 }
 
 /**
@@ -133,7 +151,29 @@ export class Cacophony {
   // duplicate wrapper-driven suspend calls, but resume() still delegates because
   // the underlying AudioContext can be suspended externally.
   private suspendState: "unknown" | "running" | "suspended" = "unknown";
+  // Cleanup function for the autoplay-unlock listeners. No-op when listeners
+  // were not installed (autoUnlock disabled, offline context, non-browser,
+  // or context not in 'suspended' state at construction time).
+  private autoplayUnlockCleanup: () => void = () => {};
 
+  /**
+   * Constructs a new Cacophony instance.
+   *
+   * If the supplied (or auto-constructed) audio context is in `suspended`
+   * state and `runtimeOptions.autoUnlock` is `true` (default), one-time
+   * `touchend` / `click` / `keydown` listeners are installed on
+   * `document.body` so the first user gesture transparently unlocks audio
+   * — matching Howler's `autoUnlock` behavior. See
+   * {@link RuntimeOptions.autoUnlock} for the opt-out and the iOS primer
+   * rationale.
+   *
+   * @param context - Audio context to use. If omitted, a fresh `AudioContext`
+   *   is constructed (which on mobile will be `suspended` until a user
+   *   gesture, triggering the auto-unlock path described above).
+   * @param cache - Optional cache implementation. Defaults to `AudioCache`.
+   * @param runtimeOptions - Optional runtime configuration including the
+   *   `autoUnlock` opt-out and a `createAudioWorkletNode` factory override.
+   */
   constructor(context?: BaseContext, cache?: ICache, runtimeOptions: RuntimeOptions = {}) {
     this.context = context ?? new AudioContext();
     this.listener = this.context.listener;
@@ -157,6 +197,36 @@ export class Cacophony {
         media.load();
       }
     });
+
+    // Install autoplay unlock — guarded against offline contexts, non-browser
+    // environments, and non-suspended contexts inside installAutoplayUnlock
+    // itself. Offline contexts are filtered out here because they cannot
+    // suspend in the same way and an unlock makes no sense for them.
+    const autoUnlock = runtimeOptions.autoUnlock !== false;
+    if (autoUnlock && !this.isOffline) {
+      this.autoplayUnlockCleanup = installAutoplayUnlock({
+        context: this.context,
+        onUnlock: () => {
+          this.suspendState = "running";
+          this.emit("unlock", undefined);
+        },
+      });
+    }
+  }
+
+  /**
+   * Returns `true` while the audio context is suspended — i.e. the library
+   * cannot produce sound until the context is resumed (typically by a user
+   * gesture). After the auto-unlock fires (or `resume()` is called manually),
+   * this becomes `false`.
+   *
+   * Mirrors Howler's `Howler.ctx.state === 'suspended'` check via the
+   * `Howler` global's `_audioUnlocked`. Use this to gate UI that hints to
+   * the user that an interaction is required to start audio.
+   */
+  get locked(): boolean {
+    const state = (this.context as unknown as { state?: string }).state;
+    return state === "suspended";
   }
 
   /** @internal */

--- a/src/events.ts
+++ b/src/events.ts
@@ -67,6 +67,13 @@ export type CacophonyEvents = {
   unmute: undefined;
   suspend: undefined;
   resume: undefined;
+  /**
+   * Fired once when the audio context is unlocked by the first user gesture
+   * (touchend / click / keydown) via the auto-unlock listeners installed by
+   * the `Cacophony` constructor. Not fired when `autoUnlock: false` is set
+   * or when the context was already running. See `RuntimeOptions.autoUnlock`.
+   */
+  unlock: undefined;
   loadingStart: LoadingStartEvent;
   loadingProgress: LoadingProgressEvent;
   loadingComplete: LoadingCompleteEvent;


### PR DESCRIPTION
## Summary

Closes a Howler-parity gap: on mobile (especially iOS Safari), an `AudioContext` constructed before any user interaction starts in `suspended` state and will silently produce no sound until the user gestures AND a node is started inside that gesture's call stack. Before this PR cacophony had no auto-unlock — mobile users heard nothing and developers had no clear signal why.

New `src/autoplayUnlock.ts` installs one-time `touchend`/`click`/`keydown` listeners on `document.body` (fallback to `document`). On first fire it constructs and starts a 1-sample silent primer buffer **synchronously inside the gesture call stack** (iOS requires this), then awaits `context.resume()` and emits an `unlock` event only after resume fulfills. On resume rejection, no `unlock` event fires.

Howler's `_unlockAudio` was the design reference (MIT, design adapted not copied).

## New API

- `RuntimeOptions.autoUnlock?: boolean` — default `true`. Set `false` to opt out.
- `Cacophony.locked: boolean` getter — mirrors Howler's lock query.
- `CacophonyEvents.unlock` event — fires once after successful resume.

Guards: never installs listeners on offline contexts or in non-browser environments, or when `state !== 'suspended'`.

## Tests

16 new tests covering all guards + the resume-contract behaviors (no unlock on rejection, async unlock, primer start/stop ordering). Suite: 470/470 pass (was 451 + 19 across two commits).

## Review

Codex review: original CHANGES_REQUESTED (2 findings on unlock event timing + primer stop) → fix commit `da7c121` addressed both → re-review APPROVED, "merge as-is."

## iOS verification needed

The 1-sample silent primer pattern cannot be unit-tested fully — SAC mock doesn't simulate iOS lockout. Suggested live test: host a tiny page, bind an `unlock` listener that plays a confirmation beep, open in iPhone Safari, tap once. Expected: hear the beep on unlock, then subsequent `sound.play()` should produce sound.