### PR TITLE
feat: add buses, sends, and Dattorro reverb

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,25 +340,97 @@ playback.connect(distortion)
 
 ### Parallel Effects (Send/Return)
 
-Create parallel effect sends like a mixing console:
+For mixing-console-style routing — named buses, shared effects, and
+per-edge send gain — use the first-class [Buses and Sends](#buses-and-sends)
+API documented below. The Bus class supersedes the older user-built
+`playback.connect()` send/return pattern.
+
+## Buses and Sends
+
+A `Bus` is a named summing node with its own filter chain and per-edge
+gain on outgoing connections. Sounds and synths route to buses via
+`routeTo`; buses can carry rich effects (not just BiquadFilter) by
+adding a `CacophonyEffect` to their filter chain. The built-in
+`cacophony.createReverb()` returns a DattorroReverb effect ready to drop
+into a bus.
 
 ```typescript
-const sound = await cacophony.createSound('vocals.mp3');
-const [playback] = sound.play();
+// 1. Create a named bus
+const reverbBus = cacophony.createBus('reverb');
 
-// Create send effects
-const reverb = cacophony.context.createConvolver();
-const reverbReturn = cacophony.context.createGain();
-reverbReturn.gain.value = 0.3;  // 30% wet
+// 2. Add a DattorroReverb effect to the bus
+const reverb = cacophony.createReverb({ wet: 0.6, dry: 0.4, decay: 0.7 });
+await reverbBus.addFilter(reverb);
 
-// Dry signal to destination
-playback.connect(cacophony.context.destination);
+// 3. Lower the bus's level a bit before it hits master
+reverbBus.gain = 0.5;
 
-// Parallel wet signal: playback → reverb → reverbReturn → destination
-playback.connect(reverb)
-        .connect(reverbReturn)
-        .connect(cacophony.context.destination);
+// 4. Route one sound's primary output to the bus
+const vocals = await cacophony.createSound('vocals.mp3');
+vocals.routeTo(reverbBus);
+vocals.play();
+
+// 5. Send another sound to the bus at 30% (primary route still goes to master)
+const drums = await cacophony.createSound('drums.mp3');
+drums.routeTo(reverbBus, 0.3);
+drums.play();
 ```
+
+### Looking up buses by name
+
+```typescript
+const fx = cacophony.createBus('fx');
+cacophony.getBus('fx');       // → same Bus instance
+cacophony.listBuses();        // → ['master', 'fx']
+sound.routeTo('fx');          // string lookup via the registry
+```
+
+### The master bus
+
+`cacophony.master` is the built-in master bus. Its `input` is literally
+the same node as `cacophony.globalGainNode`, so the existing
+`cacophony.volume` and `cacophony.mute` APIs continue to work
+transparently. Routing a sound to `cacophony.master` (or never calling
+`routeTo`) sends it through the master path.
+
+### Bus-to-bus routing with per-edge gain
+
+```typescript
+const groupBus = cacophony.createBus('group');
+const sendBus = cacophony.createBus('aux');
+groupBus.connect(sendBus, 0.2);   // 20% send: groupBus.output → sendGain(0.2) → sendBus.input
+groupBus.disconnect(sendBus);     // tears down the sendGain too
+```
+
+### Adding custom effects to a bus
+
+Bus filter chains accept Cacophony-built BiquadFilters and any
+`CacophonyEffect`. Raw third-party AudioNodes are rejected unless you
+wrap them explicitly with `cacophony.shareEffect(node)` — this surfaces
+the shared-state intent (the same node will run on every bus that adds it).
+
+```typescript
+const eq = cacophony.createBiquadFilter({ type: 'highshelf', frequency: 4000, gain: 3 });
+await bus.addFilter(eq);
+
+const sharedWorklet = new AudioWorkletNode(cacophony.context, 'my-fx');
+await bus.addFilter(cacophony.shareEffect(sharedWorklet));
+```
+
+### Cleaning up
+
+```typescript
+reverbBus.destroy();   // disconnects everything, deregisters the name
+```
+
+Sounds still routed to a destroyed bus fall back to master on their
+next playback with a `console.warn`.
+
+### Legacy: user-built send/return
+
+Before buses existed, send/return was a manual `playback.connect()`
+chain (see the [Custom Audio Routing](#custom-audio-routing) section
+for the low-level pattern). New code should use a Bus and `routeTo`.
 
 ### Dynamic Routing
 

--- a/reports/autoplay-unlock-codex-review.md
+++ b/reports/autoplay-unlock-codex-review.md
@@ -1,0 +1,24 @@
+# Codex review: autoplay-unlock
+
+## Verdict
+CHANGES_REQUESTED
+
+## Summary
+The implementation is mostly aligned with the brief: listener installation is gated correctly for suspended/browser/default-autoUnlock contexts, offline and non-browser paths are guarded, all three listeners are removed together, re-entry is locked out, the module split is defensible, the local `createBuffer` cast is acceptable for this one call site, and the README addition is legitimate new-section content despite line-ending churn around it.
+
+I did not rerun `npm run typecheck` or `npm test`; this review is based on the required prompt, implementer report, requested diffs, and final file inspection. The code still has two behavior-contract defects in the actual unlock path, so I do not consider it production-ready.
+
+## Findings
+1. High / unlock event semantics / `unlock` is emitted and `suspendState` is set to `"running"` before `context.resume()` has succeeded / `.claude/worktrees/agent-a8487d36b1ea4b06d/src/autoplayUnlock.ts:130` and `.claude/worktrees/agent-a8487d36b1ea4b06d/src/cacophony.ts:209` / The public `unlock` event is supposed to signal that the first gesture unlocked audio. In the current code, `resume.call(context).catch(...)` is fire-and-forget and `onUnlock()` runs immediately afterward, so a rejected or still-pending resume still emits `unlock` and marks the instance as running. A caller can observe `unlock` while `cacophony.locked` is still true, and a resume failure is reported only as a warning after the false unlock signal.
+
+2. Medium / iOS primer contract / The primer source is started but never stopped / `.claude/worktrees/agent-a8487d36b1ea4b06d/src/autoplayUnlock.ts:117` / The original brief explicitly required the silent `AudioBufferSourceNode` to `start(0)` and `stop(0)` inside the gesture handler. A one-sample non-looping buffer will normally end on its own, but this is still a direct miss against the load-bearing primer pattern the task asked to implement, and the test suite does not assert the required `stop(0)` call.
+
+## If CHANGES_REQUESTED
+1. Keep primer creation/start synchronous in the gesture handler, but emit `unlock` and set `suspendState = "running"` only after `context.resume()` fulfills. Do not emit `unlock` on resume rejection.
+
+2. Call `source.stop(0)` immediately after `source.start(0)` in the primer path.
+
+3. Add focused tests for resume rejection not emitting `unlock` and for the primer calling `stop(0)`.
+
+## Recommendation
+Fix the two unlock-path contract issues, then rerun typecheck and the full test suite before promotion.

--- a/reports/format-fallback-codex-review.md
+++ b/reports/format-fallback-codex-review.md
@@ -1,0 +1,30 @@
+# Codex review: format-fallback
+
+## Verdict
+CHANGES_REQUESTED
+
+## Summary
+The implementation covers the main happy path for URL-array fallback and keeps the MIME map in the shape the brief requested. The README update is scoped, the changed paths are limited to `src/cacophony.ts`, `src/cacophony.test.ts`, and `README.md`, and the required array-selection tests are mostly present.
+
+I would not land this as-is. The fallback loop treats every non-abort `cache.getAudioBuffer` rejection as if it were a decode failure, but the brief explicitly allows fallback only after decode failure, not fetch failure. The refactor also changes an existing single-URL behavior by hardcoding loaded URL sounds as `buffer` after the helper returns.
+
+## Findings
+1. MAJOR - behavior contract - fetch/cache failures incorrectly fall through to later formats. In `createSoundFromUrlArray`, every non-`AbortError` thrown by `loadBufferSound` is caught, recorded as a decode error, and the loop continues to the next playable URL (`src/cacophony.ts:546`). `loadBufferSound` wraps the whole `cache.getAudioBuffer` operation, not just decode (`src/cacophony.ts:510`), and `getAudioBuffer` can reject for fetch/cache errors before or around decode. The brief says decode failure falls back, "NOT fetch fails"; this implementation will hide a failed fetch of the selected playable source and fetch another candidate instead of propagating the fetch failure.
+
+2. MAJOR - refactor risk - the single-string URL path no longer preserves the caller's existing `soundType` for non-HTML/non-streaming values. The old path constructed `new Sound(..., soundType, ...)` after cache load; the new path calls `loadBufferSound` for any single URL that is not `html` or `streaming` (`src/cacophony.ts:507`), and `loadBufferSound` always constructs `new Sound(..., "buffer", ...)` (`src/cacophony.ts:520`). Because `SoundType` includes `"oscillator"`, `createSound("x.mp3", "oscillator")` changes from returning a `Sound` tagged as `oscillator` to one tagged as `buffer`, violating the brief's "single-string URL behavior unchanged" requirement.
+
+3. MINOR - error reporting - mixed unsupported/decode-failed arrays do not give a reason for every URL. When playable candidates all fail, the final error lists all URLs in `Tried [...]` but only includes detailed reasons for entries in `decodeErrors` (`src/cacophony.ts:556`). Unsupported URLs filtered out at `src/cacophony.ts:538` have no per-URL "codec unsupported" reason in that final all-failed error, despite the brief requiring all-unplayable errors to list URLs and reasons.
+
+4. MINOR - test coverage - the tests do not cover the fetch-failure/no-fallback contract or the refactor regression above. The new fallback tests cover first playable, unsupported first, decode fallback, no playable, empty array, and HTML/streaming rejection (`src/cacophony.test.ts:827`), but there is no case where the first playable URL fails to fetch and must reject without trying the second, and no regression asserting single-URL `soundType` preservation for the existing non-HTML/non-streaming path.
+
+## If CHANGES_REQUESTED
+1. Split fallback handling so only decode failures advance to the next playable URL. Fetch/cache/other load failures should reject immediately, while aborts should continue to reject immediately as they do now.
+
+2. Preserve the previous single-string URL behavior by passing the original `soundType` through the buffer-load helper, or otherwise keep the old construction semantics for non-array URLs.
+
+3. Include a reason for every candidate in the final URL-array failure message, including unsupported-extension/unsupported-codec candidates that were filtered before decode attempts.
+
+4. Add focused regression tests for fetch failure not falling back and for the single-URL refactor behavior that currently changed.
+
+## Recommendation
+merge after fixes

--- a/src/autoplayUnlock.test.ts
+++ b/src/autoplayUnlock.test.ts
@@ -1,8 +1,7 @@
 import { AudioBuffer, AudioContext } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-import { Cacophony } from "./cacophony";
 import { installAutoplayUnlock } from "./autoplayUnlock";
+import { Cacophony } from "./cacophony";
 import type { BaseContext, AudioBuffer as CacophonyAudioBuffer } from "./context";
 import { mockCache } from "./setupTests";
 

--- a/src/bus-integration.test.ts
+++ b/src/bus-integration.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { AudioContext } from "standardized-audio-context-mock";
+import { describe, expect, it, vi } from "vitest";
 import { Bus } from "./bus";
+import { Cacophony } from "./cacophony";
 import { cacophony } from "./setupTests";
 
 describe("Cacophony.master", () => {
@@ -27,6 +29,62 @@ describe("Cacophony.master", () => {
     expect(cacophony.master.input.gain.value).toBe(0);
     cacophony.unmute();
     expect(cacophony.master.input.gain.value).toBe(0.8);
+  });
+
+  it("master.output is connected to context.destination at construction", () => {
+    // Construct a fresh Cacophony so we can spy on context.destination.connect
+    // being reached via master.output → destination. The fresh-context
+    // approach avoids the setupTests shared fixture.
+    const freshCtx = new AudioContext();
+    // Wrap createGain so we can grab the GainNode that becomes master.output
+    // (the SECOND gain node allocated — globalGainNode is first).
+    const realCreateGain = freshCtx.createGain.bind(freshCtx);
+    const allocated: Array<{ node: any; connect: ReturnType<typeof vi.fn> }> = [];
+    vi.spyOn(freshCtx, "createGain").mockImplementation(() => {
+      const node = realCreateGain();
+      const connectSpy = vi.fn(node.connect.bind(node));
+      Object.assign(node, { connect: connectSpy });
+      allocated.push({ node, connect: connectSpy });
+      return node;
+    });
+    const fresh = new Cacophony(freshCtx);
+    // master.output is the second allocated GainNode (globalGainNode first,
+    // then the Bus ctor allocates its own output).
+    const masterOutputRecord = allocated[1];
+    expect(masterOutputRecord.node).toBe(fresh.master.output);
+    expect(masterOutputRecord.connect).toHaveBeenCalledWith(freshCtx.destination);
+  });
+
+  it("adding a master filter does NOT silence the audible path — master.output stays connected to destination", async () => {
+    // The pre-fix bug: globalGainNode was connected to destination *directly*,
+    // _refreshFilters() then severed that edge while wiring through
+    // master.output (which was never connected to destination), silencing
+    // everything. After the fix master.output is the destination edge and
+    // master.input → [filters] → master.output is rebuilt cleanly.
+    const filter = cacophony.createBiquadFilter({ frequency: 1000 });
+    const destinationConnectSpy = vi.spyOn(cacophony.master.output, "connect");
+    await cacophony.master.addFilter(filter);
+    // master.output.connect to destination must have happened at construction
+    // (already done) — and adding the filter must NOT have severed it.
+    // We assert positively by re-running connect via _refreshFilters: the
+    // filter chain rebuild reconnects master.input → filter → master.output;
+    // master.output → destination is independent and stays alive. Spy on
+    // master.output.disconnect to confirm it wasn't called.
+    const outputDisconnectSpy = vi.spyOn(cacophony.master.output, "disconnect");
+    const second = cacophony.createBiquadFilter({ frequency: 500 });
+    await cacophony.master.addFilter(second);
+    expect(outputDisconnectSpy).not.toHaveBeenCalled();
+    expect(destinationConnectSpy).toBeDefined();
+  });
+
+  it("master.gain is in the audible signal path — master.output.gain is the master level", () => {
+    // master.gain proxies master.output.gain; master.output sits between
+    // the input/filter chain and the destination, so writing master.gain
+    // affects the level of every routed signal.
+    cacophony.master.gain = 0.42;
+    expect(cacophony.master.output.gain.value).toBe(0.42);
+    // Reset to avoid bleeding into other tests.
+    cacophony.master.gain = 1;
   });
 });
 

--- a/src/bus-integration.test.ts
+++ b/src/bus-integration.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { Bus } from "./bus";
+import { cacophony } from "./setupTests";
+
+describe("Cacophony.master", () => {
+  it("exists as a Bus instance after construction", () => {
+    expect(cacophony.master).toBeInstanceOf(Bus);
+  });
+
+  it("master.input is the same node as cacophony.globalGainNode", () => {
+    expect(cacophony.master.input).toBe(cacophony.globalGainNode);
+  });
+
+  it("master.name === 'master'", () => {
+    expect(cacophony.master.name).toBe("master");
+  });
+
+  it("cacophony.volume = 0.5 reflects on master.input.gain.value", () => {
+    cacophony.volume = 0.5;
+    expect(cacophony.master.input.gain.value).toBe(0.5);
+    expect(cacophony.globalGainNode.gain.value).toBe(0.5);
+  });
+
+  it("cacophony.mute()/unmute() still works through the globalGainNode alias", () => {
+    cacophony.volume = 0.8;
+    cacophony.mute();
+    expect(cacophony.master.input.gain.value).toBe(0);
+    cacophony.unmute();
+    expect(cacophony.master.input.gain.value).toBe(0.8);
+  });
+});
+
+describe("Cacophony.createBus / getBus / listBuses", () => {
+  it("createBus('drums') returns a Bus; getBus('drums') returns the same instance", () => {
+    const drums = cacophony.createBus("drums");
+    expect(drums).toBeInstanceOf(Bus);
+    expect(cacophony.getBus("drums")).toBe(drums);
+    drums.destroy();
+  });
+
+  it("createBus() with no name returns an anonymous Bus (name=null), not in registry", () => {
+    const anon = cacophony.createBus();
+    expect(anon.name).toBeNull();
+    expect(cacophony.listBuses()).not.toContain(null);
+    anon.destroy();
+  });
+
+  it("createBus('drums') called twice throws", () => {
+    const drums = cacophony.createBus("drums");
+    expect(() => cacophony.createBus("drums")).toThrow(/already exists/);
+    drums.destroy();
+  });
+
+  it("createBus('master') throws — name is reserved", () => {
+    expect(() => cacophony.createBus("master")).toThrow(/reserved/);
+  });
+
+  it("getBus('nonexistent') returns undefined", () => {
+    expect(cacophony.getBus("nonexistent")).toBeUndefined();
+  });
+
+  it("getBus('master') returns the master bus", () => {
+    expect(cacophony.getBus("master")).toBe(cacophony.master);
+  });
+
+  it("listBuses() includes 'master' plus all named buses", () => {
+    const a = cacophony.createBus("a-bus");
+    const b = cacophony.createBus("b-bus");
+    const list = cacophony.listBuses();
+    expect(list).toContain("master");
+    expect(list).toContain("a-bus");
+    expect(list).toContain("b-bus");
+    a.destroy();
+    b.destroy();
+  });
+
+  it("destroying a named bus removes it from the registry", () => {
+    const drums = cacophony.createBus("kicks");
+    expect(cacophony.getBus("kicks")).toBe(drums);
+    drums.destroy();
+    expect(cacophony.getBus("kicks")).toBeUndefined();
+  });
+
+  it("a newly created bus auto-routes its output to master", () => {
+    // Indirectly verifiable: re-creating the same name after destroy works,
+    // and listBuses reflects current state. (Audio-graph topology is opaque
+    // to assertion via the SAC mock — but the connect call happens in
+    // createBus regardless.)
+    const a = cacophony.createBus("one-off");
+    expect(cacophony.listBuses()).toContain("one-off");
+    a.destroy();
+    expect(cacophony.listBuses()).not.toContain("one-off");
+  });
+});

--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -99,17 +99,34 @@ describe("Bus: per-edge gain on connect", () => {
     expect(connectSpy).toHaveBeenCalledWith(b.input);
   });
 
-  it("allocates a sendGain when gain !== 1; output → sendGain → target", () => {
+  it("allocates a sendGain when gain !== 1; output → sendGain → target.input", () => {
     const a = new Bus(cacophony.context, null);
     const b = new Bus(cacophony.context, null);
+    // Wrap createGain so the allocated sendGain's connect call is observable.
+    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
+    const allocated: Array<{ node: any; connect: ReturnType<typeof vi.fn> }> = [];
+    vi.spyOn(cacophony.context, "createGain").mockImplementation(() => {
+      const node = realCreateGain();
+      const connectSpy = vi.fn(node.connect.bind(node));
+      Object.assign(node, { connect: connectSpy });
+      allocated.push({ node, connect: connectSpy });
+      return node;
+    });
     const outputConnectSpy = vi.spyOn(a.output, "connect");
     a.connect(b, 0.5);
-    // First connect on a.output is to the sendGain, not to b.input directly.
+    // First hop: a.output → sendGain (not b.input directly).
     expect(outputConnectSpy).toHaveBeenCalled();
     const firstCallTarget = outputConnectSpy.mock.calls[0]?.[0] as { gain?: { value: number } };
     expect(firstCallTarget).toBeDefined();
     expect(firstCallTarget).not.toBe(b.input);
     expect(firstCallTarget.gain?.value).toBe(0.5);
+    // Second hop: sendGain → b.input. The sendGain was the LAST allocated
+    // gain in this connect call (a.output and b.input were allocated earlier
+    // when the buses were constructed).
+    const sendGainRecord = allocated[allocated.length - 1];
+    expect(sendGainRecord).toBeDefined();
+    expect(sendGainRecord.node).toBe(firstCallTarget);
+    expect(sendGainRecord.connect).toHaveBeenCalledWith(b.input);
   });
 
   it("connects to a raw AudioNode target", () => {
@@ -132,12 +149,27 @@ describe("Bus: per-edge gain on connect", () => {
   it("disconnect(target) tears down the sendGain when one was allocated", () => {
     const a = new Bus(cacophony.context, null);
     const b = new Bus(cacophony.context, null);
+    // Capture the sendGain node by wrapping its disconnect so we can assert
+    // the allocated GainNode itself was disconnected (not just the output edge).
+    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
+    const sendDisconnectSpies: ReturnType<typeof vi.fn>[] = [];
+    vi.spyOn(cacophony.context, "createGain").mockImplementation(() => {
+      const node = realCreateGain();
+      const disconnectSpy = vi.fn(node.disconnect.bind(node));
+      Object.assign(node, { disconnect: disconnectSpy });
+      sendDisconnectSpies.push(disconnectSpy);
+      return node;
+    });
     a.connect(b, 0.3);
-    // After connect with gain, an internal sendGain exists. Disconnect should
-    // disconnect it from a.output AND disconnect the sendGain itself.
+    // The sendGain is the LAST allocated GainNode.
+    const sendGainDisconnect = sendDisconnectSpies[sendDisconnectSpies.length - 1];
+    expect(sendGainDisconnect).toBeDefined();
     const outputDisconnectSpy = vi.spyOn(a.output, "disconnect");
     a.disconnect(b);
+    // a.output disconnected from the sendGain.
     expect(outputDisconnectSpy).toHaveBeenCalled();
+    // AND the sendGain itself was disconnected (its outgoing edge to b.input).
+    expect(sendGainDisconnect).toHaveBeenCalled();
     // Re-connecting after disconnect uses the no-gain path → direct edge again.
     const reconnectSpy = vi.spyOn(a.output, "connect");
     a.connect(b);
@@ -201,6 +233,46 @@ describe("Bus: destroy lifecycle", () => {
     bus.destroy();
     const filter = cacophony.createBiquadFilter({ frequency: 200 });
     expect(() => bus.removeFilter(filter)).toThrow(/destroyed/);
+  });
+
+  it("destroy() disconnects input, output, every filter, every sendGain, and fires onDestroy", async () => {
+    // Wrap createGain so we can spy on each allocated node's disconnect.
+    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
+    const allocated: Array<ReturnType<typeof vi.fn>> = [];
+    vi.spyOn(cacophony.context, "createGain").mockImplementation(() => {
+      const node = realCreateGain();
+      const disconnectSpy = vi.fn(node.disconnect.bind(node));
+      Object.assign(node, { disconnect: disconnectSpy });
+      allocated.push(disconnectSpy);
+      return node;
+    });
+
+    const onDestroy = vi.fn();
+    const bus = new Bus(cacophony.context, "destroy-paths", undefined, onDestroy);
+    // bus.input and bus.output were the first two GainNodes allocated.
+    const inputDisconnect = allocated[0];
+    const outputDisconnect = allocated[1];
+
+    // Add a filter so the destroy() path walks the filter list too.
+    const filter = cacophony.createBiquadFilter({ frequency: 500 });
+    const filterDisconnectSpy = vi.spyOn(filter, "disconnect");
+    await bus.addFilter(filter);
+
+    // Add a gained connection so destroy walks the _sendGains map.
+    const target = new Bus(cacophony.context, null);
+    bus.connect(target, 0.4);
+    // The sendGain is the LAST createGain allocation (target's input/output
+    // were allocated by the Bus(target) ctor before connect ran).
+    const sendGainDisconnect = allocated[allocated.length - 1];
+
+    bus.destroy();
+
+    expect(inputDisconnect).toHaveBeenCalled();
+    expect(outputDisconnect).toHaveBeenCalled();
+    expect(filterDisconnectSpy).toHaveBeenCalled();
+    expect(sendGainDisconnect).toHaveBeenCalled();
+    expect(onDestroy).toHaveBeenCalledTimes(1);
+    expect(bus.destroyed).toBe(true);
   });
 });
 

--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -296,6 +296,23 @@ describe("Bus: filter chain refresh", () => {
     expect(bus.filters).toEqual([f2]);
   });
 
+  it("refreshes only this bus's edges when a filter node is shared", async () => {
+    const shared = cacophony.context.createGain();
+    const busA = new Bus(cacophony.context, "a");
+    const busB = new Bus(cacophony.context, "b");
+
+    await busA.addFilter(cacophony.shareEffect(shared));
+    await busB.addFilter(cacophony.shareEffect(shared));
+
+    const disconnectShared = vi.spyOn(shared, "disconnect");
+    const secondFilter = cacophony.createBiquadFilter({ frequency: 200 });
+    await busB.addFilter(secondFilter);
+
+    expect(disconnectShared).not.toHaveBeenCalledWith();
+    expect(disconnectShared).not.toHaveBeenCalledWith(busA.output);
+    expect(disconnectShared).toHaveBeenCalledWith(busB.output);
+  });
+
   it("removeFilter throws if the node was never added", () => {
     const bus = new Bus(cacophony.context, null);
     const filter = cacophony.createBiquadFilter({ frequency: 100 });

--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+import { Bus } from "./bus";
+import { cacophony } from "./setupTests";
+
+describe("Bus: construction", () => {
+  it("creates an anonymous bus with name=null when no name supplied", () => {
+    const bus = new Bus(cacophony.context, null);
+    expect(bus.name).toBeNull();
+    expect(bus.destroyed).toBe(false);
+  });
+
+  it("creates a named bus with the supplied name", () => {
+    const bus = new Bus(cacophony.context, "drums");
+    expect(bus.name).toBe("drums");
+  });
+
+  it("allocates separate input and output GainNodes", () => {
+    const bus = new Bus(cacophony.context, "fx");
+    expect(bus.input).toBeDefined();
+    expect(bus.output).toBeDefined();
+    expect(bus.input).not.toBe(bus.output);
+  });
+
+  it("uses the externally supplied input GainNode when provided", () => {
+    const supplied = cacophony.context.createGain();
+    const bus = new Bus(cacophony.context, "master", supplied);
+    expect(bus.input).toBe(supplied);
+  });
+
+  it("exposes the output gain via the .gain getter/setter", () => {
+    const bus = new Bus(cacophony.context, null);
+    bus.gain = 0.75;
+    expect(bus.gain).toBe(0.75);
+    expect(bus.output.gain.value).toBe(0.75);
+  });
+});
+
+describe("Bus: addFilter discrimination", () => {
+  it("accepts a Cacophony-built BiquadFilterNode directly", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const filter = cacophony.createBiquadFilter({ frequency: 1000 });
+    await bus.addFilter(filter);
+    expect(bus.filters).toContain(filter);
+  });
+
+  it("accepts a CacophonyEffect by awaiting build()", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const node = cacophony.context.createGain();
+    const effect = { build: vi.fn().mockReturnValue(node) };
+    await bus.addFilter(effect);
+    expect(effect.build).toHaveBeenCalledWith(cacophony.context);
+    expect(bus.filters).toContain(node);
+  });
+
+  it("awaits async CacophonyEffect.build()", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const node = cacophony.context.createGain();
+    const effect = { build: () => Promise.resolve(node) };
+    await bus.addFilter(effect);
+    expect(bus.filters).toContain(node);
+  });
+
+  it("rejects a raw AudioNode (e.g. context.createGain())", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const raw = cacophony.context.createGain();
+    await expect(bus.addFilter(raw)).rejects.toThrow(/raw AudioNode/);
+  });
+
+  it("accepts a ShareEffect-wrapped raw AudioNode", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const raw = cacophony.context.createGain();
+    const effect = cacophony.shareEffect(raw);
+    await bus.addFilter(effect);
+    expect(bus.filters).toContain(raw);
+  });
+
+  it("rejects adding the same node twice", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const filter = cacophony.createBiquadFilter({ frequency: 500 });
+    await bus.addFilter(filter);
+    await expect(bus.addFilter(filter)).rejects.toThrow(/same filter/);
+  });
+});
+
+describe("Bus: per-edge gain on connect", () => {
+  it("connects directly (no GainNode allocated) when gain omitted", () => {
+    const a = new Bus(cacophony.context, null);
+    const b = new Bus(cacophony.context, null);
+    const connectSpy = vi.spyOn(a.output, "connect");
+    a.connect(b);
+    expect(connectSpy).toHaveBeenCalledWith(b.input);
+  });
+
+  it("connects directly when gain === 1", () => {
+    const a = new Bus(cacophony.context, null);
+    const b = new Bus(cacophony.context, null);
+    const connectSpy = vi.spyOn(a.output, "connect");
+    a.connect(b, 1);
+    expect(connectSpy).toHaveBeenCalledWith(b.input);
+  });
+
+  it("allocates a sendGain when gain !== 1; output → sendGain → target", () => {
+    const a = new Bus(cacophony.context, null);
+    const b = new Bus(cacophony.context, null);
+    const outputConnectSpy = vi.spyOn(a.output, "connect");
+    a.connect(b, 0.5);
+    // First connect on a.output is to the sendGain, not to b.input directly.
+    expect(outputConnectSpy).toHaveBeenCalled();
+    const firstCallTarget = outputConnectSpy.mock.calls[0]?.[0] as { gain?: { value: number } };
+    expect(firstCallTarget).toBeDefined();
+    expect(firstCallTarget).not.toBe(b.input);
+    expect(firstCallTarget.gain?.value).toBe(0.5);
+  });
+
+  it("connects to a raw AudioNode target", () => {
+    const a = new Bus(cacophony.context, null);
+    const dest = cacophony.context.createGain();
+    const connectSpy = vi.spyOn(a.output, "connect");
+    a.connect(dest);
+    expect(connectSpy).toHaveBeenCalledWith(dest);
+  });
+
+  it("disconnect(target) tears down the direct connection", () => {
+    const a = new Bus(cacophony.context, null);
+    const b = new Bus(cacophony.context, null);
+    a.connect(b);
+    const disconnectSpy = vi.spyOn(a.output, "disconnect");
+    a.disconnect(b);
+    expect(disconnectSpy).toHaveBeenCalledWith(b.input);
+  });
+
+  it("disconnect(target) tears down the sendGain when one was allocated", () => {
+    const a = new Bus(cacophony.context, null);
+    const b = new Bus(cacophony.context, null);
+    a.connect(b, 0.3);
+    // After connect with gain, an internal sendGain exists. Disconnect should
+    // disconnect it from a.output AND disconnect the sendGain itself.
+    const outputDisconnectSpy = vi.spyOn(a.output, "disconnect");
+    a.disconnect(b);
+    expect(outputDisconnectSpy).toHaveBeenCalled();
+    // Re-connecting after disconnect uses the no-gain path → direct edge again.
+    const reconnectSpy = vi.spyOn(a.output, "connect");
+    a.connect(b);
+    expect(reconnectSpy).toHaveBeenCalledWith(b.input);
+  });
+
+  it("updates an existing sendGain in place when reconnecting with a new gain", () => {
+    const a = new Bus(cacophony.context, null);
+    const b = new Bus(cacophony.context, null);
+    a.connect(b, 0.5);
+    // Force visibility into the sendGain by spying on createGain to count
+    // allocations after the first connect.
+    const allocationsBefore = vi.spyOn(cacophony.context, "createGain").mock.calls.length;
+    a.connect(b, 0.25);
+    const allocationsAfter = vi.spyOn(cacophony.context, "createGain").mock.calls.length;
+    // No new gain allocated (the existing send-gain's value should be mutated).
+    expect(allocationsAfter).toBe(allocationsBefore);
+  });
+});
+
+describe("Bus: destroy lifecycle", () => {
+  it("destroy() sets destroyed=true and is idempotent", () => {
+    const bus = new Bus(cacophony.context, null);
+    bus.destroy();
+    expect(bus.destroyed).toBe(true);
+    expect(() => bus.destroy()).not.toThrow();
+  });
+
+  it("calls the onDestroy hook exactly once", () => {
+    const onDestroy = vi.fn();
+    const bus = new Bus(cacophony.context, "named", undefined, onDestroy);
+    bus.destroy();
+    bus.destroy();
+    expect(onDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("addFilter throws after destroy", async () => {
+    const bus = new Bus(cacophony.context, null);
+    bus.destroy();
+    const filter = cacophony.createBiquadFilter({ frequency: 200 });
+    await expect(bus.addFilter(filter)).rejects.toThrow(/destroyed/);
+  });
+
+  it("connect throws after destroy", () => {
+    const bus = new Bus(cacophony.context, null);
+    const other = new Bus(cacophony.context, null);
+    bus.destroy();
+    expect(() => bus.connect(other)).toThrow(/destroyed/);
+  });
+
+  it("disconnect throws after destroy", () => {
+    const bus = new Bus(cacophony.context, null);
+    const other = new Bus(cacophony.context, null);
+    bus.connect(other);
+    bus.destroy();
+    expect(() => bus.disconnect(other)).toThrow(/destroyed/);
+  });
+
+  it("removeFilter throws after destroy", () => {
+    const bus = new Bus(cacophony.context, null);
+    bus.destroy();
+    const filter = cacophony.createBiquadFilter({ frequency: 200 });
+    expect(() => bus.removeFilter(filter)).toThrow(/destroyed/);
+  });
+});
+
+describe("Bus: filter chain refresh", () => {
+  it("re-inserts filters when one is added", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    expect(bus.filters).toEqual([f1, f2]);
+  });
+
+  it("removeFilter removes by identity and rebuilds the chain", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    bus.removeFilter(f1);
+    expect(bus.filters).toEqual([f2]);
+  });
+
+  it("removeFilter throws if the node was never added", () => {
+    const bus = new Bus(cacophony.context, null);
+    const filter = cacophony.createBiquadFilter({ frequency: 100 });
+    expect(() => bus.removeFilter(filter)).toThrow(/never added/);
+  });
+});

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -19,9 +19,9 @@
  * parameters affects both.
  */
 
+import type { AudioNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
 import type { CacophonyEffect } from "./effects";
 import { isCacophonyBuiltBiquad, isCacophonyEffect } from "./effects";
-import type { AudioNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
 
 /**
  * Connection target for {@link Bus.connect} / {@link Bus.disconnect}. Either
@@ -70,12 +70,7 @@ export class Bus {
    *   fresh GainNode is allocated.
    * @param onDestroy Optional registry-cleanup hook fired by destroy().
    */
-  constructor(
-    context: BaseContext,
-    name: string | null = null,
-    input?: GainNode,
-    onDestroy?: () => void,
-  ) {
+  constructor(context: BaseContext, name: string | null = null, input?: GainNode, onDestroy?: () => void) {
     this._context = context;
     this.name = name;
     this.input = input ?? context.createGain();

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -52,6 +52,7 @@ export class Bus {
 
   private readonly _context: BaseContext;
   private readonly _filterNodes: AudioNode[] = [];
+  private readonly _filterChainEdges: Array<readonly [AudioNode, AudioNode]> = [];
   private readonly _sendGains: Map<BusConnectionTarget, GainNode> = new Map();
   private readonly _directConnections: Set<BusConnectionTarget> = new Set();
   /**
@@ -80,7 +81,7 @@ export class Bus {
     this.input = input ?? context.createGain();
     this.output = context.createGain();
     this._onDestroy = onDestroy;
-    this.input.connect(this.output);
+    this._connectFilterChainEdge(this.input, this.output);
   }
 
   /** True after {@link destroy} has been called. */
@@ -148,12 +149,6 @@ export class Bus {
       throw new Error("Cannot remove filter that was never added to this bus");
     }
     this._filterNodes.splice(idx, 1);
-    try {
-      node.disconnect();
-    } catch {
-      // Filter node may have been disconnected by hand; we tolerate that on
-      // removal so cleanup is not blocked by a no-op disconnect throw.
-    }
     this._refreshFilters();
   }
 
@@ -263,12 +258,10 @@ export class Bus {
     }
     this._sendGains.clear();
     this._directConnections.clear();
-    // Disconnect every filter and the input/output nodes.
-    for (const node of this._filterNodes) {
-      try {
-        node.disconnect();
-      } catch {}
-    }
+    // Disconnect only this bus's internal chain edges. Filter nodes may be
+    // shared with other buses, so broad node.disconnect() would steal their
+    // routes.
+    this._disconnectFilterChainEdges();
     this._filterNodes.length = 0;
     try {
       this.input.disconnect();
@@ -281,29 +274,36 @@ export class Bus {
 
   /**
    * Rebuild the chain `input → [filter1 → ... → filterN] → output`. Called
-   * after any add/remove of a filter. Disconnects the input's outgoing edges
-   * (and each filter's outgoing edges) first, then reapplies the chain.
-   * The output node's edges to downstream targets are not touched.
+   * after any add/remove of a filter. Disconnects only the internal chain
+   * edges this bus created, then reapplies the chain. The output node's edges
+   * to downstream targets are not touched.
    */
   private _refreshFilters(): void {
-    try {
-      this.input.disconnect();
-    } catch {}
-    for (const f of this._filterNodes) {
-      try {
-        f.disconnect();
-      } catch {}
-    }
+    this._disconnectFilterChainEdges();
     if (this._filterNodes.length === 0) {
-      this.input.connect(this.output);
+      this._connectFilterChainEdge(this.input, this.output);
       return;
     }
     let prev: AudioNode = this.input;
     for (const f of this._filterNodes) {
-      prev.connect(f);
+      this._connectFilterChainEdge(prev, f);
       prev = f;
     }
-    prev.connect(this.output);
+    this._connectFilterChainEdge(prev, this.output);
+  }
+
+  private _connectFilterChainEdge(source: AudioNode, destination: AudioNode): void {
+    source.connect(destination);
+    this._filterChainEdges.push([source, destination]);
+  }
+
+  private _disconnectFilterChainEdges(): void {
+    for (const [source, destination] of this._filterChainEdges) {
+      try {
+        source.disconnect(destination);
+      } catch {}
+    }
+    this._filterChainEdges.length = 0;
   }
 
   private _throwIfDestroyed(): void {

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -1,0 +1,314 @@
+/**
+ * Bus — a named summing node with its own filter chain and per-edge gain.
+ *
+ * A Bus is a first-class routing primitive. Sounds and synths route into a
+ * bus via `routeTo`; the bus mixes its inputs through an optional filter
+ * chain and emits to one or more downstream targets (other buses or the
+ * master bus). Connections out can be either unity-gain (direct) or
+ * attenuated through an allocated GainNode (per-edge gain).
+ *
+ * Internal topology:
+ *     input → [filter1 → ... → filterN] → output → (sends to targets)
+ *
+ * `input` and `output` are separate GainNodes so the chain has a stable
+ * external interface even as the internal filter chain is rebuilt.
+ *
+ * Buses are SHARED LIVE — there is no per-playback clone. The filter chain
+ * holds the live node instances added via `addFilter`. Adding the same
+ * filter to two buses means the same Web Audio node is used; mutating its
+ * parameters affects both.
+ */
+
+import type { CacophonyEffect } from "./effects";
+import { isCacophonyBuiltBiquad, isCacophonyEffect } from "./effects";
+import type { AudioNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
+
+/**
+ * Connection target for {@link Bus.connect} / {@link Bus.disconnect}. Either
+ * another Bus (we connect into its `input`) or a raw AudioNode (we connect
+ * directly to it — escape hatch for advanced wiring).
+ */
+export type BusConnectionTarget = Bus | AudioNode;
+
+/**
+ * A named summing node with a filter chain and per-edge send gain. See
+ * module-level docstring for topology.
+ */
+export class Bus {
+  /** Stable name for registry lookup, or null for anonymous buses. */
+  readonly name: string | null;
+
+  /**
+   * Entry node — connect upstream sources here (sound playbacks, other bus
+   * outputs).
+   */
+  readonly input: GainNode;
+
+  /**
+   * Exit node — connected to downstream targets (other bus inputs, master,
+   * raw nodes) via {@link connect}.
+   */
+  readonly output: GainNode;
+
+  private readonly _context: BaseContext;
+  private readonly _filterNodes: AudioNode[] = [];
+  private readonly _sendGains: Map<BusConnectionTarget, GainNode> = new Map();
+  private readonly _directConnections: Set<BusConnectionTarget> = new Set();
+  /**
+   * Hook invoked by the owning Cacophony instance to remove this bus from
+   * the named-bus registry on destroy. Anonymous buses leave this undefined.
+   */
+  private readonly _onDestroy?: () => void;
+  private _destroyed = false;
+
+  /**
+   * @param context Web Audio context the bus's nodes live on.
+   * @param name Name to register under, or null for an anonymous bus.
+   * @param input Optional pre-existing GainNode to use as the input. Used by
+   *   the `master` bus to alias `cacophony.globalGainNode`. If omitted, a
+   *   fresh GainNode is allocated.
+   * @param onDestroy Optional registry-cleanup hook fired by destroy().
+   */
+  constructor(
+    context: BaseContext,
+    name: string | null = null,
+    input?: GainNode,
+    onDestroy?: () => void,
+  ) {
+    this._context = context;
+    this.name = name;
+    this.input = input ?? context.createGain();
+    this.output = context.createGain();
+    this._onDestroy = onDestroy;
+    this.input.connect(this.output);
+  }
+
+  /** True after {@link destroy} has been called. */
+  get destroyed(): boolean {
+    return this._destroyed;
+  }
+
+  /** Output node gain — controls the overall level the bus sends downstream. */
+  get gain(): number {
+    return this.output.gain.value;
+  }
+
+  set gain(v: number) {
+    this.output.gain.value = v;
+  }
+
+  /** Live filter chain (read-only view). */
+  get filters(): readonly AudioNode[] {
+    return this._filterNodes;
+  }
+
+  /**
+   * Add a filter node to the bus's chain. Accepts:
+   *
+   * - A Cacophony-built BiquadFilterNode (created via
+   *   `cacophony.createBiquadFilter`) → added directly to the chain.
+   * - A {@link CacophonyEffect} → `build(context)` is awaited; the resulting
+   *   node is added to the chain.
+   * - A raw third-party AudioNode → REJECTED. Wrap it with
+   *   `cacophony.shareEffect(node)` (or a proper CacophonyEffect class) to
+   *   make the shared-state intent explicit.
+   *
+   * @throws if the bus has been destroyed, or if the argument is a raw
+   *   AudioNode that is not a Cacophony-built biquad.
+   */
+  async addFilter(arg: BiquadFilterNode | CacophonyEffect | AudioNode): Promise<void> {
+    this._throwIfDestroyed();
+    let node: AudioNode;
+    if (isCacophonyBuiltBiquad(arg)) {
+      node = arg;
+    } else if (isCacophonyEffect(arg)) {
+      node = await arg.build(this._context);
+    } else {
+      throw new Error(
+        "Bus.addFilter rejects raw AudioNodes. Wrap with cacophony.shareEffect(node) or a CacophonyEffect to make the shared-state intent explicit.",
+      );
+    }
+    if (this._filterNodes.includes(node)) {
+      throw new Error("Cannot add the same filter node to a bus twice");
+    }
+    this._filterNodes.push(node);
+    this._refreshFilters();
+  }
+
+  /**
+   * Remove a filter node from the bus's chain. The node must have been added
+   * via {@link addFilter}; the same object identity is used to match.
+   *
+   * @throws if the bus has been destroyed or if the node was never added.
+   */
+  removeFilter(node: AudioNode): void {
+    this._throwIfDestroyed();
+    const idx = this._filterNodes.indexOf(node);
+    if (idx === -1) {
+      throw new Error("Cannot remove filter that was never added to this bus");
+    }
+    this._filterNodes.splice(idx, 1);
+    try {
+      node.disconnect();
+    } catch {
+      // Filter node may have been disconnected by hand; we tolerate that on
+      // removal so cleanup is not blocked by a no-op disconnect throw.
+    }
+    this._refreshFilters();
+  }
+
+  /**
+   * Connect this bus's output to another bus or to a raw AudioNode.
+   *
+   * If `gain` is omitted or equal to 1, connect directly (output →
+   * targetInput). If `gain` is provided, allocate an internal GainNode for
+   * per-edge attenuation: output → sendGain → targetInput. The sendGain is
+   * tracked so {@link disconnect} can tear it down cleanly.
+   *
+   * Re-connecting a target that is already wired is a no-op for the direct
+   * case; for a gained connection, the existing sendGain's `gain.value` is
+   * updated in place (no new edge is allocated).
+   *
+   * @throws if the bus has been destroyed.
+   */
+  connect(target: BusConnectionTarget, gain?: number): void {
+    this._throwIfDestroyed();
+    const targetNode = target instanceof Bus ? target.input : target;
+    if (gain === undefined || gain === 1) {
+      if (this._directConnections.has(target)) {
+        return;
+      }
+      // If a gained connection exists, tear it down first so the connection
+      // mode is unambiguous.
+      const existingSend = this._sendGains.get(target);
+      if (existingSend) {
+        try {
+          this.output.disconnect(existingSend);
+        } catch {}
+        try {
+          existingSend.disconnect();
+        } catch {}
+        this._sendGains.delete(target);
+      }
+      this.output.connect(targetNode);
+      this._directConnections.add(target);
+      return;
+    }
+    const existingSend = this._sendGains.get(target);
+    if (existingSend) {
+      existingSend.gain.value = gain;
+      return;
+    }
+    // Tear down any direct edge first (so the routing topology to this
+    // target stays unambiguous).
+    if (this._directConnections.has(target)) {
+      try {
+        this.output.disconnect(targetNode);
+      } catch {}
+      this._directConnections.delete(target);
+    }
+    const sendGain = this._context.createGain();
+    sendGain.gain.value = gain;
+    this.output.connect(sendGain);
+    sendGain.connect(targetNode);
+    this._sendGains.set(target, sendGain);
+  }
+
+  /**
+   * Disconnect this bus's output from a target previously connected with
+   * {@link connect}. Tears down the allocated sendGain (if any). No-op if
+   * the target was never connected.
+   *
+   * @throws if the bus has been destroyed.
+   */
+  disconnect(target: BusConnectionTarget): void {
+    this._throwIfDestroyed();
+    const targetNode = target instanceof Bus ? target.input : target;
+    const sendGain = this._sendGains.get(target);
+    if (sendGain) {
+      try {
+        this.output.disconnect(sendGain);
+      } catch {}
+      try {
+        sendGain.disconnect();
+      } catch {}
+      this._sendGains.delete(target);
+    }
+    if (this._directConnections.has(target)) {
+      try {
+        this.output.disconnect(targetNode);
+      } catch {}
+      this._directConnections.delete(target);
+    }
+  }
+
+  /**
+   * Tear down the bus — disconnects input, output, every send-gain, every
+   * filter, then deregisters from the owner Cacophony's named-bus map.
+   * Subsequent `addFilter`/`removeFilter`/`connect`/`disconnect` calls throw.
+   *
+   * Sounds routed to a destroyed bus fall back to master on their next
+   * playback (the routeTo machinery checks `destroyed` at preplay).
+   */
+  destroy(): void {
+    if (this._destroyed) {
+      return;
+    }
+    this._destroyed = true;
+    // Tear down all outgoing send-gain allocations.
+    for (const [, sendGain] of this._sendGains) {
+      try {
+        sendGain.disconnect();
+      } catch {}
+    }
+    this._sendGains.clear();
+    this._directConnections.clear();
+    // Disconnect every filter and the input/output nodes.
+    for (const node of this._filterNodes) {
+      try {
+        node.disconnect();
+      } catch {}
+    }
+    this._filterNodes.length = 0;
+    try {
+      this.input.disconnect();
+    } catch {}
+    try {
+      this.output.disconnect();
+    } catch {}
+    this._onDestroy?.();
+  }
+
+  /**
+   * Rebuild the chain `input → [filter1 → ... → filterN] → output`. Called
+   * after any add/remove of a filter. Disconnects the input's outgoing edges
+   * (and each filter's outgoing edges) first, then reapplies the chain.
+   * The output node's edges to downstream targets are not touched.
+   */
+  private _refreshFilters(): void {
+    try {
+      this.input.disconnect();
+    } catch {}
+    for (const f of this._filterNodes) {
+      try {
+        f.disconnect();
+      } catch {}
+    }
+    if (this._filterNodes.length === 0) {
+      this.input.connect(this.output);
+      return;
+    }
+    let prev: AudioNode = this.input;
+    for (const f of this._filterNodes) {
+      prev.connect(f);
+      prev = f;
+    }
+    prev.connect(this.output);
+  }
+
+  private _throwIfDestroyed(): void {
+    if (this._destroyed) {
+      throw new Error(`Bus '${this.name ?? "<anonymous>"}' has been destroyed`);
+    }
+  }
+}

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -183,7 +183,16 @@ export class Cacophony {
   master: Bus;
   listener: AudioListener;
   private prevVolume: number = 1;
-  private loadedAudioWorklets: Set<string> = new Set();
+  /**
+   * Per-context cache of "module-name has been loaded on this BaseContext".
+   * Keyed on the context itself because `AudioWorklet.addModule()` registers
+   * the module against ONE context — a module loaded on context A is NOT
+   * loaded on context B. A previous host-scoped `Set<string>` short-circuited
+   * `loadAudioWorkletModule()` on name alone, so cross-context
+   * {@link ReverbEffect.build} would skip `addModule` on the new context and
+   * the second construct would throw with no module registered.
+   */
+  private loadedAudioWorklets: WeakMap<BaseContext, Set<string>> = new WeakMap();
   private finalizationRegistry: FinalizationRegistry<SoundCleanupHoldings>;
   private eventEmitter: TypedEventEmitter<CacophonyEvents> = new TypedEventEmitter<CacophonyEvents>();
   private cache: ICache;
@@ -437,13 +446,13 @@ export class Cacophony {
       const node = this.createAudioWorkletNode(ctx, name, options);
       console.info(`${WORKLET_LOG_PREFIX} construct succeeded`, {
         name,
-        loaded: this.loadedAudioWorklets.has(name),
+        loaded: this.isWorkletLoadedOn(ctx, name),
       });
       return node;
     } catch (err) {
       console.warn(`${WORKLET_LOG_PREFIX} construct failed`, {
         name,
-        loaded: this.loadedAudioWorklets.has(name),
+        loaded: this.isWorkletLoadedOn(ctx, name),
         error: err,
       });
       try {
@@ -481,6 +490,26 @@ export class Cacophony {
     });
   }
 
+  /**
+   * Lookup helper: has worklet `name` been loaded on `ctx` (per the
+   * per-context {@link loadedAudioWorklets} cache).
+   */
+  private isWorkletLoadedOn(ctx: BaseContext, name: string): boolean {
+    return this.loadedAudioWorklets.get(ctx)?.has(name) ?? false;
+  }
+
+  /**
+   * Record `name` as loaded on `ctx`, lazily allocating the per-context Set.
+   */
+  private markWorkletLoadedOn(ctx: BaseContext, name: string): void {
+    let names = this.loadedAudioWorklets.get(ctx);
+    if (!names) {
+      names = new Set<string>();
+      this.loadedAudioWorklets.set(ctx, names);
+    }
+    names.add(name);
+  }
+
   private async loadAudioWorkletModule(
     name: string,
     url: string,
@@ -491,7 +520,11 @@ export class Cacophony {
     if (!ctx.audioWorklet) {
       throw new Error("AudioWorklet not supported");
     }
-    if (this.loadedAudioWorklets.has(name)) {
+    // Per-context membership: a module loaded on context A is NOT loaded on
+    // context B. The previous host-scoped check by name only would skip the
+    // addModule on B after A had loaded the same name, leaving B without
+    // the worklet registered.
+    if (this.isWorkletLoadedOn(ctx, name)) {
       console.info(`${WORKLET_LOG_PREFIX} load skipped`, { name });
       return;
     }
@@ -505,7 +538,7 @@ export class Cacophony {
         credentials: "same-origin",
         ...(signal && { signal }),
       });
-      this.loadedAudioWorklets.add(name);
+      this.markWorkletLoadedOn(ctx, name);
       console.info(`${WORKLET_LOG_PREFIX} addModule resolved`, { name });
     } catch (err) {
       console.error(`${WORKLET_LOG_PREFIX} addModule rejected`, {

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -14,6 +14,7 @@ import type {
   GainNode,
   PannerNode,
 } from "./context";
+import { Bus } from "./bus";
 import { type CacophonyEffect, markAsCacophonyBiquad, ShareEffect } from "./effects";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { CacophonyEvents } from "./events";
@@ -172,6 +173,13 @@ function mimeTypeForUrl(url: string): string | null {
 export class Cacophony {
   context: BaseContext;
   globalGainNode: GainNode;
+  /**
+   * The master bus — `master.input` IS `globalGainNode` (literally the same
+   * GainNode), so every existing `.connect(globalGainNode)` call in the
+   * codebase remains correct. `cacophony.volume` and `cacophony.mute` still
+   * read and write `master.input.gain.value` through that alias.
+   */
+  master: Bus;
   listener: AudioListener;
   private prevVolume: number = 1;
   private loadedAudioWorklets: Set<string> = new Set();
@@ -179,6 +187,11 @@ export class Cacophony {
   private eventEmitter: TypedEventEmitter<CacophonyEvents> = new TypedEventEmitter<CacophonyEvents>();
   private cache: ICache;
   private createAudioWorkletNode: (context: BaseContext, name: string, options?: AudioWorkletNodeOptions) => any;
+  /**
+   * Named-bus registry. Populated by {@link createBus} when a name is
+   * supplied; entries are removed by the bus's onDestroy hook.
+   */
+  private _busRegistry: Map<string, Bus> = new Map();
   // Tracks the lifecycle state we have explicitly transitioned to. This avoids
   // duplicate wrapper-driven suspend calls, but resume() still delegates because
   // the underlying AudioContext can be suspended externally.
@@ -211,6 +224,10 @@ export class Cacophony {
     this.listener = this.context.listener;
     this.globalGainNode = this.context.createGain();
     this.globalGainNode.connect(this.context.destination);
+    // master bus wraps globalGainNode as its input — same node, two accessors.
+    // master is exempt from the named-bus registry (its name 'master' is
+    // reserved and not user-creatable via createBus).
+    this.master = new Bus(this.context, "master", this.globalGainNode);
     this.cache = cache ?? new AudioCache();
     this.createAudioWorkletNode =
       runtimeOptions.createAudioWorkletNode ??
@@ -747,6 +764,52 @@ export class Cacophony {
    */
   shareEffect(node: AudioNode): CacophonyEffect {
     return new ShareEffect(node);
+  }
+
+  /**
+   * Creates a new {@link Bus}. If `name` is provided, the bus is registered
+   * so {@link getBus} can look it up by name. Anonymous buses (no name) are
+   * not registered and cannot be retrieved by name.
+   *
+   * @throws if a named bus with the same name already exists, or if the
+   *   reserved name 'master' is used (the master bus is auto-created).
+   */
+  createBus(name?: string): Bus {
+    if (name === "master") {
+      throw new Error("The name 'master' is reserved — use cacophony.master to access the master bus.");
+    }
+    if (name !== undefined && this._busRegistry.has(name)) {
+      throw new Error(`A bus named '${name}' already exists.`);
+    }
+    const onDestroy = name !== undefined ? () => this._busRegistry.delete(name) : undefined;
+    const bus = new Bus(this.context, name ?? null, undefined, onDestroy);
+    if (name !== undefined) {
+      this._busRegistry.set(name, bus);
+    }
+    // New buses default-route to master so audio flows out somewhere unless
+    // the user wires it elsewhere. master is intentionally not destroyable.
+    bus.connect(this.master);
+    return bus;
+  }
+
+  /**
+   * Retrieves a bus by name from the named-bus registry. Returns `undefined`
+   * if no bus with that name exists. The special name `'master'` returns
+   * the auto-created master bus.
+   */
+  getBus(name: string): Bus | undefined {
+    if (name === "master") {
+      return this.master;
+    }
+    return this._busRegistry.get(name);
+  }
+
+  /**
+   * Returns the names of every registered named bus. Anonymous buses are
+   * not included. The master bus's name (`'master'`) is included.
+   */
+  listBuses(): string[] {
+    return ["master", ...this._busRegistry.keys()];
   }
 
   createSplitter(numChannels: number = 2): ChannelSplitterNode {

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -224,11 +224,18 @@ export class Cacophony {
     this.context = context ?? new AudioContext();
     this.listener = this.context.listener;
     this.globalGainNode = this.context.createGain();
-    this.globalGainNode.connect(this.context.destination);
     // master bus wraps globalGainNode as its input — same node, two accessors.
     // master is exempt from the named-bus registry (its name 'master' is
     // reserved and not user-creatable via createBus).
+    // The Bus constructor wires input → output. We then connect master.output
+    // to context.destination so the full audible path is:
+    //   master.input (= globalGainNode) → [filters] → master.output → destination.
+    // Critical: connect master.output AFTER constructing the Bus, NOT
+    // globalGainNode directly. If globalGainNode were pre-connected to
+    // destination, adding a master filter would call _refreshFilters() which
+    // disconnects master.input's outgoing edges, severing the audible path.
     this.master = new Bus(this.context, "master", this.globalGainNode);
+    this.master.output.connect(this.context.destination);
     this.cache = cache ?? new AudioCache();
     this.createAudioWorkletNode =
       runtimeOptions.createAudioWorkletNode ??

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -377,9 +377,20 @@ export class Cacophony {
    * context. Safe to call repeatedly — subsequent calls short-circuit via
    * the {@link loadedAudioWorklets} set used by
    * {@link loadAudioWorkletModule}.
+   *
+   * @param signal Optional abort signal forwarded to the module load.
+   * @param context Optional BaseContext to load the worklet on. Defaults to
+   *   the host Cacophony instance's `context`. Supplied so a
+   *   {@link ReverbEffect} added to a bus whose context is NOT this host's
+   *   own (cross-context use) can load the worklet on the right context.
    */
-  async loadDattorroReverb(signal?: AbortSignal): Promise<void> {
-    await this.loadAudioWorkletModule("dattorro-reverb", dattorroReverbProcessorWorkletUrl, signal);
+  async loadDattorroReverb(signal?: AbortSignal, context?: BaseContext): Promise<void> {
+    await this.loadAudioWorkletModule(
+      "dattorro-reverb",
+      dattorroReverbProcessorWorkletUrl,
+      signal,
+      context,
+    );
   }
 
   /**
@@ -387,9 +398,23 @@ export class Cacophony {
    * loaded the module already (via {@link loadDattorroReverb} or by reaching
    * here through {@link ReverbEffect.build}). Uses the same construct/fallback
    * path as {@link createWorkletNode}.
+   *
+   * @param options AudioWorkletNode construction options.
+   * @param context Optional BaseContext to construct on. Defaults to the
+   *   host Cacophony instance's `context`. See {@link loadDattorroReverb}
+   *   for the cross-context rationale.
    */
-  async createDattorroReverbNode(options: AudioWorkletNodeOptions): Promise<AudioWorkletNode> {
-    return this.createWorkletNode("dattorro-reverb", dattorroReverbProcessorWorkletUrl, undefined, options);
+  async createDattorroReverbNode(
+    options: AudioWorkletNodeOptions,
+    context?: BaseContext,
+  ): Promise<AudioWorkletNode> {
+    return this.createWorkletNode(
+      "dattorro-reverb",
+      dattorroReverbProcessorWorkletUrl,
+      undefined,
+      options,
+      context,
+    );
   }
 
   async createWorkletNode(
@@ -397,13 +422,19 @@ export class Cacophony {
     url: string,
     signal?: AbortSignal,
     options?: AudioWorkletNodeOptions,
+    context?: BaseContext,
   ): Promise<AudioWorkletNode> {
+    // Use the supplied context for cross-context worklet construction
+    // (e.g. ReverbEffect built against a context other than this host's
+    // own). Default to this host's `context` for the common single-context
+    // case so all existing callers keep working without a change.
+    const ctx = context ?? this.context;
     // ensure audioWorklet has been loaded
-    if (!this.context.audioWorklet) {
+    if (!ctx.audioWorklet) {
       throw new Error("AudioWorklet not supported");
     }
     try {
-      const node = this.createAudioWorkletNode(this.context, name, options);
+      const node = this.createAudioWorkletNode(ctx, name, options);
       console.info(`${WORKLET_LOG_PREFIX} construct succeeded`, {
         name,
         loaded: this.loadedAudioWorklets.has(name),
@@ -416,7 +447,7 @@ export class Cacophony {
         error: err,
       });
       try {
-        await this.loadAudioWorkletModule(name, url, signal);
+        await this.loadAudioWorkletModule(name, url, signal, ctx);
       } catch (err) {
         console.error(`${WORKLET_LOG_PREFIX} load failed`, {
           name,
@@ -426,7 +457,7 @@ export class Cacophony {
       }
 
       try {
-        const node = this.createAudioWorkletNode(this.context, name, options);
+        const node = this.createAudioWorkletNode(ctx, name, options);
         console.info(`${WORKLET_LOG_PREFIX} construct after load succeeded`, { name });
         return node;
       } catch (err) {
@@ -450,8 +481,14 @@ export class Cacophony {
     });
   }
 
-  private async loadAudioWorkletModule(name: string, url: string, signal?: AbortSignal): Promise<void> {
-    if (!this.context.audioWorklet) {
+  private async loadAudioWorkletModule(
+    name: string,
+    url: string,
+    signal?: AbortSignal,
+    context?: BaseContext,
+  ): Promise<void> {
+    const ctx = context ?? this.context;
+    if (!ctx.audioWorklet) {
       throw new Error("AudioWorklet not supported");
     }
     if (this.loadedAudioWorklets.has(name)) {
@@ -464,7 +501,7 @@ export class Cacophony {
       aborted: signal?.aborted ?? false,
     });
     try {
-      await this.context.audioWorklet.addModule(url, {
+      await ctx.audioWorklet.addModule(url, {
         credentials: "same-origin",
         ...(signal && { signal }),
       });

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -1,4 +1,5 @@
 import { installAutoplayUnlock } from "./autoplayUnlock";
+import dattorroReverbProcessorWorkletUrl from "./bundles/dattorro-reverb-bundle.js?url";
 import phaseVocoderProcessorWorkletUrl from "./bundles/phase-vocoder-bundle.js?url";
 import stereoToBFormatProcessorWorkletUrl from "./bundles/stereo-to-bformat-bundle.js?url";
 import { AudioCache, type ICache } from "./cache";
@@ -15,7 +16,7 @@ import type {
   PannerNode,
 } from "./context";
 import { Bus } from "./bus";
-import { type CacophonyEffect, markAsCacophonyBiquad, ShareEffect } from "./effects";
+import { type CacophonyEffect, markAsCacophonyBiquad, ReverbEffect, type ReverbOptions, ShareEffect } from "./effects";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { CacophonyEvents } from "./events";
 import { Group } from "./group";
@@ -354,6 +355,7 @@ export class Cacophony {
     if (this.context.audioWorklet) {
       await this.createWorkletNode("phase-vocoder", phaseVocoderProcessorWorkletUrl, signal);
       await this.loadStereoToBFormatWorklet(signal);
+      await this.loadDattorroReverb(signal);
     } else {
       console.warn("AudioWorklet not supported");
     }
@@ -361,6 +363,26 @@ export class Cacophony {
 
   async loadStereoToBFormatWorklet(signal?: AbortSignal): Promise<void> {
     await this.loadAudioWorkletModule("stereo-to-bformat", stereoToBFormatProcessorWorkletUrl, signal);
+  }
+
+  /**
+   * Idempotently registers the DattorroReverb AudioWorkletProcessor on this
+   * context. Safe to call repeatedly — subsequent calls short-circuit via
+   * the {@link loadedAudioWorklets} set used by
+   * {@link loadAudioWorkletModule}.
+   */
+  async loadDattorroReverb(signal?: AbortSignal): Promise<void> {
+    await this.loadAudioWorkletModule("dattorro-reverb", dattorroReverbProcessorWorkletUrl, signal);
+  }
+
+  /**
+   * Constructs a DattorroReverb AudioWorkletNode. Caller is expected to have
+   * loaded the module already (via {@link loadDattorroReverb} or by reaching
+   * here through {@link ReverbEffect.build}). Uses the same construct/fallback
+   * path as {@link createWorkletNode}.
+   */
+  async createDattorroReverbNode(options: AudioWorkletNodeOptions): Promise<AudioWorkletNode> {
+    return this.createWorkletNode("dattorro-reverb", dattorroReverbProcessorWorkletUrl, undefined, options);
   }
 
   async createWorkletNode(
@@ -764,6 +786,17 @@ export class Cacophony {
    */
   shareEffect(node: AudioNode): CacophonyEffect {
     return new ShareEffect(node);
+  }
+
+  /**
+   * Creates a DattorroReverb {@link CacophonyEffect}. The effect's `build`
+   * lazily registers the worklet module (no-op if already loaded) and
+   * constructs the AudioWorkletNode with the supplied {@link ReverbOptions}
+   * as `parameterData`. Add the returned effect to a {@link Bus}'s filter
+   * chain via `bus.addFilter(effect)`.
+   */
+  createReverb(options: ReverbOptions = {}): ReverbEffect {
+    return new ReverbEffect(this, options);
   }
 
   /**

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -5,6 +5,7 @@ import { AudioCache, type ICache } from "./cache";
 import type {
   AudioBuffer,
   AudioListener,
+  AudioNode,
   AudioWorkletNode,
   BaseContext,
   BiquadFilterNode,
@@ -13,6 +14,7 @@ import type {
   GainNode,
   PannerNode,
 } from "./context";
+import { type CacophonyEffect, markAsCacophonyBiquad, ShareEffect } from "./effects";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { CacophonyEvents } from "./events";
 import { Group } from "./group";
@@ -732,8 +734,20 @@ export class Cacophony {
     filter.frequency.value = frequency;
     filter.gain.value = gain ?? 0;
     filter.Q.value = Q ?? 1;
+    markAsCacophonyBiquad(filter);
     return filter;
   };
+
+  /**
+   * Wraps a raw AudioNode in a {@link CacophonyEffect} so it can be added
+   * to a {@link Bus} filter chain. By default `Bus.addFilter` rejects raw
+   * AudioNodes — wrapping via `shareEffect` is the explicit opt-in that
+   * signals "yes, I understand this single node will be shared across every
+   * bus I add it to."
+   */
+  shareEffect(node: AudioNode): CacophonyEffect {
+    return new ShareEffect(node);
+  }
 
   createSplitter(numChannels: number = 2): ChannelSplitterNode {
     if (!this.context.createChannelSplitter) {

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -2,6 +2,7 @@ import { installAutoplayUnlock } from "./autoplayUnlock";
 import dattorroReverbProcessorWorkletUrl from "./bundles/dattorro-reverb-bundle.js?url";
 import phaseVocoderProcessorWorkletUrl from "./bundles/phase-vocoder-bundle.js?url";
 import stereoToBFormatProcessorWorkletUrl from "./bundles/stereo-to-bformat-bundle.js?url";
+import { Bus } from "./bus";
 import { AudioCache, type ICache } from "./cache";
 import type {
   AudioBuffer,
@@ -15,7 +16,6 @@ import type {
   GainNode,
   PannerNode,
 } from "./context";
-import { Bus } from "./bus";
 import { type CacophonyEffect, markAsCacophonyBiquad, ReverbEffect, type ReverbOptions, ShareEffect } from "./effects";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { CacophonyEvents } from "./events";
@@ -394,12 +394,7 @@ export class Cacophony {
    *   own (cross-context use) can load the worklet on the right context.
    */
   async loadDattorroReverb(signal?: AbortSignal, context?: BaseContext): Promise<void> {
-    await this.loadAudioWorkletModule(
-      "dattorro-reverb",
-      dattorroReverbProcessorWorkletUrl,
-      signal,
-      context,
-    );
+    await this.loadAudioWorkletModule("dattorro-reverb", dattorroReverbProcessorWorkletUrl, signal, context);
   }
 
   /**
@@ -413,17 +408,8 @@ export class Cacophony {
    *   host Cacophony instance's `context`. See {@link loadDattorroReverb}
    *   for the cross-context rationale.
    */
-  async createDattorroReverbNode(
-    options: AudioWorkletNodeOptions,
-    context?: BaseContext,
-  ): Promise<AudioWorkletNode> {
-    return this.createWorkletNode(
-      "dattorro-reverb",
-      dattorroReverbProcessorWorkletUrl,
-      undefined,
-      options,
-      context,
-    );
+  async createDattorroReverbNode(options: AudioWorkletNodeOptions, context?: BaseContext): Promise<AudioWorkletNode> {
+    return this.createWorkletNode("dattorro-reverb", dattorroReverbProcessorWorkletUrl, undefined, options, context);
   }
 
   async createWorkletNode(

--- a/src/effects.test.ts
+++ b/src/effects.test.ts
@@ -1,12 +1,6 @@
 import { AudioContext } from "standardized-audio-context-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  BiquadEffect,
-  isCacophonyBuiltBiquad,
-  isCacophonyEffect,
-  markAsCacophonyBiquad,
-  ShareEffect,
-} from "./effects";
+import { BiquadEffect, isCacophonyBuiltBiquad, isCacophonyEffect, markAsCacophonyBiquad, ShareEffect } from "./effects";
 import { audioContextMock, cacophony } from "./setupTests";
 
 /**
@@ -138,9 +132,7 @@ describe("Cacophony.createReverb / loadDattorroReverb", () => {
   });
 
   it("createReverb passes options as parameterData to the worklet (and forwards the build context)", async () => {
-    const createNodeSpy = vi
-      .spyOn(cacophony, "createDattorroReverbNode")
-      .mockResolvedValue({} as any);
+    const createNodeSpy = vi.spyOn(cacophony, "createDattorroReverbNode").mockResolvedValue({} as any);
     const effect = cacophony.createReverb({ wet: 0.7, dry: 0.3, decay: 0.8 });
     await effect.build(cacophony.context);
     // ReverbEffect.build forwards the supplied context as the second arg so

--- a/src/effects.test.ts
+++ b/src/effects.test.ts
@@ -106,13 +106,20 @@ describe("Cacophony.createReverb / loadDattorroReverb", () => {
     expect(isCacophonyEffect(effect)).toBe(true);
   });
 
-  it("ReverbEffect.build awaits loadDattorroReverb and returns an AudioWorkletNode", async () => {
+  it("ReverbEffect.build awaits loadDattorroReverb and constructs the 'dattorro-reverb' worklet node", async () => {
     const loadSpy = vi.spyOn(cacophony, "loadDattorroReverb");
+    const workletSpy = vi.spyOn(cacophony, "createWorkletNode");
     const effect = cacophony.createReverb({ wet: 0.5, dry: 0.5 });
     const node = await effect.build(cacophony.context);
     expect(loadSpy).toHaveBeenCalled();
     expect(node).toBeDefined();
+    // The constructed AudioWorkletNode must be the dattorro-reverb processor
+    // (not some other worklet). Asserting the name pins the routing through
+    // createWorkletNode("dattorro-reverb", ...).
+    expect(workletSpy).toHaveBeenCalled();
+    expect(workletSpy.mock.calls[0]?.[0]).toBe("dattorro-reverb");
     loadSpy.mockRestore();
+    workletSpy.mockRestore();
   });
 
   it("loadDattorroReverb is idempotent — second call does not re-add the module", async () => {
@@ -129,15 +136,19 @@ describe("Cacophony.createReverb / loadDattorroReverb", () => {
     expect(addModule.mock.calls.length).toBe(addModuleCallsAfterFirst);
   });
 
-  it("createReverb passes options as parameterData to the worklet", async () => {
+  it("createReverb passes options as parameterData to the worklet (and forwards the build context)", async () => {
     const createNodeSpy = vi
       .spyOn(cacophony, "createDattorroReverbNode")
       .mockResolvedValue({} as any);
     const effect = cacophony.createReverb({ wet: 0.7, dry: 0.3, decay: 0.8 });
     await effect.build(cacophony.context);
-    expect(createNodeSpy).toHaveBeenCalledWith({
-      parameterData: { wet: 0.7, dry: 0.3, decay: 0.8 },
-    });
+    // ReverbEffect.build forwards the supplied context as the second arg so
+    // cross-context use (effect on a bus whose context differs from the
+    // host's own) constructs the worklet on the right context.
+    expect(createNodeSpy).toHaveBeenCalledWith(
+      { parameterData: { wet: 0.7, dry: 0.3, decay: 0.8 } },
+      cacophony.context,
+    );
     createNodeSpy.mockRestore();
   });
 

--- a/src/effects.test.ts
+++ b/src/effects.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BiquadEffect,
   isCacophonyBuiltBiquad,
@@ -6,7 +6,23 @@ import {
   markAsCacophonyBiquad,
   ShareEffect,
 } from "./effects";
-import { cacophony } from "./setupTests";
+import { audioContextMock, cacophony } from "./setupTests";
+
+/**
+ * The standardized-audio-context mock used in setupTests doesn't expose
+ * `audioWorklet`. Every test that exercises a worklet-backed code path
+ * needs a per-test stub so `addModule` is callable. Returns the spy so
+ * tests can assert on it if needed.
+ */
+const mockAudioWorklet = () => {
+  const addModule = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(audioContextMock, "audioWorklet", {
+    value: { addModule },
+    writable: true,
+    configurable: true,
+  });
+  return addModule;
+};
 
 describe("effects: markAsCacophonyBiquad / isCacophonyBuiltBiquad", () => {
   it("returns false for a raw biquad created directly on the context", () => {
@@ -77,5 +93,59 @@ describe("Cacophony.shareEffect", () => {
     const effect = cacophony.shareEffect(node);
     expect(isCacophonyEffect(effect)).toBe(true);
     expect(effect.build(cacophony.context)).toBe(node);
+  });
+});
+
+describe("Cacophony.createReverb / loadDattorroReverb", () => {
+  beforeEach(() => {
+    mockAudioWorklet();
+  });
+
+  it("createReverb returns a CacophonyEffect (ReverbEffect)", () => {
+    const effect = cacophony.createReverb();
+    expect(isCacophonyEffect(effect)).toBe(true);
+  });
+
+  it("ReverbEffect.build awaits loadDattorroReverb and returns an AudioWorkletNode", async () => {
+    const loadSpy = vi.spyOn(cacophony, "loadDattorroReverb");
+    const effect = cacophony.createReverb({ wet: 0.5, dry: 0.5 });
+    const node = await effect.build(cacophony.context);
+    expect(loadSpy).toHaveBeenCalled();
+    expect(node).toBeDefined();
+    loadSpy.mockRestore();
+  });
+
+  it("loadDattorroReverb is idempotent — second call does not re-add the module", async () => {
+    const addModule = mockAudioWorklet();
+    // Force AudioWorkletNode construction to fail first time so addModule
+    // is reached; cacophony's createWorkletNode falls back to loadAudioWorkletModule.
+    vi.mocked(AudioWorkletNode).mockImplementationOnce(() => {
+      throw new Error("Worklet not loaded");
+    });
+    await cacophony.loadDattorroReverb();
+    const addModuleCallsAfterFirst = addModule.mock.calls.length;
+    await cacophony.loadDattorroReverb();
+    // Second call should short-circuit (loadedAudioWorklets has the name).
+    expect(addModule.mock.calls.length).toBe(addModuleCallsAfterFirst);
+  });
+
+  it("createReverb passes options as parameterData to the worklet", async () => {
+    const createNodeSpy = vi
+      .spyOn(cacophony, "createDattorroReverbNode")
+      .mockResolvedValue({} as any);
+    const effect = cacophony.createReverb({ wet: 0.7, dry: 0.3, decay: 0.8 });
+    await effect.build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({
+      parameterData: { wet: 0.7, dry: 0.3, decay: 0.8 },
+    });
+    createNodeSpy.mockRestore();
+  });
+
+  it("createReverb effect can be added to a bus's filter chain", async () => {
+    const bus = cacophony.createBus("reverb-bus");
+    const reverb = cacophony.createReverb({ wet: 0.4 });
+    await bus.addFilter(reverb);
+    expect(bus.filters.length).toBe(1);
+    bus.destroy();
   });
 });

--- a/src/effects.test.ts
+++ b/src/effects.test.ts
@@ -1,3 +1,4 @@
+import { AudioContext } from "standardized-audio-context-mock";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BiquadEffect,
@@ -158,5 +159,49 @@ describe("Cacophony.createReverb / loadDattorroReverb", () => {
     await bus.addFilter(reverb);
     expect(bus.filters.length).toBe(1);
     bus.destroy();
+  });
+
+  it("ReverbEffect.build(contextB) calls addModule on contextB even after the worklet was loaded on contextA", async () => {
+    // Regression for codex MAJOR finding: `loadedAudioWorklets` was a single
+    // `Set<string>` on the host Cacophony. After loading "dattorro-reverb"
+    // on contextA, calling effect.build(contextB) skipped
+    // `contextB.audioWorklet.addModule()` because the name was in the host
+    // set, leaving B with no registered worklet and the construct path
+    // throwing. Per-context keying (WeakMap<BaseContext, Set<string>>) fixes
+    // this — module loaded for context X is not "loaded" for context Y.
+
+    // Step 1: load "dattorro-reverb" on contextA (the host context).
+    // `loadDattorroReverb()` calls `audioWorklet.addModule()` directly — it
+    // does NOT construct an AudioWorkletNode, so no construct-mock is needed.
+    const addModuleA = mockAudioWorklet();
+    await cacophony.loadDattorroReverb();
+    expect(addModuleA).toHaveBeenCalledTimes(1);
+
+    // Step 2: build a second, distinct mock context with its own addModule
+    // spy. This is the cross-context case (e.g. a Bus on a different context).
+    const contextB = new AudioContext();
+    const addModuleB = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(contextB, "audioWorklet", {
+      value: { addModule: addModuleB },
+      writable: true,
+      configurable: true,
+    });
+
+    // Step 3: force the first construct on B to throw so the fallback load
+    // path runs. Under the pre-fix host-scoped cache, the fallback skipped
+    // addModule on B by name alone, leaving B without the module.
+    vi.mocked(AudioWorkletNode).mockImplementationOnce(() => {
+      throw new Error("Worklet not loaded on B");
+    });
+
+    const effect = cacophony.createReverb({ wet: 0.5 });
+    await effect.build(contextB as any);
+
+    // The fix: addModule must run on contextB. Pre-fix this assertion fails
+    // because the host-set short-circuit skipped the load.
+    expect(addModuleB).toHaveBeenCalledTimes(1);
+    // And addModule must NOT have been re-called on contextA — the per-context
+    // cache still short-circuits same-context reloads.
+    expect(addModuleA).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/effects.test.ts
+++ b/src/effects.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  BiquadEffect,
+  isCacophonyBuiltBiquad,
+  isCacophonyEffect,
+  markAsCacophonyBiquad,
+  ShareEffect,
+} from "./effects";
+import { cacophony } from "./setupTests";
+
+describe("effects: markAsCacophonyBiquad / isCacophonyBuiltBiquad", () => {
+  it("returns false for a raw biquad created directly on the context", () => {
+    const raw = cacophony.context.createBiquadFilter();
+    expect(isCacophonyBuiltBiquad(raw)).toBe(false);
+  });
+
+  it("returns true for a biquad produced by cacophony.createBiquadFilter", () => {
+    const built = cacophony.createBiquadFilter({ type: "lowpass", frequency: 1000 });
+    expect(isCacophonyBuiltBiquad(built)).toBe(true);
+  });
+
+  it("returns true after explicitly marking a node", () => {
+    const raw = cacophony.context.createBiquadFilter();
+    expect(isCacophonyBuiltBiquad(raw)).toBe(false);
+    markAsCacophonyBiquad(raw);
+    expect(isCacophonyBuiltBiquad(raw)).toBe(true);
+  });
+
+  it("returns false for non-node values", () => {
+    expect(isCacophonyBuiltBiquad(null)).toBe(false);
+    expect(isCacophonyBuiltBiquad(undefined)).toBe(false);
+    expect(isCacophonyBuiltBiquad({})).toBe(false);
+    expect(isCacophonyBuiltBiquad("filter")).toBe(false);
+  });
+});
+
+describe("effects: isCacophonyEffect", () => {
+  it("returns true for any object with a build function", () => {
+    const effect = { build: () => cacophony.context.createGain() };
+    expect(isCacophonyEffect(effect)).toBe(true);
+  });
+
+  it("returns false for objects without a build function", () => {
+    expect(isCacophonyEffect({})).toBe(false);
+    expect(isCacophonyEffect({ build: 42 })).toBe(false);
+    expect(isCacophonyEffect(null)).toBe(false);
+    expect(isCacophonyEffect(undefined)).toBe(false);
+  });
+
+  it("returns true for built-in BiquadEffect and ShareEffect", () => {
+    const biquad = cacophony.createBiquadFilter({ frequency: 500 });
+    expect(isCacophonyEffect(new BiquadEffect(biquad))).toBe(true);
+    expect(isCacophonyEffect(new ShareEffect(cacophony.context.createGain()))).toBe(true);
+  });
+});
+
+describe("effects: BiquadEffect", () => {
+  it("build returns the wrapped biquad instance", () => {
+    const biquad = cacophony.createBiquadFilter({ frequency: 800 });
+    const effect = new BiquadEffect(biquad);
+    expect(effect.build(cacophony.context)).toBe(biquad);
+  });
+});
+
+describe("effects: ShareEffect", () => {
+  it("build returns the wrapped node instance every time", () => {
+    const node = cacophony.context.createGain();
+    const effect = new ShareEffect(node);
+    expect(effect.build(cacophony.context)).toBe(node);
+    expect(effect.build(cacophony.context)).toBe(node);
+  });
+});
+
+describe("Cacophony.shareEffect", () => {
+  it("returns a CacophonyEffect that build()s to the supplied node", () => {
+    const node = cacophony.context.createGain();
+    const effect = cacophony.shareEffect(node);
+    expect(isCacophonyEffect(effect)).toBe(true);
+    expect(effect.build(cacophony.context)).toBe(node);
+  });
+});

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -20,10 +20,14 @@ import type { AudioNode, AudioWorkletNode, BaseContext, BiquadFilterNode } from 
 /**
  * Minimal structural interface for the Cacophony surface ReverbEffect needs.
  * Declared locally so this module avoids a circular import on cacophony.ts.
+ *
+ * Both methods accept an optional `BaseContext` so the effect can build on a
+ * context different from the host Cacophony instance's own — required for the
+ * cross-context contract `CacophonyEffect.build(context)` promises.
  */
 interface ReverbHost {
-  loadDattorroReverb(): Promise<void>;
-  createDattorroReverbNode(options: AudioWorkletNodeOptions): Promise<AudioWorkletNode>;
+  loadDattorroReverb(signal?: AbortSignal, context?: BaseContext): Promise<void>;
+  createDattorroReverbNode(options: AudioWorkletNodeOptions, context?: BaseContext): Promise<AudioWorkletNode>;
 }
 
 /**
@@ -129,10 +133,16 @@ export interface ReverbOptions {
 
 /**
  * CacophonyEffect that builds a DattorroReverb AudioWorkletNode. Calls
- * `cacophony.loadDattorroReverb()` first to idempotently ensure the worklet
- * module is registered, then constructs the worklet node with the supplied
- * options as `parameterData`. The returned node is the head AND tail of
- * the subgraph (single-node wet/dry handled internally by the processor).
+ * `cacophony.loadDattorroReverb(undefined, context)` first to idempotently
+ * ensure the worklet module is registered on the supplied context, then
+ * constructs the worklet node on the same context with the supplied options
+ * as `parameterData`. The returned node is the head AND tail of the
+ * subgraph (single-node wet/dry handled internally by the processor).
+ *
+ * Cross-context support: `build(context)` honors the {@link CacophonyEffect}
+ * contract — when the effect is added to a Bus whose context differs from
+ * the creating Cacophony's own context, the worklet is loaded and the
+ * AudioWorkletNode is constructed against the bus's context, not the host's.
  */
 export class ReverbEffect implements CacophonyEffect {
   constructor(
@@ -140,9 +150,12 @@ export class ReverbEffect implements CacophonyEffect {
     private readonly options: ReverbOptions = {},
   ) {}
 
-  async build(_context: BaseContext): Promise<AudioWorkletNode> {
-    await this.host.loadDattorroReverb();
-    return this.host.createDattorroReverbNode({ parameterData: this.options as Record<string, number> });
+  async build(context: BaseContext): Promise<AudioWorkletNode> {
+    await this.host.loadDattorroReverb(undefined, context);
+    return this.host.createDattorroReverbNode(
+      { parameterData: this.options as Record<string, number> },
+      context,
+    );
   }
 }
 

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -152,10 +152,7 @@ export class ReverbEffect implements CacophonyEffect {
 
   async build(context: BaseContext): Promise<AudioWorkletNode> {
     await this.host.loadDattorroReverb(undefined, context);
-    return this.host.createDattorroReverbNode(
-      { parameterData: this.options as Record<string, number> },
-      context,
-    );
+    return this.host.createDattorroReverbNode({ parameterData: this.options as Record<string, number> }, context);
   }
 }
 

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,0 +1,96 @@
+/**
+ * Cacophony Effects: a thin abstraction over Web Audio nodes that lets a Bus
+ * carry rich, possibly worklet-backed processing in its filter chain.
+ *
+ * A {@link CacophonyEffect} is responsible for producing a live AudioNode
+ * subgraph when its `build` method is invoked. The returned node is the
+ * "head" of the subgraph (the input the chain will connect into); the effect
+ * implementation is responsible for wiring any internal structure and
+ * arranging that the same node also serves as the output (or that the head
+ * is the only externally-visible node).
+ *
+ * The `build` return is `Promise<AudioNode> | AudioNode` so worklet-backed
+ * effects (e.g. DattorroReverb) can `await` their AudioWorklet module load
+ * before constructing the node, while pure-DOM effects (BiquadFilter, simple
+ * GainNode wrappers) can return synchronously.
+ */
+
+import type { AudioNode, BaseContext, BiquadFilterNode } from "./context";
+
+/**
+ * Public surface every Cacophony effect implements. `build` is called by
+ * `Bus.addFilter` to materialize the effect's live node graph against a
+ * specific audio context. An effect may be built more than once (e.g. on
+ * multiple buses or contexts), or it may bind to a single shared node — the
+ * implementation is free to choose. Cacophony itself does not cache.
+ */
+export interface CacophonyEffect {
+  build(context: BaseContext): Promise<AudioNode> | AudioNode;
+}
+
+/**
+ * Tracks AudioNodes that were produced by Cacophony's own factories so the
+ * Bus filter-chain admission policy can distinguish a Cacophony-built node
+ * (admit directly) from a raw third-party node (reject — user must wrap via
+ * `cacophony.shareEffect`). WeakSet membership is GC-safe and identity-keyed.
+ */
+const cacophonyBuiltBiquads = new WeakSet<BiquadFilterNode>();
+
+/**
+ * Mark a BiquadFilterNode as Cacophony-built. Called by
+ * {@link Cacophony.createBiquadFilter} on the freshly constructed node.
+ */
+export function markAsCacophonyBiquad(node: BiquadFilterNode): void {
+  cacophonyBuiltBiquads.add(node);
+}
+
+/**
+ * Test whether a node was produced by {@link Cacophony.createBiquadFilter}.
+ * Used by {@link Bus.addFilter} to admit Biquads directly without wrapping.
+ */
+export function isCacophonyBuiltBiquad(node: unknown): node is BiquadFilterNode {
+  return typeof node === "object" && node !== null && cacophonyBuiltBiquads.has(node as BiquadFilterNode);
+}
+
+/**
+ * Effect wrapper for a pre-constructed BiquadFilterNode. `build` returns
+ * the same node every time, so the same Biquad is shared across every bus
+ * that adds this effect. Use when you want explicit shared filter state
+ * across multiple buses.
+ */
+export class BiquadEffect implements CacophonyEffect {
+  constructor(private readonly node: BiquadFilterNode) {}
+
+  build(_context: BaseContext): AudioNode {
+    return this.node;
+  }
+}
+
+/**
+ * Explicit "I know what I'm doing" wrapper around a raw AudioNode the user
+ * built outside of Cacophony's factories. `Bus.addFilter` rejects raw
+ * AudioNodes by default to surface the shared-state implication; wrapping
+ * the node in a `ShareEffect` (via `cacophony.shareEffect(node)`) is the
+ * documented opt-in. The same node instance is returned from every `build`
+ * call, so all buses using the effect feed the same Web Audio node.
+ */
+export class ShareEffect implements CacophonyEffect {
+  constructor(private readonly node: AudioNode) {}
+
+  build(_context: BaseContext): AudioNode {
+    return this.node;
+  }
+}
+
+/**
+ * Type guard for the structural shape `CacophonyEffect`. A value qualifies if
+ * it exposes a callable `build` property.
+ */
+export function isCacophonyEffect(value: unknown): value is CacophonyEffect {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "build" in value &&
+    typeof (value as { build: unknown }).build === "function"
+  );
+}

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -15,7 +15,16 @@
  * GainNode wrappers) can return synchronously.
  */
 
-import type { AudioNode, BaseContext, BiquadFilterNode } from "./context";
+import type { AudioNode, AudioWorkletNode, BaseContext, BiquadFilterNode } from "./context";
+
+/**
+ * Minimal structural interface for the Cacophony surface ReverbEffect needs.
+ * Declared locally so this module avoids a circular import on cacophony.ts.
+ */
+interface ReverbHost {
+  loadDattorroReverb(): Promise<void>;
+  createDattorroReverbNode(options: AudioWorkletNodeOptions): Promise<AudioWorkletNode>;
+}
 
 /**
  * Public surface every Cacophony effect implements. `build` is called by
@@ -79,6 +88,61 @@ export class ShareEffect implements CacophonyEffect {
 
   build(_context: BaseContext): AudioNode {
     return this.node;
+  }
+}
+
+/**
+ * Subset of the {@link import('./processors/dattorro-reverb').DattorroReverbProcessor}
+ * AudioWorkletProcessor's AudioParam set that we expose for construction-time
+ * configuration via {@link Cacophony.createReverb}. All values are optional
+ * and clamped to the worklet's documented ranges (0..1 for most params).
+ *
+ * Every field corresponds to a `parameterData` entry passed to the
+ * AudioWorkletNode constructor; the worklet handles validation downstream.
+ */
+export interface ReverbOptions {
+  /** Pre-delay in samples (0..sampleRate-1). Default 0. */
+  preDelay?: number;
+  /** Input bandwidth (0..1). Default 0.9999. */
+  bandwidth?: number;
+  /** First input diffusion stage (0..1). Default 0.75. */
+  inputDiffusion1?: number;
+  /** Second input diffusion stage (0..1). Default 0.625. */
+  inputDiffusion2?: number;
+  /** Tail decay (0..1). Default 0.5. */
+  decay?: number;
+  /** First decay diffusion stage (0..0.999999). Default 0.7. */
+  decayDiffusion1?: number;
+  /** Second decay diffusion stage (0..0.999999). Default 0.5. */
+  decayDiffusion2?: number;
+  /** Frequency damping (0..1). Default 0.005. */
+  damping?: number;
+  /** Modulation rate (0..2). Default 0.5. */
+  excursionRate?: number;
+  /** Modulation depth (0..2). Default 0.7. */
+  excursionDepth?: number;
+  /** Wet mix (0..1). Default 0.3. */
+  wet?: number;
+  /** Dry mix (0..1). Default 0.6. */
+  dry?: number;
+}
+
+/**
+ * CacophonyEffect that builds a DattorroReverb AudioWorkletNode. Calls
+ * `cacophony.loadDattorroReverb()` first to idempotently ensure the worklet
+ * module is registered, then constructs the worklet node with the supplied
+ * options as `parameterData`. The returned node is the head AND tail of
+ * the subgraph (single-node wet/dry handled internally by the processor).
+ */
+export class ReverbEffect implements CacophonyEffect {
+  constructor(
+    private readonly host: ReverbHost,
+    private readonly options: ReverbOptions = {},
+  ) {}
+
+  async build(_context: BaseContext): Promise<AudioWorkletNode> {
+    await this.host.loadDattorroReverb();
+    return this.host.createDattorroReverbNode({ parameterData: this.options as Record<string, number> });
   }
 }
 

--- a/src/group.ts
+++ b/src/group.ts
@@ -1,3 +1,4 @@
+import type { Bus } from "./bus";
 import type { BaseSound, FadeType, LoopCount, Position } from "./cacophony";
 import type { BiquadFilterNode } from "./context";
 import type { Playback } from "./playback";
@@ -178,6 +179,20 @@ export class Group implements BaseSound {
    */
   removeFilter(filter: BiquadFilterNode): void {
     this.sounds.forEach((sound) => sound.removeFilter(filter));
+  }
+
+  /**
+   * Routes every sound in this group to the specified Bus (or back to
+   * master). Fans the call out to every member; see {@link Sound.routeTo}
+   * for full semantics. With a `sendGain`, adds a per-sound send instead
+   * of redirecting primary routing.
+   */
+  routeTo(target: Bus | string, sendGain?: number): void {
+    if (sendGain !== undefined) {
+      this.sounds.forEach((sound) => sound.routeTo(target, sendGain));
+    } else {
+      this.sounds.forEach((sound) => sound.routeTo(target));
+    }
   }
 
   set position(position: [number, number, number]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,8 +61,8 @@ export type {
 } from "./events";
 export type { BusConnectionTarget } from "./bus";
 export { Bus } from "./bus";
-export type { CacophonyEffect } from "./effects";
-export { BiquadEffect, ShareEffect } from "./effects";
+export type { CacophonyEffect, ReverbOptions } from "./effects";
+export { BiquadEffect, ReverbEffect, ShareEffect } from "./effects";
 export { Group } from "./group";
 export type { MediaStreamSoundOptions } from "./mediaStream";
 export { MediaStreamPlayback, MediaStreamSound } from "./mediaStream";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@
 // supported surface. Do NOT add `export *` — every value/type must be listed
 // explicitly so additions to internal modules cannot leak out without review.
 
+export type { BusConnectionTarget } from "./bus";
+export { Bus } from "./bus";
 export { AudioCache } from "./cache";
 export type {
   BaseSound,
@@ -37,6 +39,8 @@ export type {
   SourceNode,
   StereoPannerNode,
 } from "./context";
+export type { CacophonyEffect, ReverbOptions } from "./effects";
+export { BiquadEffect, ReverbEffect, ShareEffect } from "./effects";
 export type {
   AudioEventCallbacks,
   BaseAudioEvents,
@@ -59,10 +63,6 @@ export type {
   SoundEvents,
   SynthEvents,
 } from "./events";
-export type { BusConnectionTarget } from "./bus";
-export { Bus } from "./bus";
-export type { CacophonyEffect, ReverbOptions } from "./effects";
-export { BiquadEffect, ReverbEffect, ShareEffect } from "./effects";
 export { Group } from "./group";
 export type { MediaStreamSoundOptions } from "./mediaStream";
 export { MediaStreamPlayback, MediaStreamSound } from "./mediaStream";

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ export type {
   SoundEvents,
   SynthEvents,
 } from "./events";
+export type { CacophonyEffect } from "./effects";
+export { BiquadEffect, ShareEffect } from "./effects";
 export { Group } from "./group";
 export type { MediaStreamSoundOptions } from "./mediaStream";
 export { MediaStreamPlayback, MediaStreamSound } from "./mediaStream";

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ export type {
   SoundEvents,
   SynthEvents,
 } from "./events";
+export type { BusConnectionTarget } from "./bus";
+export { Bus } from "./bus";
 export type { CacophonyEffect } from "./effects";
 export { BiquadEffect, ShareEffect } from "./effects";
 export { Group } from "./group";

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -19,6 +19,7 @@
  */
 
 import { BasePlayback } from "./basePlayback";
+import type { Bus } from "./bus";
 import type { BaseSound, FadeType, LoopCount, PanType } from "./cacophony";
 import type {
   AudioBuffer,
@@ -59,6 +60,17 @@ export class Playback extends BasePlayback implements BaseSound {
   _fadeInConfig?: { duration: number; type: FadeType; perLoop: boolean; targetVolume: number };
   _fadeOutConfig?: { duration: number; type: FadeType };
   _loopEndCallback?: () => void;
+  /**
+   * Per-playback send-gain allocations: bus → allocated GainNode. Sounds
+   * record send intent in `Sound._sends` (value-only), and the actual
+   * GainNode lifecycle is owned here — allocated at preplay or
+   * `Sound.routeTo(bus, gain)`, torn down in {@link cleanup}.
+   *
+   * Iterable Map (not WeakMap) so cleanup can walk every send and call
+   * `disconnect()` on it; relying on GC for disconnect would leave the bus
+   * graph holding the allocation indirectly.
+   */
+  _sendGains: Map<Bus, GainNode> = new Map();
 
   /**
    * Creates an instance of the Playback class.
@@ -549,6 +561,17 @@ export class Playback extends BasePlayback implements BaseSound {
     this.currentLoop = 0;
     this.source.disconnect();
     this.source = undefined;
+    // Tear down any per-playback send-gain nodes allocated by Sound.routeTo
+    // (or preplay) before the gainNode is severed by super.cleanup(). The
+    // gainNode → sendGain → bus.input chain is now fully disconnected.
+    for (const sendGain of this._sendGains.values()) {
+      try {
+        sendGain.disconnect();
+      } catch {
+        // Best-effort — node may already have been disconnected externally.
+      }
+    }
+    this._sendGains.clear();
     super.cleanup();
   }
 

--- a/src/routeTo.test.ts
+++ b/src/routeTo.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for Sound/Synth/Group `routeTo` and the per-Sound _routeTarget /
+ * _sends machinery. Covers both primary redirection (with live-playback
+ * rewiring) and additive sends.
+ */
+
+import { AudioBuffer } from "standardized-audio-context-mock";
+import { describe, expect, it, vi } from "vitest";
+import { cacophony } from "./setupTests";
+
+const buildSound = async () => {
+  const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+  return cacophony.createSound(buffer as unknown as AudioBuffer);
+};
+
+describe("Sound.routeTo: primary redirection", () => {
+  it("future playbacks connect to bus.input when routeTo(bus) was called", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("primary-test");
+    // Spy on context.createGain so we can capture the gainNode the
+    // forthcoming preplay will allocate and inspect its connect calls.
+    const created: { connect: ReturnType<typeof vi.fn>; original: any }[] = [];
+    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
+    vi.spyOn(cacophony.context, "createGain").mockImplementation(() => {
+      const node = realCreateGain();
+      const connectSpy = vi.fn(node.connect.bind(node));
+      const wrapped = Object.assign(node, { connect: connectSpy });
+      created.push({ connect: connectSpy, original: node });
+      return wrapped;
+    });
+    sound.routeTo(bus);
+    sound.play();
+    // The most recently created gain (the playback's gainNode) should have
+    // been connected to bus.input. Walk created from the back since other
+    // calls (sendGains, etc.) may also be allocated.
+    const playbackGain = created[created.length - 1];
+    expect(playbackGain).toBeDefined();
+    expect(playbackGain.connect).toHaveBeenCalledWith(bus.input);
+    bus.destroy();
+  });
+
+  it("routeTo(name) looks up the bus via cacophony.getBus", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("named-route");
+    sound.routeTo("named-route");
+    // No throw → looked up successfully. Re-routing to the same bus again
+    // should be a no-op (target unchanged).
+    expect(() => sound.routeTo("named-route")).not.toThrow();
+    bus.destroy();
+  });
+
+  it("routeTo('nonexistent') throws", async () => {
+    const sound = await buildSound();
+    expect(() => sound.routeTo("nonexistent")).toThrow(/No bus registered/);
+  });
+
+  it("routeTo(master) collapses to null and reverts to master", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("scratch");
+    sound.routeTo(bus);
+    sound.routeTo(cacophony.master);
+    // Future playbacks should connect to globalGainNode (master.input).
+    sound.play();
+    bus.destroy();
+  });
+
+  it("redirects live playbacks via disconnect/connect on each playback", async () => {
+    const sound = await buildSound();
+    const [playback] = sound.play();
+    const bus = cacophony.createBus("live-redirect");
+    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
+    const connectSpy = vi.spyOn(playback.outputNode, "connect");
+    sound.routeTo(bus);
+    expect(disconnectSpy).toHaveBeenCalled();
+    expect(connectSpy).toHaveBeenCalledWith(bus.input);
+    bus.destroy();
+  });
+
+  it("routes to a destroyed bus by falling back to master with a console.warn", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("doomed");
+    sound.routeTo(bus);
+    bus.destroy();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    sound.play();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/destroyed bus.*master/));
+    warnSpy.mockRestore();
+  });
+});
+
+describe("Sound.routeTo: additive send", () => {
+  it("routeTo(bus, 0.3) adds a send without changing primary routing", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("send-test");
+    const [playback] = sound.play();
+    // Capture the next createGain (the send gain).
+    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
+    const allocatedSendGains: any[] = [];
+    vi.spyOn(cacophony.context, "createGain").mockImplementationOnce(() => {
+      const node = realCreateGain();
+      allocatedSendGains.push(node);
+      return node;
+    });
+    const playbackConnectSpy = vi.spyOn(playback.outputNode, "connect");
+    sound.routeTo(bus, 0.3);
+    expect(playbackConnectSpy).toHaveBeenCalled();
+    // Verify a send-gain was allocated with value 0.3.
+    expect(allocatedSendGains.length).toBe(1);
+    expect(allocatedSendGains[0].gain.value).toBe(0.3);
+    bus.destroy();
+  });
+
+  it("updates an existing send's gain in place when called twice", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("send-update");
+    sound.play();
+    sound.routeTo(bus, 0.5);
+    sound.routeTo(bus, 0.25);
+    // No new allocation expected on the second call — verified by behavior
+    // not throwing and the routeTo helper returning normally.
+    expect(true).toBe(true);
+    bus.destroy();
+  });
+
+  it("throws when adding a send to a destroyed bus", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("dead-send");
+    bus.destroy();
+    expect(() => sound.routeTo(bus, 0.5)).toThrow(/destroyed/);
+  });
+
+  it("establishes a send on future playbacks (not just live ones)", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("future-send");
+    sound.routeTo(bus, 0.4);
+    // No playback yet; play and check no throw.
+    const [playback] = sound.play();
+    expect(playback).toBeDefined();
+    bus.destroy();
+  });
+});
+
+describe("Synth.routeTo", () => {
+  it("redirects future playbacks to bus.input", () => {
+    const synth = cacophony.createOscillator({});
+    const bus = cacophony.createBus("synth-route");
+    synth.routeTo(bus);
+    synth.play();
+    // No throw — the connect happened against bus.input.
+    bus.destroy();
+  });
+
+  it("redirects live playbacks (uses outputNode.disconnect/connect)", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    const bus = cacophony.createBus("synth-live");
+    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
+    const connectSpy = vi.spyOn(playback.outputNode, "connect");
+    synth.routeTo(bus);
+    expect(disconnectSpy).toHaveBeenCalled();
+    expect(connectSpy).toHaveBeenCalledWith(bus.input);
+    bus.destroy();
+  });
+
+  it("routeTo with sendGain adds a send", () => {
+    const synth = cacophony.createOscillator({});
+    synth.play();
+    const bus = cacophony.createBus("synth-send");
+    expect(() => synth.routeTo(bus, 0.2)).not.toThrow();
+    bus.destroy();
+  });
+
+  it("routeTo by name looks up via cacophony.getBus", () => {
+    const synth = cacophony.createOscillator({});
+    cacophony.createBus("synth-by-name");
+    expect(() => synth.routeTo("synth-by-name")).not.toThrow();
+  });
+
+  it("routeTo('nonexistent') throws", () => {
+    const synth = cacophony.createOscillator({});
+    expect(() => synth.routeTo("never-existed")).toThrow(/No bus registered/);
+  });
+});
+
+describe("Group.routeTo", () => {
+  it("fans out routeTo to every member sound", async () => {
+    const s1 = await buildSound();
+    const s2 = await buildSound();
+    const group = await cacophony.createGroup([s1, s2]);
+    const bus = cacophony.createBus("group-route");
+    const s1Spy = vi.spyOn(s1, "routeTo");
+    const s2Spy = vi.spyOn(s2, "routeTo");
+    group.routeTo(bus);
+    expect(s1Spy).toHaveBeenCalledWith(bus);
+    expect(s2Spy).toHaveBeenCalledWith(bus);
+    bus.destroy();
+  });
+
+  it("fans out routeTo with sendGain to every member sound", async () => {
+    const s1 = await buildSound();
+    const s2 = await buildSound();
+    const group = await cacophony.createGroup([s1, s2]);
+    const bus = cacophony.createBus("group-send");
+    const s1Spy = vi.spyOn(s1, "routeTo");
+    const s2Spy = vi.spyOn(s2, "routeTo");
+    group.routeTo(bus, 0.4);
+    expect(s1Spy).toHaveBeenCalledWith(bus, 0.4);
+    expect(s2Spy).toHaveBeenCalledWith(bus, 0.4);
+    bus.destroy();
+  });
+});

--- a/src/routeTo.test.ts
+++ b/src/routeTo.test.ts
@@ -86,27 +86,50 @@ describe("Sound.routeTo: primary redirection", () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/destroyed bus.*master/));
     warnSpy.mockRestore();
   });
+
+  it("primary routeTo(destroyedBus) throws — caller is mutating a torn-down resource", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("predead");
+    bus.destroy();
+    expect(() => sound.routeTo(bus)).toThrow(/destroyed/);
+  });
 });
 
 describe("Sound.routeTo: additive send", () => {
-  it("routeTo(bus, 0.3) adds a send without changing primary routing", async () => {
+  it("routeTo(bus, 0.3) adds a send without changing primary routing — playback feeds BOTH primary master AND the bus via sendGain", async () => {
     const sound = await buildSound();
     const bus = cacophony.createBus("send-test");
     const [playback] = sound.play();
-    // Capture the next createGain (the send gain).
+    // The primary edge already exists from preplay: playback.outputNode →
+    // globalGainNode (master.input). Establishing a send must NOT remove it.
+    // Snapshot the primary edge by spying on outputNode.disconnect — it must
+    // not be invoked. Then capture the send-gain allocation + its outgoing
+    // connect to assert the new edge actually targets bus.input.
     const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
-    const allocatedSendGains: any[] = [];
+    const allocatedSendGains: Array<{ node: any; connect: ReturnType<typeof vi.fn> }> = [];
     vi.spyOn(cacophony.context, "createGain").mockImplementationOnce(() => {
       const node = realCreateGain();
-      allocatedSendGains.push(node);
+      const connectSpy = vi.fn(node.connect.bind(node));
+      Object.assign(node, { connect: connectSpy });
+      allocatedSendGains.push({ node, connect: connectSpy });
       return node;
     });
     const playbackConnectSpy = vi.spyOn(playback.outputNode, "connect");
+    const playbackDisconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
     sound.routeTo(bus, 0.3);
+    // Primary edge to master untouched.
+    expect(playbackDisconnectSpy).not.toHaveBeenCalled();
+    // New send edge from the playback's outputNode goes to the allocated sendGain.
     expect(playbackConnectSpy).toHaveBeenCalled();
-    // Verify a send-gain was allocated with value 0.3.
     expect(allocatedSendGains.length).toBe(1);
-    expect(allocatedSendGains[0].gain.value).toBe(0.3);
+    const sendGain = allocatedSendGains[0];
+    expect(sendGain.node.gain.value).toBe(0.3);
+    expect(playbackConnectSpy).toHaveBeenCalledWith(sendGain.node);
+    // Send edge's second hop: sendGain → bus.input. This is the additive
+    // "playback also reaches the bus" half of the contract.
+    expect(sendGain.connect).toHaveBeenCalledWith(bus.input);
+    // And after destroy + cleanup, the sendGain (owned by the playback) must
+    // have its disconnect called — see playback._sendGains teardown.
     bus.destroy();
   });
 
@@ -136,6 +159,23 @@ describe("Sound.routeTo: additive send", () => {
     // No playback yet; play and check no throw.
     const [playback] = sound.play();
     expect(playback).toBeDefined();
+    bus.destroy();
+  });
+
+  it("cleanup disconnects every allocated send-gain node (no GC reliance)", async () => {
+    const sound = await buildSound();
+    const bus = cacophony.createBus("cleanup-send");
+    sound.routeTo(bus, 0.6);
+    const [playback] = sound.play();
+    // The sendGain is owned by the playback under playback._sendGains.
+    const sendGain = playback._sendGains.get(bus);
+    expect(sendGain).toBeDefined();
+    const sendGainDisconnect = vi.spyOn(sendGain!, "disconnect");
+    sound.cleanup();
+    // The sendGain.disconnect() call is the deterministic "this allocation
+    // is torn down" signal — without it we'd be waiting on GC for the bus
+    // graph to lose the reference.
+    expect(sendGainDisconnect).toHaveBeenCalled();
     bus.destroy();
   });
 });
@@ -179,6 +219,34 @@ describe("Synth.routeTo", () => {
   it("routeTo('nonexistent') throws", () => {
     const synth = cacophony.createOscillator({});
     expect(() => synth.routeTo("never-existed")).toThrow(/No bus registered/);
+  });
+
+  it("primary routeTo(destroyedBus) throws", () => {
+    const synth = cacophony.createOscillator({});
+    const bus = cacophony.createBus("synth-predead");
+    bus.destroy();
+    expect(() => synth.routeTo(bus)).toThrow(/destroyed/);
+  });
+
+  it("SynthPlayback cleanup disconnects every allocated send-gain node", () => {
+    const synth = cacophony.createOscillator({});
+    const bus = cacophony.createBus("synth-cleanup-send");
+    synth.routeTo(bus, 0.5);
+    const [playback] = synth.play();
+    const sendGain = playback._sendGains.get(bus);
+    expect(sendGain).toBeDefined();
+    const sendGainDisconnect = vi.spyOn(sendGain!, "disconnect");
+    playback.cleanup();
+    expect(sendGainDisconnect).toHaveBeenCalled();
+    bus.destroy();
+  });
+
+  it("SynthPlayback.outputNode throws after cleanup (parity with Playback)", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    expect(playback.outputNode).toBeDefined();
+    playback.cleanup();
+    expect(() => playback.outputNode).toThrow(/cleaned up/);
   });
 });
 

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -78,17 +78,11 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
    * GainNode per send per playback so each playback has its own send edges
    * (a per-Sound shared sendGain would crash the second simultaneous
    * playback because both gainNodes would connect into the same single
-   * sendGain, doubling the dry signal). Send GainNodes are tracked in the
-   * playback-local map below.
+   * sendGain, doubling the dry signal). The actual GainNode lifecycle is
+   * owned by each Playback in {@link Playback._sendGains} — iterable so
+   * cleanup can walk every send and call `disconnect()`.
    */
   private _sends: Map<Bus, number> = new Map();
-  /**
-   * Per-playback send-gain allocations: playback → (bus → allocated
-   * GainNode). Tracked so {@link routeTo}(bus, sendGain) can update the
-   * gain in place when called twice, and so cleanup tears down only the
-   * nodes this Sound allocated.
-   */
-  private _playbackSendGains: WeakMap<Playback, Map<Bus, GainNode>> = new WeakMap();
 
   constructor(
     public url: string,
@@ -230,9 +224,10 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
       gainNode.connect(primaryTargetNode);
       const playback = new Playback(this, source, gainNode);
       // Establish send edges (per-playback allocation so each playback owns
-      // its own send-gain nodes — see _sends docstring).
+      // its own send-gain nodes — see _sends docstring). The allocated
+      // GainNode lives on the Playback (`playback._sendGains`) so it gets
+      // torn down explicitly in Playback.cleanup().
       if (this._sends.size > 0) {
-        const sendMap = new Map<Bus, GainNode>();
         for (const [bus, gainValue] of this._sends) {
           if (bus.destroyed) {
             console.warn(`Sound has a send to destroyed bus '${bus.name ?? "<anonymous>"}'; skipping`);
@@ -242,9 +237,8 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
           sendGain.gain.value = gainValue;
           gainNode.connect(sendGain);
           sendGain.connect(bus.input);
-          sendMap.set(bus, sendGain);
+          playback._sendGains.set(bus, sendGain);
         }
-        this._playbackSendGains.set(playback, sendMap);
       }
       this._holdings.sources.push(source);
       this._holdings.gainNodes.push(gainNode);
@@ -543,8 +537,16 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
    * Apply a new primary route. If a bus is passed and it's the master bus,
    * collapse to `null` so the canonical "route to master" representation is
    * always `null` (matches the default).
+   *
+   * @throws if `bus` is destroyed. Symmetric with {@link _addSend}'s guard;
+   *   a destroyed bus is an invalid mutation target. (Sounds already routed
+   *   BEFORE the bus was destroyed still fall back to master at preplay via
+   *   {@link _resolveRouteTargetNode} — that path is separate.)
    */
   private _setPrimary(bus: Bus): void {
+    if (bus.destroyed) {
+      throw new Error(`Cannot route to destroyed bus '${bus.name ?? "<anonymous>"}'`);
+    }
     // master.input === globalGainNode — normalize to null in either case so
     // there is one canonical "route to master" state.
     const collapseToMaster = bus.input === this.globalGainNode;
@@ -574,10 +576,11 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
       throw new Error(`Cannot add a send to destroyed bus '${bus.name ?? "<anonymous>"}'`);
     }
     this._sends.set(bus, gainValue);
-    // Establish send edges on existing playbacks.
+    // Establish send edges on existing playbacks. The per-playback Map is
+    // the canonical owner of the GainNode lifecycle (so cleanup can iterate
+    // and disconnect every send).
     for (const playback of this.playbacks) {
-      const sendMap = this._playbackSendGains.get(playback) ?? new Map<Bus, GainNode>();
-      const existing = sendMap.get(bus);
+      const existing = playback._sendGains.get(bus);
       if (existing) {
         existing.gain.value = gainValue;
         continue;
@@ -591,8 +594,7 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
         continue;
       }
       sendGain.connect(bus.input);
-      sendMap.set(bus, sendGain);
-      this._playbackSendGains.set(playback, sendMap);
+      playback._sendGains.set(bus, sendGain);
     }
   }
 

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -21,6 +21,7 @@
  * instances of a sound with different settings, without requiring the user to manually manage each playback instance.
  */
 
+import type { Bus } from "./bus";
 import type {
   BaseSound,
   Cacophony,
@@ -64,6 +65,30 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
    * tied to the playback identity.
    */
   private _playbackUnsubscribes: WeakMap<Playback, Array<() => void>> = new WeakMap();
+  /**
+   * Primary route target for this Sound. `null` means master (the default —
+   * preplay connects to {@link globalGainNode} which IS `master.input`).
+   * When a Bus is assigned via {@link routeTo}, future playbacks connect to
+   * `bus.input` instead, and live playbacks are rewired.
+   */
+  private _routeTarget: Bus | null = null;
+  /**
+   * Additional send edges established by {@link routeTo}(bus, sendGain).
+   * Keyed by target bus → send gain value. At preplay we allocate one
+   * GainNode per send per playback so each playback has its own send edges
+   * (a per-Sound shared sendGain would crash the second simultaneous
+   * playback because both gainNodes would connect into the same single
+   * sendGain, doubling the dry signal). Send GainNodes are tracked in the
+   * playback-local map below.
+   */
+  private _sends: Map<Bus, number> = new Map();
+  /**
+   * Per-playback send-gain allocations: playback → (bus → allocated
+   * GainNode). Tracked so {@link routeTo}(bus, sendGain) can update the
+   * gain in place when called twice, and so cleanup tears down only the
+   * nodes this Sound allocated.
+   */
+  private _playbackSendGains: WeakMap<Playback, Map<Bus, GainNode>> = new WeakMap();
 
   constructor(
     public url: string,
@@ -198,8 +223,29 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
       createdSource = source;
       const gainNode = this.context.createGain();
       createdGainNode = gainNode;
-      gainNode.connect(this.globalGainNode);
+      // Resolve the primary route target. A null `_routeTarget` means master
+      // — which is structurally `globalGainNode`. A destroyed bus falls back
+      // to master with a warning.
+      const primaryTargetNode = this._resolveRouteTargetNode();
+      gainNode.connect(primaryTargetNode);
       const playback = new Playback(this, source, gainNode);
+      // Establish send edges (per-playback allocation so each playback owns
+      // its own send-gain nodes — see _sends docstring).
+      if (this._sends.size > 0) {
+        const sendMap = new Map<Bus, GainNode>();
+        for (const [bus, gainValue] of this._sends) {
+          if (bus.destroyed) {
+            console.warn(`Sound has a send to destroyed bus '${bus.name ?? "<anonymous>"}'; skipping`);
+            continue;
+          }
+          const sendGain = this.context.createGain();
+          sendGain.gain.value = gainValue;
+          gainNode.connect(sendGain);
+          sendGain.connect(bus.input);
+          sendMap.set(bus, sendGain);
+        }
+        this._playbackSendGains.set(playback, sendMap);
+      }
       this._holdings.sources.push(source);
       this._holdings.gainNodes.push(gainNode);
       if ("mediaElement" in source && source.mediaElement) {
@@ -435,6 +481,119 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
   set volume(volume: number) {
     super.volume = volume;
     this.emit("volumeChange", volume);
+  }
+
+  /**
+   * Routes this Sound to a Bus (or back to master). Two modes:
+   *
+   * - `routeTo(target)` — replace primary routing. Live playbacks are
+   *   rewired: each playback's outputNode is disconnected from its current
+   *   target and re-connected to the new target's input. Future playbacks
+   *   read the stored target at preplay.
+   * - `routeTo(target, sendGain)` — ADD a send (does not change primary
+   *   routing). An additional edge is created from each live playback
+   *   through an allocated GainNode set to `sendGain`. Future playbacks
+   *   get the same send at preplay.
+   *
+   * `target` may be a Bus instance or the name of a registered bus (string
+   *  lookup via `cacophony.getBus`). A string with no matching bus throws.
+   *
+   * Passing the master bus (or `cacophony.master`) as `target` (no
+   *  sendGain) is the canonical way to reset primary routing back to master.
+   */
+  routeTo(target: Bus | string, sendGain?: number): void {
+    const bus = this._resolveBusArg(target);
+    if (sendGain !== undefined) {
+      this._addSend(bus, sendGain);
+      return;
+    }
+    this._setPrimary(bus);
+  }
+
+  private _resolveBusArg(target: Bus | string): Bus {
+    if (typeof target !== "string") {
+      return target;
+    }
+    const bus = this._cacophony?.getBus(target);
+    if (!bus) {
+      throw new Error(`No bus registered with name '${target}'`);
+    }
+    return bus;
+  }
+
+  /**
+   * Returns the AudioNode that future playbacks should connect to as their
+   * primary target. Handles the master bus alias and the destroyed-bus
+   * fallback (which warns).
+   */
+  private _resolveRouteTargetNode(): GainNode {
+    if (!this._routeTarget) {
+      return this.globalGainNode;
+    }
+    if (this._routeTarget.destroyed) {
+      console.warn(
+        `Sound routed to destroyed bus '${this._routeTarget.name ?? "<anonymous>"}'; falling back to master`,
+      );
+      return this.globalGainNode;
+    }
+    return this._routeTarget.input;
+  }
+
+  /**
+   * Apply a new primary route. If a bus is passed and it's the master bus,
+   * collapse to `null` so the canonical "route to master" representation is
+   * always `null` (matches the default).
+   */
+  private _setPrimary(bus: Bus): void {
+    // master.input === globalGainNode — normalize to null in either case so
+    // there is one canonical "route to master" state.
+    const collapseToMaster = bus.input === this.globalGainNode;
+    const oldTargetNode = this._resolveRouteTargetNode();
+    this._routeTarget = collapseToMaster ? null : bus;
+    const newTargetNode = this._resolveRouteTargetNode();
+    if (oldTargetNode === newTargetNode) {
+      return;
+    }
+    for (const playback of this.playbacks) {
+      try {
+        playback.outputNode.disconnect(oldTargetNode);
+      } catch {
+        // Some playbacks may already have been disconnected (cleanup, manual
+        // disconnect). Tolerate.
+      }
+      try {
+        playback.outputNode.connect(newTargetNode);
+      } catch {
+        // Best-effort live rewire.
+      }
+    }
+  }
+
+  private _addSend(bus: Bus, gainValue: number): void {
+    if (bus.destroyed) {
+      throw new Error(`Cannot add a send to destroyed bus '${bus.name ?? "<anonymous>"}'`);
+    }
+    this._sends.set(bus, gainValue);
+    // Establish send edges on existing playbacks.
+    for (const playback of this.playbacks) {
+      const sendMap = this._playbackSendGains.get(playback) ?? new Map<Bus, GainNode>();
+      const existing = sendMap.get(bus);
+      if (existing) {
+        existing.gain.value = gainValue;
+        continue;
+      }
+      const sendGain = this.context.createGain();
+      sendGain.gain.value = gainValue;
+      try {
+        playback.outputNode.connect(sendGain);
+      } catch {
+        // Playback may have been cleaned up; skip.
+        continue;
+      }
+      sendGain.connect(bus.input);
+      sendMap.set(bus, sendGain);
+      this._playbackSendGains.set(playback, sendMap);
+    }
   }
 
   cleanup(): void {

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -21,8 +21,6 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
   private _routeTarget: Bus | null = null;
   /** Send target → send gain value. See Sound._sends for notes. */
   private _sends: Map<Bus, number> = new Map();
-  /** Per-playback send-gain allocations. See Sound._playbackSendGains. */
-  private _playbackSendGains: WeakMap<SynthPlayback, Map<Bus, GainNode>> = new WeakMap();
 
   /**
    * Register event listener.
@@ -122,8 +120,9 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
     gainNode.connect(primaryTargetNode);
     const playback = new SynthPlayback(this, oscillator, gainNode);
     // Establish send edges (per-playback allocation; see Sound docstring).
+    // Send-gain GainNodes are owned by the playback (`playback._sendGains`)
+    // so cleanup can iterate and disconnect them explicitly.
     if (this._sends.size > 0) {
-      const sendMap = new Map<Bus, GainNode>();
       for (const [bus, gainValue] of this._sends) {
         if (bus.destroyed) {
           console.warn(`Synth has a send to destroyed bus '${bus.name ?? "<anonymous>"}'; skipping`);
@@ -133,9 +132,8 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
         sendGain.gain.value = gainValue;
         gainNode.connect(sendGain);
         sendGain.connect(bus.input);
-        sendMap.set(bus, sendGain);
+        playback._sendGains.set(bus, sendGain);
       }
-      this._playbackSendGains.set(playback, sendMap);
     }
     playback.volume = this.volume;
     // Clone filters from synth to playback (each playback gets independent filter instances)
@@ -264,6 +262,9 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
   }
 
   private _setPrimary(bus: Bus): void {
+    if (bus.destroyed) {
+      throw new Error(`Cannot route to destroyed bus '${bus.name ?? "<anonymous>"}'`);
+    }
     const collapseToMaster = bus.input === this.globalGainNode;
     const oldTargetNode = this._resolveRouteTargetNode();
     this._routeTarget = collapseToMaster ? null : bus;
@@ -287,8 +288,7 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
     }
     this._sends.set(bus, gainValue);
     for (const playback of this.playbacks) {
-      const sendMap = this._playbackSendGains.get(playback) ?? new Map<Bus, GainNode>();
-      const existing = sendMap.get(bus);
+      const existing = playback._sendGains.get(bus);
       if (existing) {
         existing.gain.value = gainValue;
         continue;
@@ -301,8 +301,7 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
         continue;
       }
       sendGain.connect(bus.input);
-      sendMap.set(bus, sendGain);
-      this._playbackSendGains.set(playback, sendMap);
+      playback._sendGains.set(bus, sendGain);
     }
   }
 

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -1,3 +1,4 @@
+import type { Bus } from "./bus";
 import type { BaseSound, Cacophony, PanType, SoundType } from "./cacophony";
 import { PlaybackContainer } from "./container";
 import type { BaseContext, GainNode, OscillatorNode } from "./context";
@@ -16,6 +17,12 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
   _oscillatorOptions: Partial<OscillatorOptions>;
   playbacks: SynthPlayback[] = [];
   private eventEmitter: TypedEventEmitter<SynthEvents> = new TypedEventEmitter<SynthEvents>();
+  /** Primary route target. `null` means master. See Sound for full notes. */
+  private _routeTarget: Bus | null = null;
+  /** Send target → send gain value. See Sound._sends for notes. */
+  private _sends: Map<Bus, number> = new Map();
+  /** Per-playback send-gain allocations. See Sound._playbackSendGains. */
+  private _playbackSendGains: WeakMap<SynthPlayback, Map<Bus, GainNode>> = new WeakMap();
 
   /**
    * Register event listener.
@@ -111,8 +118,25 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
     if (this.oscillatorOptions.type) oscillator.type = this.oscillatorOptions.type;
 
     const gainNode = this.context.createGain();
-    gainNode.connect(this.globalGainNode);
+    const primaryTargetNode = this._resolveRouteTargetNode();
+    gainNode.connect(primaryTargetNode);
     const playback = new SynthPlayback(this, oscillator, gainNode);
+    // Establish send edges (per-playback allocation; see Sound docstring).
+    if (this._sends.size > 0) {
+      const sendMap = new Map<Bus, GainNode>();
+      for (const [bus, gainValue] of this._sends) {
+        if (bus.destroyed) {
+          console.warn(`Synth has a send to destroyed bus '${bus.name ?? "<anonymous>"}'; skipping`);
+          continue;
+        }
+        const sendGain = this.context.createGain();
+        sendGain.gain.value = gainValue;
+        gainNode.connect(sendGain);
+        sendGain.connect(bus.input);
+        sendMap.set(bus, sendGain);
+      }
+      this._playbackSendGains.set(playback, sendMap);
+    }
     playback.volume = this.volume;
     // Clone filters from synth to playback (each playback gets independent filter instances)
     this._filters.forEach((filter) => {
@@ -200,6 +224,86 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
     this._oscillatorOptions.detune = detune;
     this.playbacks.forEach((p) => (p.detune = detune));
     this.emit("detuneChange", detune);
+  }
+
+  /**
+   * Routes this Synth to a Bus (or back to master). See Sound.routeTo for
+   * full semantics — Synth mirrors the behavior exactly.
+   */
+  routeTo(target: Bus | string, sendGain?: number): void {
+    const bus = this._resolveBusArg(target);
+    if (sendGain !== undefined) {
+      this._addSend(bus, sendGain);
+      return;
+    }
+    this._setPrimary(bus);
+  }
+
+  private _resolveBusArg(target: Bus | string): Bus {
+    if (typeof target !== "string") {
+      return target;
+    }
+    const bus = this.cacophony?.getBus(target);
+    if (!bus) {
+      throw new Error(`No bus registered with name '${target}'`);
+    }
+    return bus;
+  }
+
+  private _resolveRouteTargetNode(): GainNode {
+    if (!this._routeTarget) {
+      return this.globalGainNode;
+    }
+    if (this._routeTarget.destroyed) {
+      console.warn(
+        `Synth routed to destroyed bus '${this._routeTarget.name ?? "<anonymous>"}'; falling back to master`,
+      );
+      return this.globalGainNode;
+    }
+    return this._routeTarget.input;
+  }
+
+  private _setPrimary(bus: Bus): void {
+    const collapseToMaster = bus.input === this.globalGainNode;
+    const oldTargetNode = this._resolveRouteTargetNode();
+    this._routeTarget = collapseToMaster ? null : bus;
+    const newTargetNode = this._resolveRouteTargetNode();
+    if (oldTargetNode === newTargetNode) {
+      return;
+    }
+    for (const playback of this.playbacks) {
+      try {
+        playback.outputNode.disconnect(oldTargetNode);
+      } catch {}
+      try {
+        playback.outputNode.connect(newTargetNode);
+      } catch {}
+    }
+  }
+
+  private _addSend(bus: Bus, gainValue: number): void {
+    if (bus.destroyed) {
+      throw new Error(`Cannot add a send to destroyed bus '${bus.name ?? "<anonymous>"}'`);
+    }
+    this._sends.set(bus, gainValue);
+    for (const playback of this.playbacks) {
+      const sendMap = this._playbackSendGains.get(playback) ?? new Map<Bus, GainNode>();
+      const existing = sendMap.get(bus);
+      if (existing) {
+        existing.gain.value = gainValue;
+        continue;
+      }
+      const sendGain = this.context.createGain();
+      sendGain.gain.value = gainValue;
+      try {
+        playback.outputNode.connect(sendGain);
+      } catch {
+        continue;
+      }
+      sendGain.connect(bus.input);
+      sendMap.set(bus, sendGain);
+      this._playbackSendGains.set(playback, sendMap);
+    }
   }
 
   get type(): OscillatorType {

--- a/src/synthPlayback-output.test.ts
+++ b/src/synthPlayback-output.test.ts
@@ -41,6 +41,20 @@ describe("SynthPlayback: outputNode / connect / disconnect parity with Playback"
     synth.stop();
   });
 
+  it("connects and disconnects AudioParam targets", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    const target = cacophony.createBiquadFilter({ frequency: 440 }).frequency;
+    const connectSpy = vi.spyOn(playback.outputNode, "connect");
+    playback.connect(target);
+    expect(connectSpy).toHaveBeenCalledWith(target);
+
+    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
+    playback.disconnect(target);
+    expect(disconnectSpy).toHaveBeenCalledWith(target);
+    synth.stop();
+  });
+
   it("outputNode returns the same GainNode across calls", () => {
     const synth = cacophony.createOscillator({});
     const [playback] = synth.play();

--- a/src/synthPlayback-output.test.ts
+++ b/src/synthPlayback-output.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { cacophony } from "./setupTests";
+
+describe("SynthPlayback: outputNode / connect / disconnect parity with Playback", () => {
+  it("exposes outputNode (a GainNode) on a live synth playback", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    expect(playback.outputNode).toBeDefined();
+    // outputNode should be a GainNode (has .gain.value).
+    expect((playback.outputNode as unknown as { gain: { value: number } }).gain.value).toBeDefined();
+    synth.stop();
+  });
+
+  it("connect(target) delegates to outputNode.connect", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    const target = cacophony.context.createGain();
+    const spy = vi.spyOn(playback.outputNode, "connect");
+    playback.connect(target);
+    expect(spy).toHaveBeenCalledWith(target);
+    synth.stop();
+  });
+
+  it("disconnect() with no args delegates to outputNode.disconnect()", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    const spy = vi.spyOn(playback.outputNode, "disconnect");
+    playback.disconnect();
+    expect(spy).toHaveBeenCalledWith();
+    synth.stop();
+  });
+
+  it("disconnect(target) delegates to outputNode.disconnect(target)", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    const target = cacophony.context.createGain();
+    playback.connect(target);
+    const spy = vi.spyOn(playback.outputNode, "disconnect");
+    playback.disconnect(target);
+    expect(spy).toHaveBeenCalledWith(target);
+    synth.stop();
+  });
+
+  it("outputNode returns the same GainNode across calls", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    const node = playback.outputNode;
+    expect(playback.outputNode).toBe(node);
+    synth.stop();
+  });
+
+  it("connect returns the destination node (for chaining)", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.play();
+    const target = cacophony.context.createGain();
+    const returned = playback.connect(target);
+    // Web Audio convention: connect(destination) returns the destination.
+    expect(returned).toBe(target);
+    synth.stop();
+  });
+});

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -107,6 +107,45 @@ export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(Filte
     this.eventEmitter.removeAllListeners();
   }
 
+  /**
+   * Gets the output node of this synth playback's audio graph — the final
+   * GainNode before connection to the destination. Use this to manually
+   * wire the playback into custom audio graphs.
+   *
+   * @throws if the playback has been cleaned up.
+   */
+  get outputNode(): GainNode {
+    if (!this.gainNode) {
+      throw new Error("Cannot access output node of a synth playback that has been cleaned up");
+    }
+    return this.gainNode;
+  }
+
+  /**
+   * Connects this synth playback's output to an AudioNode. Mirrors
+   * Playback.connect.
+   *
+   * @returns The destination node (for chaining).
+   * @throws if the playback has been cleaned up.
+   */
+  connect(destination: AudioNode): AudioNode {
+    return this.outputNode.connect(destination);
+  }
+
+  /**
+   * Disconnects this synth playback's output from a specific destination
+   * or from all destinations. Mirrors Playback.disconnect.
+   *
+   * @throws if the playback has been cleaned up.
+   */
+  disconnect(destination?: AudioNode): void {
+    if (destination) {
+      this.outputNode.disconnect(destination);
+    } else {
+      this.outputNode.disconnect();
+    }
+  }
+
   private recreateSource(): void {
     if (!this.panner) {
       throw new Error("Cannot recreate source of a synth that has been cleaned up");

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,3 +1,4 @@
+import type { Bus } from "./bus";
 import type { BaseSound } from "./cacophony";
 import type { AudioNode, BaseContext, GainNode, OscillatorNode } from "./context";
 import { FilterManager } from "./filters";
@@ -11,13 +12,27 @@ type SynthPlaybackState = "unplayed" | "playing" | "paused" | "stopped";
 export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(FilterManager))) implements BaseSound {
   context: BaseContext;
   private _state: SynthPlaybackState = "unplayed";
+  /**
+   * Per-playback send-gain allocations: bus → allocated GainNode. Mirrors
+   * {@link Playback._sendGains}. Owned/teardown contract is identical:
+   * Synth allocates send gains at preplay or `routeTo(bus, gain)`; cleanup
+   * walks this map and calls `disconnect()` on every send.
+   */
+  _sendGains: Map<Bus, GainNode> = new Map();
+  /**
+   * Live oscillator node. Set in the constructor; cleared to `undefined` in
+   * {@link cleanup} (matches Playback's `source?` shape so post-cleanup
+   * checks of `!this.source` work uniformly).
+   */
+  public declare source?: OscillatorNode;
   constructor(
     public origin: Synth,
-    public source: OscillatorNode,
+    source: OscillatorNode,
     gainNode: GainNode,
   ) {
     super(origin);
     this.context = origin.context;
+    this.source = source;
     this.setPanType(origin.panType, origin.context);
     // setPanType synchronously assigns this.panner; capture locally so TS
     // narrows to non-undefined for the connect calls below.
@@ -25,7 +40,7 @@ export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(Filte
     if (!panner) {
       throw new Error("setPanType did not produce a panner node");
     }
-    this.source.connect(panner);
+    source.connect(panner);
     this.setGainNode(gainNode);
     panner.connect(gainNode);
     this.refreshFilters();
@@ -99,12 +114,35 @@ export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(Filte
   }
 
   cleanup(): void {
-    if (this.panner && this.gainNode) {
-      this.source.disconnect(this.panner);
-      this.panner.disconnect();
-      this.gainNode.disconnect();
+    if (!this.source) {
+      // Already cleaned up — same idempotency guard as Playback.cleanup.
+      return;
     }
+    if (this.panner && this.gainNode) {
+      try {
+        this.source.disconnect(this.panner);
+      } catch {
+        // Tolerate already-disconnected source.
+      }
+      try {
+        this.panner.disconnect();
+      } catch {}
+    }
+    this.source = undefined;
+    this.panner = undefined;
+    this._state = "stopped";
+    // Tear down per-playback send-gain nodes before super.cleanup() severs
+    // the gainNode edges they feed off of.
+    for (const sendGain of this._sendGains.values()) {
+      try {
+        sendGain.disconnect();
+      } catch {}
+    }
+    this._sendGains.clear();
     this.eventEmitter.removeAllListeners();
+    // super.cleanup() (VolumeMixin) disconnects + clears `gainNode`; after
+    // this call `outputNode` throws (parity with Playback.cleanup).
+    super.cleanup();
   }
 
   /**
@@ -147,7 +185,7 @@ export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(Filte
   }
 
   private recreateSource(): void {
-    if (!this.panner) {
+    if (!this.panner || !this.source) {
       throw new Error("Cannot recreate source of a synth that has been cleaned up");
     }
 

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,6 +1,6 @@
 import type { Bus } from "./bus";
 import type { BaseSound } from "./cacophony";
-import type { AudioNode, BaseContext, GainNode, OscillatorNode } from "./context";
+import type { AudioNode, AudioParam, BaseContext, GainNode, OscillatorNode } from "./context";
 import { FilterManager } from "./filters";
 import { OscillatorMixin } from "./oscillatorMixin";
 import { PannerMixin } from "./pannerMixin";
@@ -160,14 +160,14 @@ export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(Filte
   }
 
   /**
-   * Connects this synth playback's output to an AudioNode. Mirrors
+   * Connects this synth playback's output to an AudioNode or AudioParam. Mirrors
    * Playback.connect.
    *
    * @returns The destination node (for chaining).
    * @throws if the playback has been cleaned up.
    */
-  connect(destination: AudioNode): AudioNode {
-    return this.outputNode.connect(destination);
+  connect(destination: AudioNode | AudioParam): AudioNode {
+    return this.outputNode.connect(destination as any);
   }
 
   /**
@@ -176,9 +176,9 @@ export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(Filte
    *
    * @throws if the playback has been cleaned up.
    */
-  disconnect(destination?: AudioNode): void {
+  disconnect(destination?: AudioNode | AudioParam): void {
     if (destination) {
-      this.outputNode.disconnect(destination);
+      this.outputNode.disconnect(destination as any);
     } else {
       this.outputNode.disconnect();
     }


### PR DESCRIPTION
## ⚠️ Draft — codex re-review pending after BLOCKER fix

Codex's initial review on commit \`040eb68\` returned **do not merge** due to a BLOCKER (master bus structurally not in audible path) plus 3 MAJORs + 1 MINOR + 5 PARTIAL tests. Three fix commits (\`77df699\`, \`4000eff\`, \`928f9c4\`) address all findings per the implementer's report. **Codex re-review has NOT been done** — recommend running it before merging.

## Summary

Adds a routing layer:

- \`Bus\` class — named summing nodes with own filter chain. Sounds route to them via new \`routeTo()\` method.
- Per-edge gain on \`bus.connect(target, gain?)\` — allocates an internal \`GainNode\` for the sendGain. Bacon-shaped sends-as-gained-edges.
- \`CacophonyEffect\` interface for rich effects on bus chains (not Sound chains — Sound stays Biquad-only per scope-out).
- \`cacophony.master: Bus\` — retrofit of \`globalGainNode\` as a Bus instance. \`master.input === globalGainNode\` literally; existing volume/mute unchanged.
- \`cacophony.createReverb()\` returns a \`ReverbEffect\` wrapping the DattorroReverb worklet (was bundled but unused before).
- \`Sound.routeTo(bus | name)\`, \`Sound.routeTo(bus, sendGain)\`, plus \`Synth\` and \`Group\` parity.
- SynthPlayback gets \`outputNode\`/\`connect\`/\`disconnect\` parity with Playback (was missing).
- \`cacophony.shareEffect(node)\` — explicit opt-in escape hatch for sharing raw \`AudioNode\`s in bus chains.

## New public API

\`Bus\`, \`BusConnectionTarget\`, \`CacophonyEffect\`, \`BiquadEffect\`, \`ShareEffect\`, \`ReverbEffect\`, \`ReverbOptions\` exported from \`src/index.ts\`. New methods on Cacophony: \`master\`, \`createBus\`, \`getBus\`, \`listBuses\`, \`shareEffect\`, \`createReverb\`, \`loadDattorroReverb\`, \`createDattorroReverbNode\`.

## Tests

539/539 pass (was 451 + 88 new across 7 + 3 commits). Includes 25-bullet behavior contract coverage from the brief, plus strengthened tests for the 5 PARTIAL bullets codex flagged in original review.

## Scope-out (deferred to followups)

- Sound/Synth/Group own filter chains stay Biquad-only with per-playback clone semantics. Rich effects on Sound chains is a separate L1 PR.
- \`MediaStreamSound\` has no \`routeTo\` (per-instance microphone routing is its own thing).
- No bacon IR serialization — design ideas borrowed, format not.
- No transport/clock/scheduler.

## Review state

- Original brief: \`prompts/l2-buses.md\` (in-repo, not pushed)
- Original L2 commits: \`e6c556f\` \`ec6e365\` \`4151925\` \`9e935b2\` \`e33124a\` \`900585d\` \`040eb68\`
- Codex review of original: CHANGES_REQUESTED — do not merge
- Fix commits per findings: \`77df699\` \`4000eff\` \`928f9c4\`
- **Recommended before un-drafting: codex re-review of the integrated state.**