### PR TITLE
fix(autoplay): skip unlock listeners when context.resume is missing

### DIFF
--- a/src/autoplayUnlock.test.ts
+++ b/src/autoplayUnlock.test.ts
@@ -2,6 +2,7 @@ import { AudioBuffer, AudioContext } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Cacophony } from "./cacophony";
+import { installAutoplayUnlock } from "./autoplayUnlock";
 import type { BaseContext, AudioBuffer as CacophonyAudioBuffer } from "./context";
 import { mockCache } from "./setupTests";
 
@@ -352,6 +353,36 @@ describe("Autoplay unlock", () => {
       expect(stopSpy).toHaveBeenCalledWith(0);
       // start must precede stop
       expect(startSpy.mock.invocationCallOrder[0]).toBeLessThan(stopSpy.mock.invocationCallOrder[0]);
+    });
+  });
+
+  describe("missing resume() on context", () => {
+    it("does NOT install gesture listeners when context.resume is not a function", () => {
+      const doc = installMockDocument();
+      // Hand-built minimal BaseContext-like stub: suspended, no resume method.
+      // Models the optional-resume shape declared at src/context.ts:182 and the
+      // codex PR-#81 finding — installing listeners is pointless when we can't
+      // actually unlock the context, and would cause `unlock` to fire while
+      // `Cacophony.locked` stays true (locked is derived from state).
+      const stub = {
+        state: "suspended",
+        sampleRate: 44100,
+        // No `resume` property at all.
+      } as unknown as BaseContext;
+
+      const onUnlock = vi.fn();
+      const cleanup = installAutoplayUnlock({ context: stub, onUnlock });
+
+      expect(doc.addEventListenerSpy).not.toHaveBeenCalled();
+      expect(typeof cleanup).toBe("function");
+      // Cleanup must be a safe no-op.
+      expect(() => cleanup()).not.toThrow();
+
+      // And no gesture path could have fired onUnlock (nothing listening).
+      doc.fire("click");
+      doc.fire("touchend");
+      doc.fire("keydown");
+      expect(onUnlock).not.toHaveBeenCalled();
     });
   });
 

--- a/src/autoplayUnlock.ts
+++ b/src/autoplayUnlock.ts
@@ -80,6 +80,17 @@ export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
     return () => {};
   }
 
+  // `BaseContext.resume` is optional. If this context has no resume() we
+  // cannot actually unlock it — installing gesture listeners would be noise,
+  // and firing the `unlock` event without a fulfilled resume() would violate
+  // the contract (caller would see `unlock` while `Cacophony.locked` stays
+  // true, since `locked` is derived from `context.state === "suspended"`).
+  // Treat the absence as "this context isn't ours to unlock" and bail.
+  const resume = (context as unknown as { resume?: () => Promise<void> }).resume;
+  if (typeof resume !== "function") {
+    return () => {};
+  }
+
   const doc = document as unknown as DocumentLike;
   const target: EventTargetLike = (doc.body as EventTargetLike | null | undefined) ?? doc;
 
@@ -132,30 +143,20 @@ export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
     // Resume the context, then emit unlock. The `unlock` event signals that
     // audio is actually playable, so we must wait for resume() to fulfill
     // before emitting. On rejection we surface the error and do NOT emit
-    // unlock — a failed resume is not an unlock.
-    const resume = (context as unknown as { resume?: () => Promise<void> }).resume;
-    if (typeof resume === "function") {
-      resume.call(context).then(
-        () => {
-          try {
-            onUnlock();
-          } catch (err) {
-            console.error("[cacophony/autoplayUnlock] onUnlock callback threw:", err);
-          }
-        },
-        (err: unknown) => {
-          console.warn("[cacophony/autoplayUnlock] resume failed:", err);
-        },
-      );
-    } else {
-      // No resume() available (unusual, but possible in stubbed contexts).
-      // The primer is enough to consider the context unlocked.
-      try {
-        onUnlock();
-      } catch (err) {
-        console.error("[cacophony/autoplayUnlock] onUnlock callback threw:", err);
-      }
-    }
+    // unlock — a failed resume is not an unlock. `resume` is guaranteed to
+    // be a function here (guarded at install time above).
+    resume.call(context).then(
+      () => {
+        try {
+          onUnlock();
+        } catch (err) {
+          console.error("[cacophony/autoplayUnlock] onUnlock callback threw:", err);
+        }
+      },
+      (err: unknown) => {
+        console.warn("[cacophony/autoplayUnlock] resume failed:", err);
+      },
+    );
   };
 
   for (const type of UNLOCK_EVENT_TYPES) {


### PR DESCRIPTION
## Summary

Addresses the single MEDIUM finding from the codex review of PR #81
(`reports/pr-81-autoplay-unlock-codex-review.md`).

`BaseContext.resume` is typed optional (`src/context.ts:182`). Before
this change, when a suspended context had no `resume` method the gesture
handler took a fallback branch and called `onUnlock()` anyway, emitting
the public `unlock` event while `Cacophony.locked` stayed `true` (locked
is derived from `context.state === "suspended"`, and the absent
`resume()` never transitions state). That violates the PR's documented
contract that `unlock` means `resume()` fulfilled.

## Approach

**Approach A** from the review — guard at install time. If
`context.resume` is not a function we cannot actually unlock the
context, so installing one-time `touchend`/`click`/`keydown` listeners
is noise; return a no-op cleanup. The handler's now-dead no-resume
fallback branch is removed.

## Test plan

- [x] New regression test in `src/autoplayUnlock.test.ts`
  ("missing resume() on context") constructs a suspended `BaseContext`
  stub without a `resume` property, calls `installAutoplayUnlock`
  directly, and asserts no listeners are installed and `onUnlock` is
  never invoked.
- [x] Test verified to FAIL against pre-fix code, PASS after.
- [x] `npm run typecheck` clean.
- [x] `npm test` — 486 passed across 21 files, including all 20
  autoplay-unlock cases.