### PR TITLE
fix: add shebang to husky pre-commit hook for Windows

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,4 @@
+#!/usr/bin/env sh
 npx biome ci .
 npm run typecheck
 npm test


### PR DESCRIPTION
## Summary

\`.husky/pre-commit\` is missing a \`#!/usr/bin/env sh\` shebang line. On Windows, git cannot spawn the hook and reports \`Exec format error\`, forcing contributors to use \`--no-verify\` or \`git -c core.hooksPath= commit\` workarounds.

This PR adds the shebang. The hook's contents (\`npx biome ci .\`, \`npm run typecheck\`, \`npm test\`) are unchanged.

## Tests

No code changes — hook contents not modified. Suite still 451/451 pass.

Verification: \`git commit\` on Windows now runs the hook normally.

## Review

Not codex-reviewed (trivial single-line file change; codex was used on the larger features in this batch).