### PR TITLE
feat: format fallback for createSound URL arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,33 @@ const music = await cacophony.createSound('bgm.mp3', 'html');
 const radio = await cacophony.createStream('https://example.com/stream.m3u8');
 ```
 
+### Format Fallback (Howler-style)
+
+Pass an array of URLs and Cacophony picks the first one the browser can play.
+It queries `HTMLAudioElement.canPlayType` per extension and fetches only the
+chosen source (cache and loading events fire only for that URL). If the
+selected source's `canPlayType` was `'maybe'` and decoding actually fails,
+the next playable candidate is tried.
+
+```typescript
+// First playable source wins. Cacophony fetches only that one.
+const boom = await cacophony.createSound([
+  'sfx/boom.webm',  // small/modern, preferred when supported
+  'sfx/boom.mp3',   // universal fallback
+  'sfx/boom.wav',   // last-resort uncompressed
+]);
+boom.play();
+```
+
+Recognised extensions: `.webm`, `.mp3`, `.ogg`, `.wav`, `.flac`, `.m4a`,
+`.aac`, `.opus`. If no candidate is reported playable, or every playable
+candidate fails to decode, the promise rejects with an error naming the
+URLs that were tried.
+
+v1 limitation: format fallback is only available for the default `'buffer'`
+sound type. Passing an array together with `'html'` or `'streaming'`
+rejects with a "not yet supported" error.
+
 ## Playback Control
 
 ### Seeking

--- a/README.md
+++ b/README.md
@@ -132,7 +132,14 @@ boom.play();
 Recognised extensions: `.webm`, `.mp3`, `.ogg`, `.wav`, `.flac`, `.m4a`,
 `.aac`, `.opus`. If no candidate is reported playable, or every playable
 candidate fails to decode, the promise rejects with an error naming the
-URLs that were tried.
+URLs that were tried and the reason each failed (codec unsupported or
+decode failure).
+
+Only decode failures advance to the next candidate. Fetch/network/cache
+failures of the selected source propagate immediately so the caller sees
+the real cause instead of a silent format swap. Decode failures are
+detected by the Web Audio spec marker -- `DOMException` with name
+`EncodingError`.
 
 v1 limitation: format fallback is only available for the default `'buffer'`
 sound type. Passing an array together with `'html'` or `'streaming'`

--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -880,7 +880,7 @@ describe("Cacophony advanced features", () => {
       });
       const getAudioBufferSpy = vi
         .spyOn(mockCache, "getAudioBuffer")
-        .mockRejectedValueOnce(new Error("decode failed"))
+        .mockRejectedValueOnce(new DOMException("Unable to decode audio data", "EncodingError"))
         .mockResolvedValueOnce(mockBuffer);
 
       const sound = await cacophony.createSound(urls);
@@ -909,7 +909,9 @@ describe("Cacophony advanced features", () => {
         "audio/webm": "maybe",
         "audio/mpeg": "maybe",
       });
-      vi.spyOn(mockCache, "getAudioBuffer").mockRejectedValue(new Error("decode failed"));
+      vi.spyOn(mockCache, "getAudioBuffer").mockRejectedValue(
+        new DOMException("Unable to decode audio data", "EncodingError"),
+      );
 
       await expect(cacophony.createSound(urls)).rejects.toThrow(/a\.webm[\s\S]*a\.mp3/);
     });
@@ -938,6 +940,49 @@ describe("Cacophony advanced features", () => {
       expect(getAudioBufferSpy).toHaveBeenCalledTimes(1);
       expect(getAudioBufferSpy).toHaveBeenCalledWith(audioContextMock, url, undefined, expect.any(Object));
       expect(sound.url).toBe(url);
+    });
+
+    it("array with first URL fetch failure (non-decode error) — propagates, does NOT fall back", async () => {
+      const urls = ["https://example.com/a.webm", "https://example.com/a.mp3"];
+      mockCanPlayType({
+        "audio/webm": "probably",
+        "audio/mpeg": "probably",
+      });
+      const fetchError = new Error("network unreachable");
+      const getAudioBufferSpy = vi.spyOn(mockCache, "getAudioBuffer").mockRejectedValueOnce(fetchError);
+
+      await expect(cacophony.createSound(urls)).rejects.toThrow(/network unreachable/);
+      expect(getAudioBufferSpy).toHaveBeenCalledTimes(1);
+      expect(getAudioBufferSpy).toHaveBeenCalledWith(audioContextMock, urls[0], undefined, expect.any(Object));
+    });
+
+    it("single-string URL preserves caller's soundType (regression for refactor)", async () => {
+      const url = "https://example.com/audio.mp3";
+      const mockBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+      vi.spyOn(mockCache, "getAudioBuffer").mockResolvedValueOnce(mockBuffer);
+
+      const sound = await cacophony.createSound(url, "oscillator");
+
+      expect(sound.soundType).toBe("oscillator");
+    });
+
+    it("array all-failed error message contains per-URL reasons for both codec-unsupported and decode-failed candidates", async () => {
+      const urls = [
+        "https://example.com/a.webm", // unsupported by canPlayType
+        "https://example.com/a.flac", // unsupported by canPlayType
+        "https://example.com/a.mp3", // playable but decode fails
+      ];
+      mockCanPlayType({
+        "audio/webm": "",
+        "audio/flac": "",
+        "audio/mpeg": "maybe",
+      });
+      const decodeErr = new DOMException("Unable to decode audio data", "EncodingError");
+      vi.spyOn(mockCache, "getAudioBuffer").mockRejectedValue(decodeErr);
+
+      await expect(cacophony.createSound(urls)).rejects.toThrow(
+        /a\.webm.*codec unsupported[\s\S]*a\.flac.*codec unsupported[\s\S]*a\.mp3.*decode failed/i,
+      );
     });
   });
 

--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -806,6 +806,141 @@ describe("Cacophony advanced features", () => {
     });
   });
 
+  describe("createSound format fallback (URL array)", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const mockCanPlayType = (responses: Record<string, CanPlayTypeResult>) => {
+      vi.spyOn(global, "Audio").mockImplementation(
+        () =>
+          ({
+            canPlayType: (mime: string): CanPlayTypeResult => responses[mime] ?? "",
+          }) as unknown as HTMLAudioElement,
+      );
+    };
+
+    it("array with one URL behaves like single-string URL", async () => {
+      const url = "https://example.com/audio.mp3";
+      const mockBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+      mockCanPlayType({ "audio/mpeg": "probably" });
+      const getAudioBufferSpy = vi.spyOn(mockCache, "getAudioBuffer").mockResolvedValueOnce(mockBuffer);
+
+      const sound = await cacophony.createSound([url]);
+
+      expect(getAudioBufferSpy).toHaveBeenCalledTimes(1);
+      expect(getAudioBufferSpy).toHaveBeenCalledWith(audioContextMock, url, undefined, expect.any(Object));
+      expect(sound.url).toBe(url);
+      expect(sound.buffer).toBe(mockBuffer);
+    });
+
+    it("array with multiple URLs, all supported — picks the first", async () => {
+      const urls = ["https://example.com/a.webm", "https://example.com/a.mp3", "https://example.com/a.wav"];
+      const mockBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+      mockCanPlayType({
+        "audio/webm": "probably",
+        "audio/mpeg": "probably",
+        "audio/wav": "probably",
+      });
+      const getAudioBufferSpy = vi.spyOn(mockCache, "getAudioBuffer").mockResolvedValueOnce(mockBuffer);
+
+      const sound = await cacophony.createSound(urls);
+
+      expect(getAudioBufferSpy).toHaveBeenCalledTimes(1);
+      expect(getAudioBufferSpy).toHaveBeenCalledWith(audioContextMock, urls[0], undefined, expect.any(Object));
+      expect(sound.url).toBe(urls[0]);
+    });
+
+    it("array with first URL unsupported by canPlayType — picks the second", async () => {
+      const urls = ["https://example.com/a.webm", "https://example.com/a.mp3"];
+      const mockBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+      mockCanPlayType({
+        "audio/webm": "",
+        "audio/mpeg": "probably",
+      });
+      const getAudioBufferSpy = vi.spyOn(mockCache, "getAudioBuffer").mockResolvedValueOnce(mockBuffer);
+
+      const sound = await cacophony.createSound(urls);
+
+      expect(getAudioBufferSpy).toHaveBeenCalledTimes(1);
+      expect(getAudioBufferSpy).toHaveBeenCalledWith(audioContextMock, urls[1], undefined, expect.any(Object));
+      expect(sound.url).toBe(urls[1]);
+    });
+
+    it("array with first URL passing canPlayType but decode throws — falls back and decodes the second", async () => {
+      const urls = ["https://example.com/a.webm", "https://example.com/a.mp3"];
+      const mockBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+      mockCanPlayType({
+        "audio/webm": "maybe",
+        "audio/mpeg": "probably",
+      });
+      const getAudioBufferSpy = vi
+        .spyOn(mockCache, "getAudioBuffer")
+        .mockRejectedValueOnce(new Error("decode failed"))
+        .mockResolvedValueOnce(mockBuffer);
+
+      const sound = await cacophony.createSound(urls);
+
+      expect(getAudioBufferSpy).toHaveBeenCalledTimes(2);
+      expect(getAudioBufferSpy).toHaveBeenNthCalledWith(1, audioContextMock, urls[0], undefined, expect.any(Object));
+      expect(getAudioBufferSpy).toHaveBeenNthCalledWith(2, audioContextMock, urls[1], undefined, expect.any(Object));
+      expect(sound.url).toBe(urls[1]);
+    });
+
+    it("array with no playable URLs — throws an error listing all URLs", async () => {
+      const urls = ["https://example.com/a.webm", "https://example.com/a.flac"];
+      mockCanPlayType({
+        "audio/webm": "",
+        "audio/flac": "",
+      });
+      const getAudioBufferSpy = vi.spyOn(mockCache, "getAudioBuffer");
+
+      await expect(cacophony.createSound(urls)).rejects.toThrow(/a\.webm[\s\S]*a\.flac/);
+      expect(getAudioBufferSpy).not.toHaveBeenCalled();
+    });
+
+    it("array with all canPlayType candidates failing decode — throws listing tried URLs", async () => {
+      const urls = ["https://example.com/a.webm", "https://example.com/a.mp3"];
+      mockCanPlayType({
+        "audio/webm": "maybe",
+        "audio/mpeg": "maybe",
+      });
+      vi.spyOn(mockCache, "getAudioBuffer").mockRejectedValue(new Error("decode failed"));
+
+      await expect(cacophony.createSound(urls)).rejects.toThrow(/a\.webm[\s\S]*a\.mp3/);
+    });
+
+    it("empty array — throws with clear error", async () => {
+      await expect(cacophony.createSound([])).rejects.toThrow(/empty|at least one/i);
+    });
+
+    it("array with SoundType.html — throws not-yet-supported", async () => {
+      await expect(cacophony.createSound(["https://example.com/a.mp3"], "html")).rejects.toThrow(/not yet supported/i);
+    });
+
+    it("array with SoundType.streaming — throws not-yet-supported", async () => {
+      await expect(cacophony.createSound(["https://example.com/a.mp3"], "streaming")).rejects.toThrow(
+        /not yet supported/i,
+      );
+    });
+
+    it("single-string URL — existing behavior unchanged (regression)", async () => {
+      const url = "https://example.com/audio.mp3";
+      const mockBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+      const getAudioBufferSpy = vi.spyOn(mockCache, "getAudioBuffer").mockResolvedValueOnce(mockBuffer);
+
+      const sound = await cacophony.createSound(url);
+
+      expect(getAudioBufferSpy).toHaveBeenCalledTimes(1);
+      expect(getAudioBufferSpy).toHaveBeenCalledWith(audioContextMock, url, undefined, expect.any(Object));
+      expect(sound.url).toBe(url);
+    });
+  });
+
   describe("Global playback events", () => {
     it("emits globalPlay event when a Sound plays", async () => {
       const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -119,6 +119,36 @@ export interface SoundCleanupHoldings {
 
 const WORKLET_LOG_PREFIX = "[cacophony/worklet]";
 
+/**
+ * Extension → MIME type map used by `createSound` format fallback to query
+ * `HTMLAudioElement.canPlayType`. Keys are lower-cased extensions without
+ * the leading dot.
+ */
+const EXTENSION_MIME_MAP: Readonly<Record<string, string>> = Object.freeze({
+  webm: "audio/webm",
+  mp3: "audio/mpeg",
+  ogg: "audio/ogg",
+  wav: "audio/wav",
+  flac: "audio/flac",
+  m4a: "audio/mp4",
+  aac: "audio/aac",
+  opus: "audio/ogg; codecs=opus",
+});
+
+/**
+ * Returns the MIME type for a URL based on its file extension, or `null` if
+ * the extension is not recognised. Query strings and fragments are ignored.
+ */
+function mimeTypeForUrl(url: string): string | null {
+  const withoutQuery = url.split(/[?#]/, 1)[0];
+  const dotIndex = withoutQuery.lastIndexOf(".");
+  if (dotIndex < 0) {
+    return null;
+  }
+  const ext = withoutQuery.slice(dotIndex + 1).toLowerCase();
+  return EXTENSION_MIME_MAP[ext] ?? null;
+}
+
 export class Cacophony {
   context: BaseContext;
   globalGainNode: GainNode;
@@ -429,12 +459,41 @@ export class Cacophony {
 
   async createSound(url: string, soundType?: SoundType, panType?: PanType, signal?: AbortSignal): Promise<Sound>;
 
+  /**
+   * Creates a Sound from the first playable URL in a Howler-style fallback
+   * array. The browser's `HTMLAudioElement.canPlayType` is queried per
+   * extension; the first source it reports as supported (`'probably'` or
+   * `'maybe'`) is fetched and decoded. If decoding rejects for a candidate,
+   * the next playable candidate is tried — a `'maybe'` can still fail at
+   * decode time.
+   *
+   * MIME types are inferred from file extensions: `.webm` → `audio/webm`,
+   * `.mp3` → `audio/mpeg`, `.ogg` → `audio/ogg`, `.wav` → `audio/wav`,
+   * `.flac` → `audio/flac`, `.m4a` → `audio/mp4`, `.aac` → `audio/aac`,
+   * `.opus` → `audio/ogg; codecs=opus`.
+   *
+   * Cache and loading events fire only for the URL actually fetched.
+   *
+   * v1 limitation: only the default `'buffer'` sound type participates in
+   * fallback. Passing an array together with `'html'` or `'streaming'`
+   * rejects with a clear "not yet supported" error.
+   *
+   * @param urls - Non-empty array of candidate URLs in priority order.
+   * @throws If the array is empty, if `soundType` is `'html'`/`'streaming'`,
+   *   or if no candidate is playable (codec unsupported or every decode
+   *   failed). The error message names the URLs that were tried.
+   */
+  async createSound(urls: string[], soundType?: SoundType, panType?: PanType, signal?: AbortSignal): Promise<Sound>;
+
   async createSound(
-    bufferOrUrl: AudioBuffer | string,
+    bufferOrUrl: AudioBuffer | string | string[],
     soundType: SoundType = "buffer",
     panType: PanType = "HRTF",
     signal?: AbortSignal,
   ): Promise<Sound> {
+    if (Array.isArray(bufferOrUrl)) {
+      return this.createSoundFromUrlArray(bufferOrUrl, soundType, panType, signal);
+    }
     if (typeof bufferOrUrl === "object") {
       return Promise.resolve(new Sound("", bufferOrUrl, this.context, this.globalGainNode, soundType, panType, this));
     }
@@ -445,17 +504,75 @@ export class Cacophony {
     if (soundType === "streaming") {
       return this.createMediaSound(url, "streaming", panType, signal);
     }
-    return this.cache
-      .getAudioBuffer(this.context, url, signal, {
-        onLoadingStart: (event) => this.emitAsync("loadingStart", event),
-        onLoadingProgress: (event) => this.emitAsync("loadingProgress", event),
-        onLoadingComplete: (event) => this.emitAsync("loadingComplete", event),
-        onLoadingError: (event) => this.emitAsync("loadingError", event),
-        onCacheHit: (event) => this.emitAsync("cacheHit", event),
-        onCacheMiss: (event) => this.emitAsync("cacheMiss", event),
-        onCacheError: (event) => this.emitAsync("cacheError", event),
-      })
-      .then((buffer) => new Sound(url as string, buffer, this.context, this.globalGainNode, soundType, panType, this));
+    return this.loadBufferSound(url, panType, signal);
+  }
+
+  private async loadBufferSound(url: string, panType: PanType, signal?: AbortSignal): Promise<Sound> {
+    const buffer = await this.cache.getAudioBuffer(this.context, url, signal, {
+      onLoadingStart: (event) => this.emitAsync("loadingStart", event),
+      onLoadingProgress: (event) => this.emitAsync("loadingProgress", event),
+      onLoadingComplete: (event) => this.emitAsync("loadingComplete", event),
+      onLoadingError: (event) => this.emitAsync("loadingError", event),
+      onCacheHit: (event) => this.emitAsync("cacheHit", event),
+      onCacheMiss: (event) => this.emitAsync("cacheMiss", event),
+      onCacheError: (event) => this.emitAsync("cacheError", event),
+    });
+    return new Sound(url, buffer, this.context, this.globalGainNode, "buffer", panType, this);
+  }
+
+  private async createSoundFromUrlArray(
+    urls: string[],
+    soundType: SoundType,
+    panType: PanType,
+    signal?: AbortSignal,
+  ): Promise<Sound> {
+    if (urls.length === 0) {
+      throw new Error("createSound: URL array is empty; provide at least one URL");
+    }
+    if (soundType === "html" || soundType === "streaming") {
+      throw new Error(
+        `createSound: URL array with soundType='${soundType}' is not yet supported. ` +
+          `Format fallback is only available for buffer sounds in this version.`,
+      );
+    }
+    const playable = urls.filter((url) => this.canPlaySource(url));
+    if (playable.length === 0) {
+      throw new Error(
+        `createSound: no playable source found among [${urls.join(", ")}] ` +
+          `(no candidate's MIME type was reported as supported by HTMLAudioElement.canPlayType)`,
+      );
+    }
+    const decodeErrors: Array<{ url: string; error: unknown }> = [];
+    for (const url of playable) {
+      try {
+        return await this.loadBufferSound(url, panType, signal);
+      } catch (error) {
+        if ((error as { name?: string } | null)?.name === "AbortError") {
+          throw error;
+        }
+        decodeErrors.push({ url, error });
+      }
+    }
+    const detail = decodeErrors
+      .map(({ url, error }) => `${url}: ${(error as Error)?.message ?? String(error)}`)
+      .join("; ");
+    throw new Error(
+      `createSound: every playable candidate failed to decode. Tried [${urls.join(", ")}]. Decode errors: ${detail}`,
+    );
+  }
+
+  private canPlaySource(url: string): boolean {
+    const mime = mimeTypeForUrl(url);
+    if (!mime) {
+      return false;
+    }
+    try {
+      const probe = new Audio();
+      const result = probe.canPlayType(mime);
+      return result === "probably" || result === "maybe";
+    } catch {
+      return false;
+    }
   }
 
   async createGroup(sounds: Sound[]): Promise<Group> {

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -504,10 +504,15 @@ export class Cacophony {
     if (soundType === "streaming") {
       return this.createMediaSound(url, "streaming", panType, signal);
     }
-    return this.loadBufferSound(url, panType, signal);
+    return this.loadBufferSound(url, soundType, panType, signal);
   }
 
-  private async loadBufferSound(url: string, panType: PanType, signal?: AbortSignal): Promise<Sound> {
+  private async loadBufferSound(
+    url: string,
+    soundType: SoundType,
+    panType: PanType,
+    signal?: AbortSignal,
+  ): Promise<Sound> {
     const buffer = await this.cache.getAudioBuffer(this.context, url, signal, {
       onLoadingStart: (event) => this.emitAsync("loadingStart", event),
       onLoadingProgress: (event) => this.emitAsync("loadingProgress", event),
@@ -517,7 +522,24 @@ export class Cacophony {
       onCacheMiss: (event) => this.emitAsync("cacheMiss", event),
       onCacheError: (event) => this.emitAsync("cacheError", event),
     });
-    return new Sound(url, buffer, this.context, this.globalGainNode, "buffer", panType, this);
+    return new Sound(url, buffer, this.context, this.globalGainNode, soundType, panType, this);
+  }
+
+  /**
+   * Returns true if the error came from `AudioContext.decodeAudioData`.
+   *
+   * Per the Web Audio spec, decode failures throw a `DOMException` with name
+   * `EncodingError`. We deliberately do NOT treat plain `Error` instances as
+   * decode failures: fetch/cache/network errors must propagate so the caller
+   * sees the real cause instead of silently falling through to a different
+   * format. See `reports/format-fallback-codex-review.md` (Major 1).
+   */
+  private static isDecodeError(error: unknown): boolean {
+    if (error === null || typeof error !== "object") {
+      return false;
+    }
+    const name = (error as { name?: unknown }).name;
+    return name === "EncodingError";
   }
 
   private async createSoundFromUrlArray(
@@ -535,29 +557,43 @@ export class Cacophony {
           `Format fallback is only available for buffer sounds in this version.`,
       );
     }
-    const playable = urls.filter((url) => this.canPlaySource(url));
+    const candidateReasons = new Map<string, string>();
+    const playable: string[] = [];
+    for (const url of urls) {
+      if (this.canPlaySource(url)) {
+        playable.push(url);
+      } else {
+        const ext = url.match(/\.([a-z0-9]+)(?:\?|#|$)/i)?.[1]?.toLowerCase();
+        candidateReasons.set(url, ext ? `codec unsupported: .${ext}` : "codec unsupported: unknown extension");
+      }
+    }
     if (playable.length === 0) {
+      const detail = urls.map((u) => `${u}: ${candidateReasons.get(u) ?? "codec unsupported"}`).join("; ");
       throw new Error(
         `createSound: no playable source found among [${urls.join(", ")}] ` +
-          `(no candidate's MIME type was reported as supported by HTMLAudioElement.canPlayType)`,
+          `(no candidate's MIME type was reported as supported by HTMLAudioElement.canPlayType). ` +
+          `Reasons: ${detail}`,
       );
     }
-    const decodeErrors: Array<{ url: string; error: unknown }> = [];
     for (const url of playable) {
       try {
-        return await this.loadBufferSound(url, panType, signal);
+        // Array path always produces buffer sounds; html/streaming were rejected above.
+        return await this.loadBufferSound(url, "buffer", panType, signal);
       } catch (error) {
         if ((error as { name?: string } | null)?.name === "AbortError") {
           throw error;
         }
-        decodeErrors.push({ url, error });
+        if (!Cacophony.isDecodeError(error)) {
+          // Fetch/cache/network failure of the selected source — propagate.
+          // Only decode failures fall through to the next candidate.
+          throw error;
+        }
+        candidateReasons.set(url, `decode failed: ${(error as Error)?.message ?? String(error)}`);
       }
     }
-    const detail = decodeErrors
-      .map(({ url, error }) => `${url}: ${(error as Error)?.message ?? String(error)}`)
-      .join("; ");
+    const detail = urls.map((u) => `${u}: ${candidateReasons.get(u) ?? "unknown"}`).join("; ");
     throw new Error(
-      `createSound: every playable candidate failed to decode. Tried [${urls.join(", ")}]. Decode errors: ${detail}`,
+      `createSound: every playable candidate failed to decode. Tried [${urls.join(", ")}]. Reasons: ${detail}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Closes a Howler-parity gap: pass an array of URLs to `createSound`, and the library picks the first format the browser can play.

\`\`\`ts
const sound = await cacophony.createSound(['boom.webm', 'boom.mp3']);
\`\`\`

New third overload on `Cacophony.createSound(urls: string[], soundType?, panType?, signal?)`. Codec selection uses `HTMLAudioElement.canPlayType` against an extension→MIME map (`.webm`, `.mp3`, `.ogg`, `.wav`, `.flac`, `.m4a`, `.aac`, `.opus`). First URL whose `canPlayType` returns `'probably'` or `'maybe'` is fetched and decoded; if decode rejects with a `DOMException` named `EncodingError`, falls back to the next playable candidate. Fetch/cache errors propagate immediately (no false fallback). Aborts propagate immediately too.

If all candidates fail, throws an error listing each URL with its specific reason (codec unsupported / decode failed / ...).

v1 limitation: only `SoundType.Buffer` participates. HTML/Streaming with an array throws "not yet supported." Documented in JSDoc.

The cache layer is URL-keyed, so each format gets its own cache entry — no plumbing changes.

## Tests

11 new tests in `cacophony.test.ts` covering: single-URL unchanged, array picks first, falls back on codec-unsupported, falls back on EncodingError, propagates fetch failures (no fallback), preserves single-URL `soundType` (oscillator stays oscillator), all-fail error message includes reasons for both codec-unsupported and decode-failed entries, empty array rejects, HTML/Streaming + array throws.

Suite: 464/464 pass (was 451 + 13 across two commits including 2 existing test updates).

## Review

Codex review: original CHANGES_REQUESTED (2 majors on fetch-vs-decode distinction + single-URL soundType preservation, 2 minors on error messages + missing regression tests) → fix commit `f82ca6e` addressed all → re-review APPROVED, "merge as-is."