### PR TITLE
fix(cacophony): tighten format-fallback error classification (PR #82 followup)

### DIFF
--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -966,6 +966,45 @@ describe("Cacophony advanced features", () => {
       expect(sound.soundType).toBe("oscillator");
     });
 
+    it("array with first URL rejecting with a non-DOMException whose name is 'EncodingError' — propagates, does NOT fall back", async () => {
+      const urls = ["https://example.com/a.webm", "https://example.com/a.mp3"];
+      mockCanPlayType({
+        "audio/webm": "probably",
+        "audio/mpeg": "probably",
+      });
+      const spoofedDecodeError = new Error("spoofed encoding error from cache layer");
+      spoofedDecodeError.name = "EncodingError";
+      const getAudioBufferSpy = vi.spyOn(mockCache, "getAudioBuffer").mockRejectedValueOnce(spoofedDecodeError);
+
+      await expect(cacophony.createSound(urls)).rejects.toThrow(/spoofed encoding error from cache layer/);
+      expect(getAudioBufferSpy).toHaveBeenCalledTimes(1);
+      expect(getAudioBufferSpy).toHaveBeenCalledWith(audioContextMock, urls[0], undefined, expect.any(Object));
+    });
+
+    it("array with DOMException EncodingError still falls back (positive regression)", async () => {
+      const urls = ["https://example.com/a.webm", "https://example.com/a.mp3"];
+      const mockBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+      mockCanPlayType({
+        "audio/webm": "maybe",
+        "audio/mpeg": "probably",
+      });
+      const getAudioBufferSpy = vi
+        .spyOn(mockCache, "getAudioBuffer")
+        .mockRejectedValueOnce(new DOMException("Unable to decode audio data", "EncodingError"))
+        .mockResolvedValueOnce(mockBuffer);
+
+      const sound = await cacophony.createSound(urls);
+
+      expect(getAudioBufferSpy).toHaveBeenCalledTimes(2);
+      expect(sound.url).toBe(urls[1]);
+    });
+
+    it("array with soundType='oscillator' — throws not-yet-supported", async () => {
+      await expect(cacophony.createSound(["https://example.com/a.mp3"], "oscillator")).rejects.toThrow(
+        /not yet supported/i,
+      );
+    });
+
     it("array all-failed error message contains per-URL reasons for both codec-unsupported and decode-failed candidates", async () => {
       const urls = [
         "https://example.com/a.webm", // unsupported by canPlayType

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -545,13 +545,14 @@ export class Cacophony {
    * Cache and loading events fire only for the URL actually fetched.
    *
    * v1 limitation: only the default `'buffer'` sound type participates in
-   * fallback. Passing an array together with `'html'` or `'streaming'`
-   * rejects with a clear "not yet supported" error.
+   * fallback. Passing an array with any non-`'buffer'` soundType (e.g.
+   * `'html'`, `'streaming'`, `'oscillator'`) rejects with a clear "not yet
+   * supported" error.
    *
    * @param urls - Non-empty array of candidate URLs in priority order.
-   * @throws If the array is empty, if `soundType` is `'html'`/`'streaming'`,
-   *   or if no candidate is playable (codec unsupported or every decode
-   *   failed). The error message names the URLs that were tried.
+   * @throws If the array is empty, if `soundType` is not `'buffer'`, or if
+   *   no candidate is playable (codec unsupported or every decode failed).
+   *   The error message names the URLs that were tried.
    */
   async createSound(urls: string[], soundType?: SoundType, panType?: PanType, signal?: AbortSignal): Promise<Sound>;
 
@@ -605,11 +606,10 @@ export class Cacophony {
    * format. See `reports/format-fallback-codex-review.md` (Major 1).
    */
   private static isDecodeError(error: unknown): boolean {
-    if (error === null || typeof error !== "object") {
+    if (typeof DOMException === "undefined") {
       return false;
     }
-    const name = (error as { name?: unknown }).name;
-    return name === "EncodingError";
+    return error instanceof DOMException && error.name === "EncodingError";
   }
 
   private async createSoundFromUrlArray(
@@ -621,7 +621,7 @@ export class Cacophony {
     if (urls.length === 0) {
       throw new Error("createSound: URL array is empty; provide at least one URL");
     }
-    if (soundType === "html" || soundType === "streaming") {
+    if (soundType !== "buffer") {
       throw new Error(
         `createSound: URL array with soundType='${soundType}' is not yet supported. ` +
           `Format fallback is only available for buffer sounds in this version.`,


### PR DESCRIPTION
Followup to #82. Addresses both codex findings from
`reports/pr-82-format-fallback-codex-review.md`.

## MAJOR — `isDecodeError` too loose

`src/cacophony.ts:607` previously returned `true` for any object with
`name === "EncodingError"`. A fetch/cache error that happened to carry
that name would silently trigger fallback instead of propagating, in
violation of the documented contract.

Fix: require `error instanceof DOMException` AND `error.name === "EncodingError"`.
Plain `Error` instances now propagate, even if their `.name` was spoofed.

## MINOR — Array path silently accepts `'oscillator'`

`src/cacophony.ts:624` previously rejected only `'html'` and `'streaming'`.
Because the array path always constructs a buffer Sound, a caller passing
`createSound(['x.mp3'], 'oscillator')` was silently downgraded to buffer.

Fix: invert the check — `if (soundType !== 'buffer') throw ...`. Every
non-buffer soundType is now explicitly rejected. JSDoc updated to match.

## Tests

Two new regression tests in `src/cacophony.test.ts`:

- "array with first URL rejecting with a non-DOMException whose name is 'EncodingError' — propagates, does NOT fall back" — proves a spoofed/non-DOMException `EncodingError` propagates and the second URL is not fetched.
- "array with DOMException EncodingError still falls back (positive regression)" — confirms the genuine spec-compliant case still works.
- "array with soundType='oscillator' — throws not-yet-supported".

Both new failure-case tests fail under pre-fix code, pass after.

## Verification

- `npm run typecheck` — clean
- `npm test` — 488/488 passing