### PR TITLE
Add live bus draining and filter-chain controls

### DIFF
--- a/src/bus-drainto.test.ts
+++ b/src/bus-drainto.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for Bus.drainTo / Bus.destroy({ drainTo }) and the inbound
+ * source-tracking that backs it. A draining bus moves every source routed to
+ * it (primary route and/or send) onto a target bus before teardown, so live
+ * playbacks keep feeding a live bus instead of the dead `input`.
+ */
+
+import { AudioBuffer } from "standardized-audio-context-mock";
+import { describe, expect, it, vi } from "vitest";
+import { cacophony } from "./setupTests";
+
+const buildSound = async () => {
+  const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+  return cacophony.createSound(buffer as unknown as AudioBuffer);
+};
+
+describe("Bus.drainTo: primary route", () => {
+  it("reroutes a playing primary-routed sound onto the target bus", async () => {
+    const sound = await buildSound();
+    const busA = cacophony.createBus("drain-primary-a");
+    const busB = cacophony.createBus("drain-primary-b");
+    sound.routeTo(busA);
+    const [playback] = sound.play();
+    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
+    const connectSpy = vi.spyOn(playback.outputNode, "connect");
+
+    busA.drainTo(busB);
+
+    // _routeTarget is now busB.
+    expect((sound as unknown as { _routeTarget: unknown })._routeTarget).toBe(busB);
+    // Live playback was rewired off busA.input onto busB.input.
+    expect(disconnectSpy).toHaveBeenCalledWith(busA.input);
+    expect(connectSpy).toHaveBeenCalledWith(busB.input);
+
+    busA.destroy();
+    busB.destroy();
+  });
+});
+
+describe("Bus.drainTo: send", () => {
+  it("moves a send (preserving gain) and rewires the per-playback sendGain", async () => {
+    const sound = await buildSound();
+    const busA = cacophony.createBus("drain-send-a");
+    const busB = cacophony.createBus("drain-send-b");
+    sound.routeTo(busA, 0.3);
+    const [playback] = sound.play();
+
+    const oldSendGain = playback._sendGains.get(busA);
+    expect(oldSendGain).toBeDefined();
+    const oldSendGainDisconnect = vi.spyOn(oldSendGain!, "disconnect");
+
+    // Capture the new sendGain that _addSend(busB, ...) will allocate so we can
+    // assert its outgoing edge targets busB.input.
+    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
+    const allocated: Array<{ node: any; connect: ReturnType<typeof vi.fn> }> = [];
+    vi.spyOn(cacophony.context, "createGain").mockImplementationOnce(() => {
+      const node = realCreateGain();
+      const connectSpy = vi.fn(node.connect.bind(node));
+      Object.assign(node, { connect: connectSpy });
+      allocated.push({ node, connect: connectSpy });
+      return node;
+    });
+
+    busA.drainTo(busB);
+
+    const sends = (sound as unknown as { _sends: Map<unknown, number> })._sends;
+    expect(sends.has(busA)).toBe(false);
+    expect(sends.get(busB)).toBe(0.3);
+    // Old per-playback sendGain to busA was disconnected and dropped.
+    expect(oldSendGainDisconnect).toHaveBeenCalled();
+    expect(playback._sendGains.has(busA)).toBe(false);
+    // New sendGain → busB.input.
+    expect(allocated.length).toBe(1);
+    expect(allocated[0]?.node.gain.value).toBe(0.3);
+    expect(allocated[0]?.connect).toHaveBeenCalledWith(busB.input);
+
+    busA.destroy();
+    busB.destroy();
+  });
+});
+
+describe("Bus.destroy({ drainTo })", () => {
+  it("reroutes then destroys", async () => {
+    const sound = await buildSound();
+    const busA = cacophony.createBus("destroy-drain-a");
+    const busB = cacophony.createBus("destroy-drain-b");
+    sound.routeTo(busA);
+    sound.play();
+
+    busA.destroy({ drainTo: busB });
+
+    expect(busA.destroyed).toBe(true);
+    expect((sound as unknown as { _routeTarget: unknown })._routeTarget).toBe(busB);
+
+    busB.destroy();
+  });
+
+  it("default destroy() does NOT reroute — sound stays on _routeTarget = busA", async () => {
+    const sound = await buildSound();
+    const busA = cacophony.createBus("destroy-no-drain");
+    sound.routeTo(busA);
+    const [playback] = sound.play();
+    // No live rewire to master should happen at destroy time.
+    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
+    const connectSpy = vi.spyOn(playback.outputNode, "connect");
+
+    busA.destroy();
+
+    expect(busA.destroyed).toBe(true);
+    expect((sound as unknown as { _routeTarget: unknown })._routeTarget).toBe(busA);
+    expect(disconnectSpy).not.toHaveBeenCalled();
+    expect(connectSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("Bus.drainTo: unregister on bus-identity change with unchanged resolved node", () => {
+  it("rerouting off a destroyed bus to master unregisters the sound from the old bus", async () => {
+    const sound = await buildSound();
+    const busA = cacophony.createBus("identity-unreg-a");
+    // Route a playing sound to busA; the sound registers in busA._routedSources.
+    sound.routeTo(busA);
+    sound.play();
+    const routedSources = (busA as unknown as { _routedSources: Set<unknown> })._routedSources;
+    expect(routedSources.has(sound)).toBe(true);
+
+    // Destroy busA with NO drain. _routeTarget stays busA; the destroyed bus now
+    // resolves to globalGainNode (master) at preplay/_resolveRouteTargetNode.
+    busA.destroy();
+    expect(routedSources.has(sound)).toBe(true);
+
+    // Reroute to master. oldTargetNode (destroyed busA -> globalGainNode) and
+    // newTargetNode (master -> globalGainNode) are EQUAL, so the old
+    // node-equality early-return would have skipped the unregister. The fix
+    // drives the unregister off the BUS-identity change instead.
+    sound.routeTo(cacophony.master);
+
+    // The sound is no longer leaked in busA's source-tracking.
+    expect(routedSources.has(sound)).toBe(false);
+    // _routeTarget collapsed to master (null).
+    expect((sound as unknown as { _routeTarget: unknown })._routeTarget).toBe(null);
+
+    // A subsequent cleanup must not throw and fully detaches the sound.
+    expect(() => sound.cleanup()).not.toThrow();
+  });
+});
+
+describe("Bus.drainTo: guards", () => {
+  it("throws when draining a bus to itself", () => {
+    const bus = cacophony.createBus("drain-self");
+    expect(() => bus.drainTo(bus)).toThrow(/itself/);
+    bus.destroy();
+  });
+
+  it("throws when draining a destroyed bus", () => {
+    const busA = cacophony.createBus("drain-dead-a");
+    const busB = cacophony.createBus("drain-dead-b");
+    busA.destroy();
+    expect(() => busA.drainTo(busB)).toThrow(/destroyed/);
+    busB.destroy();
+  });
+});
+
+describe("Bus.drainTo: registration cleanup", () => {
+  it("does not touch a sound that was cleaned up before the bus drains", async () => {
+    const sound = await buildSound();
+    const busA = cacophony.createBus("drain-cleanup-a");
+    const busB = cacophony.createBus("drain-cleanup-b");
+    sound.routeTo(busA);
+    sound.routeTo(busA, 0.5);
+    sound.play();
+
+    // Cleanup unregisters the sound from busA's source-tracking.
+    sound.cleanup();
+    const onDrainedSpy = vi.spyOn(sound, "_onBusDrained");
+
+    // Draining the now-empty bus must not reach the dead sound (no throw).
+    expect(() => busA.drainTo(busB)).not.toThrow();
+    expect(onDrainedSpy).not.toHaveBeenCalled();
+
+    busA.destroy();
+    busB.destroy();
+  });
+});

--- a/src/bus-drainto.test.ts
+++ b/src/bus-drainto.test.ts
@@ -161,6 +161,38 @@ describe("Bus.drainTo: guards", () => {
 });
 
 describe("Bus.drainTo: registration cleanup", () => {
+  it("keeps a sound registered with a bus when primary reroute leaves a send behind", async () => {
+    const sound = await buildSound();
+    const busA = cacophony.createBus("drain-send-only-a");
+    const busB = cacophony.createBus("drain-send-only-b");
+    const busC = cacophony.createBus("drain-send-only-c");
+    sound.routeTo(busA);
+    sound.routeTo(busA, 0.45);
+    const [playback] = sound.play();
+
+    sound.routeTo(busB);
+
+    const routedSources = (busA as unknown as { _routedSources: Set<unknown> })._routedSources;
+    expect(routedSources.has(sound)).toBe(true);
+
+    const oldSendGain = playback._sendGains.get(busA);
+    expect(oldSendGain).toBeDefined();
+    const oldSendGainDisconnect = vi.spyOn(oldSendGain!, "disconnect");
+
+    busA.drainTo(busC);
+
+    const sends = (sound as unknown as { _sends: Map<unknown, number> })._sends;
+    expect((sound as unknown as { _routeTarget: unknown })._routeTarget).toBe(busB);
+    expect(sends.has(busA)).toBe(false);
+    expect(sends.get(busC)).toBe(0.45);
+    expect(playback._sendGains.has(busA)).toBe(false);
+    expect(oldSendGainDisconnect).toHaveBeenCalled();
+
+    busA.destroy();
+    busB.destroy();
+    busC.destroy();
+  });
+
   it("does not touch a sound that was cleaned up before the bus drains", async () => {
     const sound = await buildSound();
     const busA = cacophony.createBus("drain-cleanup-a");

--- a/src/bus-drainto.test.ts
+++ b/src/bus-drainto.test.ts
@@ -79,6 +79,50 @@ describe("Bus.drainTo: send", () => {
   });
 });
 
+describe("Bus.drainTo: synth sources", () => {
+  it("reroutes a playing primary-routed synth onto the target bus", () => {
+    const synth = cacophony.createOscillator({});
+    const busA = cacophony.createBus("drain-synth-primary-a");
+    const busB = cacophony.createBus("drain-synth-primary-b");
+    synth.routeTo(busA);
+    const [playback] = synth.play();
+    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
+    const connectSpy = vi.spyOn(playback.outputNode, "connect");
+
+    busA.drainTo(busB);
+
+    expect((synth as unknown as { _routeTarget: unknown })._routeTarget).toBe(busB);
+    expect(disconnectSpy).toHaveBeenCalledWith(busA.input);
+    expect(connectSpy).toHaveBeenCalledWith(busB.input);
+
+    busA.destroy();
+    busB.destroy();
+  });
+
+  it("moves a synth send when the sending bus drains", () => {
+    const synth = cacophony.createOscillator({});
+    const busA = cacophony.createBus("drain-synth-send-a");
+    const busB = cacophony.createBus("drain-synth-send-b");
+    synth.routeTo(busA, 0.25);
+    const [playback] = synth.play();
+
+    const oldSendGain = playback._sendGains.get(busA);
+    expect(oldSendGain).toBeDefined();
+    const oldSendGainDisconnect = vi.spyOn(oldSendGain!, "disconnect");
+
+    busA.drainTo(busB);
+
+    const sends = (synth as unknown as { _sends: Map<unknown, number> })._sends;
+    expect(sends.has(busA)).toBe(false);
+    expect(sends.get(busB)).toBe(0.25);
+    expect(playback._sendGains.has(busA)).toBe(false);
+    expect(oldSendGainDisconnect).toHaveBeenCalled();
+
+    busA.destroy();
+    busB.destroy();
+  });
+});
+
 describe("Bus.destroy({ drainTo })", () => {
   it("reroutes then destroys", async () => {
     const sound = await buildSound();

--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -587,3 +587,221 @@ describe("Bus: rampFilterParam", () => {
     expect(() => bus.rampFilterParam(node, "frequency", 1)).toThrow();
   });
 });
+
+describe("Bus: per-filter bypass", () => {
+  it("bypassing a middle filter skips it (input → f1 → f3 → output) and preserves filters order", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    const f3 = cacophony.createBiquadFilter({ frequency: 300 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    await bus.addFilter(f3);
+    // Chain is now input → f1 → f2 → f3 → output.
+
+    const f1Connect = vi.spyOn(f1, "connect");
+    const f1Disconnect = vi.spyOn(f1, "disconnect");
+    const f2Connect = vi.spyOn(f2, "connect");
+    const f2Disconnect = vi.spyOn(f2, "disconnect");
+
+    bus.setFilterBypassed(f2, true);
+    // Chain is now input → f1 → f3 → output, with f2 skipped.
+
+    // The two edges around f2 (f1 → f2 and f2 → f3) are disconnected.
+    expect(f1Disconnect).toHaveBeenCalledTimes(1);
+    expect(f1Disconnect).toHaveBeenCalledWith(f2);
+    expect(f2Disconnect).toHaveBeenCalledTimes(1);
+    expect(f2Disconnect).toHaveBeenCalledWith(f3);
+    // The single bridging edge f1 → f3 is connected.
+    expect(f1Connect).toHaveBeenCalledTimes(1);
+    expect(f1Connect).toHaveBeenCalledWith(f3);
+    // f2 receives no inbound connect (nothing wires into a bypassed node).
+    expect(f2Connect).not.toHaveBeenCalled();
+
+    // filters STILL reports all three in order; identity preserved.
+    expect(bus.filters).toEqual([f1, f2, f3]);
+    expect(bus.isFilterBypassed(f2)).toBe(true);
+    expect(bus.isFilterBypassed(f1)).toBe(false);
+    expect(bus.isFilterBypassed(f3)).toBe(false);
+  });
+
+  it("un-bypassing restores the node incrementally (f1 → f3 dropped, f1 → f2 and f2 → f3 reconnected)", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    const f3 = cacophony.createBiquadFilter({ frequency: 300 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    await bus.addFilter(f3);
+    bus.setFilterBypassed(f2, true);
+    // Chain is now input → f1 → f3 → output.
+
+    const f1Connect = vi.spyOn(f1, "connect");
+    const f1Disconnect = vi.spyOn(f1, "disconnect");
+    const f2Connect = vi.spyOn(f2, "connect");
+
+    bus.setFilterBypassed(f2, false);
+    // Chain is back to input → f1 → f2 → f3 → output.
+
+    // The bridging edge f1 → f3 is dropped.
+    expect(f1Disconnect).toHaveBeenCalledTimes(1);
+    expect(f1Disconnect).toHaveBeenCalledWith(f3);
+    // f1 → f2 and f2 → f3 are reconnected.
+    expect(f1Connect).toHaveBeenCalledTimes(1);
+    expect(f1Connect).toHaveBeenCalledWith(f2);
+    expect(f2Connect).toHaveBeenCalledTimes(1);
+    expect(f2Connect).toHaveBeenCalledWith(f3);
+
+    expect(bus.filters).toEqual([f1, f2, f3]);
+    expect(bus.isFilterBypassed(f2)).toBe(false);
+  });
+
+  it("bypassing the head wires input → f2", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    // Chain is now input → f1 → f2 → output.
+
+    const inputConnect = vi.spyOn(bus.input, "connect");
+
+    bus.setFilterBypassed(f1, true);
+    // Chain is now input → f2 → output (f1 skipped).
+
+    expect(inputConnect).toHaveBeenCalledTimes(1);
+    expect(inputConnect).toHaveBeenCalledWith(f2);
+    expect(bus.filters).toEqual([f1, f2]);
+    expect(bus.isFilterBypassed(f1)).toBe(true);
+  });
+
+  it("bypassing the tail wires f1 → output", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    // Chain is now input → f1 → f2 → output.
+
+    const f1Connect = vi.spyOn(f1, "connect");
+
+    bus.setFilterBypassed(f2, true);
+    // Chain is now input → f1 → output (f2 skipped).
+
+    expect(f1Connect).toHaveBeenCalledTimes(1);
+    expect(f1Connect).toHaveBeenCalledWith(bus.output);
+    expect(bus.filters).toEqual([f1, f2]);
+    expect(bus.isFilterBypassed(f2)).toBe(true);
+  });
+
+  it("bypassing every filter collapses to the direct input → output edge", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    const f3 = cacophony.createBiquadFilter({ frequency: 300 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    await bus.addFilter(f3);
+
+    bus.setFilterBypassed(f1, true);
+    bus.setFilterBypassed(f2, true);
+
+    const inputConnect = vi.spyOn(bus.input, "connect");
+    bus.setFilterBypassed(f3, true);
+    // With all three bypassed the desired chain is the direct edge.
+
+    expect(inputConnect).toHaveBeenCalledTimes(1);
+    expect(inputConnect).toHaveBeenCalledWith(bus.output);
+    expect(bus.filters).toEqual([f1, f2, f3]);
+    expect(bus.isFilterBypassed(f1)).toBe(true);
+    expect(bus.isFilterBypassed(f2)).toBe(true);
+    expect(bus.isFilterBypassed(f3)).toBe(true);
+  });
+
+  it("a bypassed node's params survive: rampFilterParam still schedules on it", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const biquad = cacophony.createBiquadFilter({ frequency: 100 });
+    const node = await bus.addFilter(biquad);
+
+    bus.setFilterBypassed(node, true);
+
+    const freq = (
+      biquad as unknown as {
+        frequency: { setValueAtTime: (v: number, t: number) => unknown };
+      }
+    ).frequency;
+    const setSpy = vi.spyOn(freq, "setValueAtTime");
+
+    // The node is alive (still in _filterNodes), just unwired — automation works.
+    expect(() => bus.rampFilterParam(node, "frequency", 800)).not.toThrow();
+    expect(setSpy).toHaveBeenCalledTimes(1);
+
+    setSpy.mockRestore();
+  });
+
+  it("setFilterBypassed throws for a node that was never added", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const onBus = cacophony.createBiquadFilter({ frequency: 100 });
+    await bus.addFilter(onBus);
+    const foreign = cacophony.createBiquadFilter({ frequency: 999 });
+
+    expect(() => bus.setFilterBypassed(foreign, true)).toThrow(/never added/);
+  });
+
+  it("setFilterBypassed throws after the bus is destroyed", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    await bus.addFilter(f1);
+    bus.destroy();
+    expect(() => bus.setFilterBypassed(f1, true)).toThrow(/destroyed/);
+  });
+
+  it("removing a bypassed node clears its bypass; re-adding wires it back into the chain", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+
+    bus.setFilterBypassed(f2, true);
+    expect(bus.isFilterBypassed(f2)).toBe(true);
+
+    bus.removeFilter(f2);
+    expect(bus.filters).toEqual([f1]);
+
+    const f1Connect = vi.spyOn(f1, "connect");
+    await bus.addFilter(f2);
+    // Chain is now input → f1 → f2 → output again — not phantom-bypassed.
+
+    expect(bus.isFilterBypassed(f2)).toBe(false);
+    expect(bus.filters).toEqual([f1, f2]);
+    expect(f1Connect).toHaveBeenCalledWith(f2);
+  });
+
+  it("isFilterBypassed returns false for a node that was never added", () => {
+    const bus = new Bus(cacophony.context, null);
+    const foreign = cacophony.createBiquadFilter({ frequency: 100 });
+    expect(bus.isFilterBypassed(foreign)).toBe(false);
+  });
+
+  it("setFilterBypassed to the same state is a no-op (no chain churn)", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    bus.setFilterBypassed(f1, true);
+
+    const inputConnect = vi.spyOn(bus.input, "connect");
+    const inputDisconnect = vi.spyOn(bus.input, "disconnect");
+    const f2Connect = vi.spyOn(f2, "connect");
+
+    // Already bypassed → no-op.
+    bus.setFilterBypassed(f1, true);
+
+    expect(inputConnect).not.toHaveBeenCalled();
+    expect(inputDisconnect).not.toHaveBeenCalled();
+    expect(f2Connect).not.toHaveBeenCalled();
+    expect(bus.isFilterBypassed(f1)).toBe(true);
+  });
+});

--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -435,3 +435,155 @@ describe("Bus: filter chain refresh", () => {
     expect(() => bus.setFilterOrder([f1, f2, f2])).toThrow(/permutation/);
   });
 });
+
+describe("Bus: addFilter returns the built node", () => {
+  it("returns the same node it added (a biquad)", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const biquad = cacophony.createBiquadFilter({ frequency: 100 });
+    const n = await bus.addFilter(biquad);
+    expect(n).toBe(biquad);
+    expect(bus.filters.includes(n)).toBe(true);
+  });
+});
+
+describe("Bus: rampFilterParam", () => {
+  it("ramps a native biquad param linearly, pinning the start", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const biquad = cacophony.createBiquadFilter({ frequency: 100 });
+    const node = await bus.addFilter(biquad);
+    // The mocked context exposes a real `.frequency` AudioParam with the ramp
+    // scheduling methods.
+    const freq = (
+      biquad as unknown as {
+        frequency: {
+          value: number;
+          setValueAtTime: (v: number, t: number) => unknown;
+          linearRampToValueAtTime: (v: number, t: number) => unknown;
+        };
+      }
+    ).frequency;
+    const now = (node as unknown as { context: { currentTime: number } }).context.currentTime;
+    const startValue = freq.value;
+
+    const setSpy = vi.spyOn(freq, "setValueAtTime");
+    const linSpy = vi.spyOn(freq, "linearRampToValueAtTime");
+
+    bus.rampFilterParam(node, "frequency", 800, { duration: 500 });
+
+    // Start pinned at the current value, then a linear ramp to the target.
+    expect(setSpy).toHaveBeenCalledWith(startValue, now);
+    expect(linSpy).toHaveBeenCalledTimes(1);
+    const [rampValue, endTime] = linSpy.mock.calls[0] as [number, number];
+    expect(rampValue).toBe(800);
+    expect(endTime).toBeCloseTo(now + 0.5, 10);
+
+    setSpy.mockRestore();
+    linSpy.mockRestore();
+  });
+
+  it("sets the value instantly when duration is omitted", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const biquad = cacophony.createBiquadFilter({ frequency: 100 });
+    const node = await bus.addFilter(biquad);
+    const freq = (
+      biquad as unknown as {
+        frequency: {
+          setValueAtTime: (v: number, t: number) => unknown;
+          linearRampToValueAtTime: (v: number, t: number) => unknown;
+          exponentialRampToValueAtTime: (v: number, t: number) => unknown;
+        };
+      }
+    ).frequency;
+    const now = (node as unknown as { context: { currentTime: number } }).context.currentTime;
+
+    const setSpy = vi.spyOn(freq, "setValueAtTime");
+    const linSpy = vi.spyOn(freq, "linearRampToValueAtTime");
+    const expSpy = vi.spyOn(freq, "exponentialRampToValueAtTime");
+
+    bus.rampFilterParam(node, "frequency", 800);
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(setSpy).toHaveBeenCalledWith(800, now);
+    expect(linSpy).not.toHaveBeenCalled();
+    expect(expSpy).not.toHaveBeenCalled();
+
+    setSpy.mockRestore();
+    linSpy.mockRestore();
+    expSpy.mockRestore();
+  });
+
+  it("uses an exponential ramp when type is 'exponential'", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const biquad = cacophony.createBiquadFilter({ frequency: 100 });
+    const node = await bus.addFilter(biquad);
+    const freq = (
+      biquad as unknown as {
+        frequency: {
+          value: number;
+          setValueAtTime: (v: number, t: number) => unknown;
+          linearRampToValueAtTime: (v: number, t: number) => unknown;
+          exponentialRampToValueAtTime: (v: number, t: number) => unknown;
+        };
+      }
+    ).frequency;
+    const now = (node as unknown as { context: { currentTime: number } }).context.currentTime;
+
+    const setSpy = vi.spyOn(freq, "setValueAtTime");
+    const linSpy = vi.spyOn(freq, "linearRampToValueAtTime");
+    const expSpy = vi.spyOn(freq, "exponentialRampToValueAtTime");
+
+    bus.rampFilterParam(node, "frequency", 800, { type: "exponential", duration: 200 });
+
+    expect(setSpy).toHaveBeenCalledWith(freq.value, now);
+    expect(linSpy).not.toHaveBeenCalled();
+    expect(expSpy).toHaveBeenCalledTimes(1);
+    const [rampValue, endTime] = expSpy.mock.calls[0] as [number, number];
+    expect(rampValue).toBe(800);
+    expect(endTime).toBeCloseTo(now + 0.2, 10);
+
+    setSpy.mockRestore();
+    linSpy.mockRestore();
+    expSpy.mockRestore();
+  });
+
+  it("warns and no-ops (no throw) when the node is not on the bus", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const onBus = cacophony.createBiquadFilter({ frequency: 100 });
+    await bus.addFilter(onBus);
+    const notOnBus = cacophony.createBiquadFilter({ frequency: 200 });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const freq = (notOnBus as unknown as { frequency: { setValueAtTime: (v: number, t: number) => unknown } })
+      .frequency;
+    const setSpy = vi.spyOn(freq, "setValueAtTime");
+
+    expect(() => bus.rampFilterParam(notOnBus, "frequency", 1)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    // No scheduling happened on a node that is not on the bus.
+    expect(setSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    setSpy.mockRestore();
+  });
+
+  it("warns and no-ops (no throw) for a bogus param name on a valid node", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const biquad = cacophony.createBiquadFilter({ frequency: 100 });
+    const node = await bus.addFilter(biquad);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(() => bus.rampFilterParam(node, "totallyBogusParam", 1)).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it("throws only when the bus has been destroyed", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const biquad = cacophony.createBiquadFilter({ frequency: 100 });
+    const node = await bus.addFilter(biquad);
+    bus.destroy();
+    expect(() => bus.rampFilterParam(node, "frequency", 1)).toThrow();
+  });
+});

--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -318,4 +318,120 @@ describe("Bus: filter chain refresh", () => {
     const filter = cacophony.createBiquadFilter({ frequency: 100 });
     expect(() => bus.removeFilter(filter)).toThrow(/never added/);
   });
+
+  it("adding a filter only touches the changed tail edge, not the unchanged head", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    const f3 = cacophony.createBiquadFilter({ frequency: 300 });
+    const f4 = cacophony.createBiquadFilter({ frequency: 400 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    await bus.addFilter(f3);
+    // Chain is now input → f1 → f2 → f3 → output.
+
+    const inputConnect = vi.spyOn(bus.input, "connect");
+    const inputDisconnect = vi.spyOn(bus.input, "disconnect");
+    const f1Connect = vi.spyOn(f1, "connect");
+    const f1Disconnect = vi.spyOn(f1, "disconnect");
+    const f2Connect = vi.spyOn(f2, "connect");
+    const f2Disconnect = vi.spyOn(f2, "disconnect");
+    const f3Connect = vi.spyOn(f3, "connect");
+    const f3Disconnect = vi.spyOn(f3, "disconnect");
+    const f4Connect = vi.spyOn(f4, "connect");
+
+    await bus.addFilter(f4);
+    // Chain is now input → f1 → f2 → f3 → f4 → output.
+
+    // The only edge removed is the old f3 → output tail.
+    expect(f3Disconnect).toHaveBeenCalledTimes(1);
+    expect(f3Disconnect).toHaveBeenCalledWith(bus.output);
+    // The only new edges are f3 → f4 and f4 → output.
+    expect(f3Connect).toHaveBeenCalledTimes(1);
+    expect(f3Connect).toHaveBeenCalledWith(f4);
+    expect(f4Connect).toHaveBeenCalledTimes(1);
+    expect(f4Connect).toHaveBeenCalledWith(bus.output);
+
+    // The unchanged head input → f1 → f2 → f3 is untouched.
+    expect(inputConnect).not.toHaveBeenCalled();
+    expect(inputDisconnect).not.toHaveBeenCalled();
+    expect(f1Connect).not.toHaveBeenCalled();
+    expect(f1Disconnect).not.toHaveBeenCalled();
+    expect(f2Connect).not.toHaveBeenCalled();
+    expect(f2Disconnect).not.toHaveBeenCalled();
+
+    expect(bus.filters).toEqual([f1, f2, f3, f4]);
+  });
+
+  it("removing a middle filter only touches the edges around it", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    const f3 = cacophony.createBiquadFilter({ frequency: 300 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    await bus.addFilter(f3);
+    // Chain is now input → f1 → f2 → f3 → output.
+
+    const inputConnect = vi.spyOn(bus.input, "connect");
+    const inputDisconnect = vi.spyOn(bus.input, "disconnect");
+    const f1Connect = vi.spyOn(f1, "connect");
+    const f1Disconnect = vi.spyOn(f1, "disconnect");
+    const f2Connect = vi.spyOn(f2, "connect");
+    const f2Disconnect = vi.spyOn(f2, "disconnect");
+    const f3Connect = vi.spyOn(f3, "connect");
+    const f3Disconnect = vi.spyOn(f3, "disconnect");
+
+    bus.removeFilter(f2);
+    // Chain is now input → f1 → f3 → output.
+
+    // f2's two edges (f1 → f2 and f2 → f3) are disconnected.
+    expect(f1Disconnect).toHaveBeenCalledTimes(1);
+    expect(f1Disconnect).toHaveBeenCalledWith(f2);
+    expect(f2Disconnect).toHaveBeenCalledTimes(1);
+    expect(f2Disconnect).toHaveBeenCalledWith(f3);
+    // The single new bridging edge f1 → f3 is connected.
+    expect(f1Connect).toHaveBeenCalledTimes(1);
+    expect(f1Connect).toHaveBeenCalledWith(f3);
+
+    // input → f1 and f3 → output are untouched.
+    expect(inputConnect).not.toHaveBeenCalled();
+    expect(inputDisconnect).not.toHaveBeenCalled();
+    expect(f2Connect).not.toHaveBeenCalled();
+    expect(f3Connect).not.toHaveBeenCalled();
+    expect(f3Disconnect).not.toHaveBeenCalled();
+
+    expect(bus.filters).toEqual([f1, f3]);
+  });
+
+  it("setFilterOrder reorders the chain to the supplied permutation", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    const f3 = cacophony.createBiquadFilter({ frequency: 300 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    await bus.addFilter(f3);
+
+    bus.setFilterOrder([f3, f1, f2]);
+    expect(bus.filters).toEqual([f3, f1, f2]);
+  });
+
+  it("setFilterOrder throws when given a non-permutation", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const f1 = cacophony.createBiquadFilter({ frequency: 100 });
+    const f2 = cacophony.createBiquadFilter({ frequency: 200 });
+    const f3 = cacophony.createBiquadFilter({ frequency: 300 });
+    const foreign = cacophony.createBiquadFilter({ frequency: 999 });
+    await bus.addFilter(f1);
+    await bus.addFilter(f2);
+    await bus.addFilter(f3);
+
+    // Wrong length (subset).
+    expect(() => bus.setFilterOrder([f1, f2])).toThrow(/permutation/);
+    // Right length but contains a foreign node.
+    expect(() => bus.setFilterOrder([f1, f2, foreign])).toThrow(/permutation/);
+    // Right length but contains a duplicate.
+    expect(() => bus.setFilterOrder([f1, f2, f2])).toThrow(/permutation/);
+  });
 });

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -171,6 +171,30 @@ export class Bus {
   }
 
   /**
+   * Reorder the existing filter chain. `nodes` must be a PERMUTATION of the
+   * current filters — the same set of node objects (matched by identity), the
+   * same length, with no duplicates — just in a new order. Because
+   * {@link _refreshFilters} is incremental, only the edges that actually move
+   * are reconnected; unchanged edges are left untouched.
+   *
+   * @throws if the bus has been destroyed, or if `nodes` is not a permutation
+   *   of the current filters.
+   */
+  setFilterOrder(nodes: readonly AudioNode[]): void {
+    this._throwIfDestroyed();
+    const isPermutation =
+      nodes.length === this._filterNodes.length &&
+      new Set(nodes).size === nodes.length &&
+      nodes.every((node) => this._filterNodes.includes(node));
+    if (!isPermutation) {
+      throw new Error("setFilterOrder requires a permutation of the current filters");
+    }
+    this._filterNodes.length = 0;
+    this._filterNodes.push(...nodes);
+    this._refreshFilters();
+  }
+
+  /**
    * Connect this bus's output to another bus or to a raw AudioNode.
    *
    * If `gain` is omitted or equal to 1, connect directly (output →
@@ -342,23 +366,57 @@ export class Bus {
   }
 
   /**
-   * Rebuild the chain `input → [filter1 → ... → filterN] → output`. Called
-   * after any add/remove of a filter. Disconnects only the internal chain
-   * edges this bus created, then reapplies the chain. The output node's edges
-   * to downstream targets are not touched.
+   * Reconcile the live chain to `input → [filter1 → ... → filterN] → output`.
+   * Called after any add/remove/reorder of a filter. This is an INCREMENTAL
+   * diff, not a full rebuild: it disconnects only edges that are no longer part
+   * of the desired chain and connects only edges that are newly required,
+   * leaving edges present in both the old and new chain connected and
+   * untouched (no audible click on the unchanged portion of the chain).
+   *
+   * Edges are matched by OBJECT IDENTITY on both endpoints. Only this bus's own
+   * internal `input → ... → output` edges are touched — never a broad
+   * `node.disconnect()`, never the outbound send/direct edges.
    */
   private _refreshFilters(): void {
-    this._disconnectFilterChainEdges();
-    if (this._filterNodes.length === 0) {
-      this._connectFilterChainEdge(this.input, this.output);
-      return;
+    const desired = this._desiredFilterChainEdges();
+    // Disconnect every currently-recorded edge that is not in the desired set.
+    for (const [source, destination] of this._filterChainEdges) {
+      const stillPresent = desired.some(([s, d]) => s === source && d === destination);
+      if (!stillPresent) {
+        try {
+          source.disconnect(destination);
+        } catch {}
+      }
     }
+    // Connect every desired edge that is not already recorded.
+    for (const [source, destination] of desired) {
+      const alreadyConnected = this._filterChainEdges.some(([s, d]) => s === source && d === destination);
+      if (!alreadyConnected) {
+        source.connect(destination);
+      }
+    }
+    // Record the new chain as exactly the desired edge list.
+    this._filterChainEdges.length = 0;
+    this._filterChainEdges.push(...desired);
+  }
+
+  /**
+   * Compute the desired ordered chain edge list from the current
+   * `_filterNodes`: `[[input, output]]` when there are no filters, otherwise
+   * `[[input, f1], [f1, f2], ..., [fN, output]]`.
+   */
+  private _desiredFilterChainEdges(): Array<readonly [AudioNode, AudioNode]> {
+    if (this._filterNodes.length === 0) {
+      return [[this.input, this.output]];
+    }
+    const edges: Array<readonly [AudioNode, AudioNode]> = [];
     let prev: AudioNode = this.input;
     for (const f of this._filterNodes) {
-      this._connectFilterChainEdge(prev, f);
+      edges.push([prev, f]);
       prev = f;
     }
-    this._connectFilterChainEdge(prev, this.output);
+    edges.push([prev, this.output]);
+    return edges;
   }
 
   private _connectFilterChainEdge(source: AudioNode, destination: AudioNode): void {

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -31,6 +31,21 @@ import { isCacophonyBuiltBiquad, isCacophonyEffect } from "./effects";
 export type BusConnectionTarget = Bus | AudioNode;
 
 /**
+ * Structural contract a routed source (e.g. a {@link Sound}) implements so a
+ * Bus can move it off itself before teardown. Declared here — rather than
+ * importing `Sound` — to avoid an import cycle (`sound.ts` already imports
+ * `Bus`). A Bus only ever needs this one method on its inbound sources.
+ */
+export interface BusRoutedSource {
+  /**
+   * Called by {@link Bus.drainTo} to move this source off the draining bus
+   * onto `target`. The source reroutes its primary route and/or any send that
+   * targeted `bus`.
+   */
+  _onBusDrained(bus: Bus, target: Bus): void;
+}
+
+/**
  * A named summing node with a filter chain and per-edge send gain. See
  * module-level docstring for topology.
  */
@@ -55,6 +70,14 @@ export class Bus {
   private readonly _filterChainEdges: Array<readonly [AudioNode, AudioNode]> = [];
   private readonly _sendGains: Map<BusConnectionTarget, GainNode> = new Map();
   private readonly _directConnections: Set<BusConnectionTarget> = new Set();
+  /**
+   * Inbound sources currently routed to this bus (primary route and/or sends).
+   * A Web Audio node cannot enumerate its own inputs, so sources register
+   * themselves here (via {@link _registerRoutedSource}) when they route to
+   * this bus and unregister on reroute/cleanup. {@link drainTo} walks this set
+   * to move live sounds off the bus before it is torn down.
+   */
+  private readonly _routedSources = new Set<BusRoutedSource>();
   /**
    * Hook invoked by the owning Cacophony instance to remove this bus from
    * the named-bus registry on destroy. Anonymous buses leave this undefined.
@@ -233,16 +256,67 @@ export class Bus {
   }
 
   /**
+   * Register an inbound source that routes to this bus (primary and/or send).
+   * Called by the source when it begins routing here. Idempotent (Set). Safe
+   * to call without a destroyed guard — registration during normal routing
+   * must never throw — but a destroyed bus has nothing to drain, so this
+   * early-returns once destroyed.
+   *
+   * @internal
+   */
+  _registerRoutedSource(source: BusRoutedSource): void {
+    if (this._destroyed) {
+      return;
+    }
+    this._routedSources.add(source);
+  }
+
+  /**
+   * Unregister an inbound source (it rerouted away or was cleaned up). No-op
+   * if the source was never registered.
+   *
+   * @internal
+   */
+  _unregisterRoutedSource(source: BusRoutedSource): void {
+    this._routedSources.delete(source);
+  }
+
+  /**
+   * Move every source currently routed to this bus onto `target`, so live
+   * sounds keep feeding a live bus instead of the dead `input` after this bus
+   * is torn down. Each registered source's {@link BusRoutedSource._onBusDrained}
+   * reroutes its primary route and/or the send that targeted this bus.
+   *
+   * @throws if this bus has been destroyed, or if `target` is this bus.
+   */
+  drainTo(target: Bus): void {
+    this._throwIfDestroyed();
+    if (target === this) {
+      throw new Error("Cannot drain a bus to itself");
+    }
+    for (const source of [...this._routedSources]) {
+      source._onBusDrained(this, target);
+    }
+    this._routedSources.clear();
+  }
+
+  /**
    * Tear down the bus — disconnects input, output, every send-gain, every
    * filter, then deregisters from the owner Cacophony's named-bus map.
    * Subsequent `addFilter`/`removeFilter`/`connect`/`disconnect` calls throw.
    *
-   * Sounds routed to a destroyed bus fall back to master on their next
+   * If `options.drainTo` is provided, every source routed to this bus is first
+   * rerouted onto that bus (via {@link drainTo}) so live sounds keep playing
+   * through a live bus. With no options the default teardown is unchanged:
+   * sounds routed to the destroyed bus fall back to master on their next
    * playback (the routeTo machinery checks `destroyed` at preplay).
    */
-  destroy(): void {
+  destroy(options?: { drainTo?: Bus }): void {
     if (this._destroyed) {
       return;
+    }
+    if (options?.drainTo) {
+      this.drainTo(options.drainTo);
     }
     this._destroyed = true;
     // Tear down all outgoing send-gain allocations.

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -68,6 +68,14 @@ export class Bus {
 
   private readonly _context: BaseContext;
   private readonly _filterNodes: AudioNode[] = [];
+  /**
+   * Filter nodes currently bypassed (skipped in the audible chain). A bypassed
+   * node stays in {@link _filterNodes} — so {@link filters} order, identity, and
+   * its live AudioParams are preserved — but {@link _desiredFilterChainEdges}
+   * builds the series chain over the NON-bypassed filters only, wiring the
+   * signal around it. Membership is by node identity.
+   */
+  private readonly _bypassedFilters = new Set<AudioNode>();
   private readonly _filterChainEdges: Array<readonly [AudioNode, AudioNode]> = [];
   private readonly _sendGains: Map<BusConnectionTarget, GainNode> = new Map();
   private readonly _directConnections: Set<BusConnectionTarget> = new Set();
@@ -174,6 +182,7 @@ export class Bus {
       throw new Error("Cannot remove filter that was never added to this bus");
     }
     this._filterNodes.splice(idx, 1);
+    this._bypassedFilters.delete(node);
     this._refreshFilters();
   }
 
@@ -199,6 +208,48 @@ export class Bus {
     this._filterNodes.length = 0;
     this._filterNodes.push(...nodes);
     this._refreshFilters();
+  }
+
+  /**
+   * Bypass (or un-bypass) a filter without removing it from the chain. A
+   * bypassed filter stays in {@link filters} — its order, identity, and live
+   * AudioParams are preserved (so an automation target survives a bypass) — but
+   * it is skipped in the audible series chain: the signal is wired around it.
+   * Un-bypassing wires it back in at its original position.
+   *
+   * The reconnect goes through the incremental {@link _refreshFilters}, so only
+   * the seam around `node` is touched — the rest of the chain is left connected.
+   *
+   * @param node A filter node currently on this bus (from {@link addFilter} or
+   *   {@link filters}).
+   * @param bypassed `true` to skip the node, `false` to wire it back in. A no-op
+   *   if the node is already in the requested state.
+   * @throws if the bus has been destroyed, or if `node` was never added to this
+   *   bus.
+   */
+  setFilterBypassed(node: AudioNode, bypassed: boolean): void {
+    this._throwIfDestroyed();
+    if (!this._filterNodes.includes(node)) {
+      throw new Error("Cannot bypass a filter that was never added to this bus");
+    }
+    const alreadyBypassed = this._bypassedFilters.has(node);
+    if (bypassed === alreadyBypassed) {
+      return;
+    }
+    if (bypassed) {
+      this._bypassedFilters.add(node);
+    } else {
+      this._bypassedFilters.delete(node);
+    }
+    this._refreshFilters();
+  }
+
+  /**
+   * Whether `node` is currently bypassed (skipped in the audible chain). Returns
+   * `false` for nodes that were never added to this bus.
+   */
+  isFilterBypassed(node: AudioNode): boolean {
+    return this._bypassedFilters.has(node);
   }
 
   /**
@@ -517,16 +568,22 @@ export class Bus {
 
   /**
    * Compute the desired ordered chain edge list from the current
-   * `_filterNodes`: `[[input, output]]` when there are no filters, otherwise
-   * `[[input, f1], [f1, f2], ..., [fN, output]]`.
+   * `_filterNodes`, skipping any node in {@link _bypassedFilters}: the series
+   * chain is built over the NON-bypassed filters only. With no active (non-
+   * bypassed) filters — whether the bus has no filters at all or every filter is
+   * bypassed — the desired list is `[[input, output]]` (the direct edge);
+   * otherwise `[[input, a1], [a1, a2], ..., [aN, output]]` over the active
+   * filters `a1..aN`. Bypassed nodes stay in {@link _filterNodes} (and thus in
+   * {@link filters}) but receive no inbound/outbound chain edge.
    */
   private _desiredFilterChainEdges(): Array<readonly [AudioNode, AudioNode]> {
-    if (this._filterNodes.length === 0) {
+    const active = this._filterNodes.filter((n) => !this._bypassedFilters.has(n));
+    if (active.length === 0) {
       return [[this.input, this.output]];
     }
     const edges: Array<readonly [AudioNode, AudioNode]> = [];
     let prev: AudioNode = this.input;
-    for (const f of this._filterNodes) {
+    for (const f of active) {
       edges.push([prev, f]);
       prev = f;
     }

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -19,7 +19,8 @@
  * parameters affects both.
  */
 
-import type { AudioNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
+import type { FadeType } from "./cacophony";
+import type { AudioNode, AudioParam, AudioWorkletNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
 import type { CacophonyEffect } from "./effects";
 import { isCacophonyBuiltBiquad, isCacophonyEffect } from "./effects";
 
@@ -132,10 +133,15 @@ export class Bus {
    *   `cacophony.shareEffect(node)` (or a proper CacophonyEffect class) to
    *   make the shared-state intent explicit.
    *
+   * @returns the built AudioNode that was added to the chain. For a biquad this
+   *   is the argument itself; for a {@link CacophonyEffect} it is the node
+   *   produced by `build`. The returned handle can be passed to
+   *   {@link rampFilterParam} to automate the node's parameters. Existing
+   *   callers that ignore the result keep working unchanged.
    * @throws if the bus has been destroyed, or if the argument is a raw
    *   AudioNode that is not a Cacophony-built biquad.
    */
-  async addFilter(arg: BiquadFilterNode | CacophonyEffect | AudioNode): Promise<void> {
+  async addFilter(arg: BiquadFilterNode | CacophonyEffect | AudioNode): Promise<AudioNode> {
     this._throwIfDestroyed();
     let node: AudioNode;
     if (isCacophonyBuiltBiquad(arg)) {
@@ -152,6 +158,7 @@ export class Bus {
     }
     this._filterNodes.push(node);
     this._refreshFilters();
+    return node;
   }
 
   /**
@@ -192,6 +199,114 @@ export class Bus {
     this._filterNodes.length = 0;
     this._filterNodes.push(...nodes);
     this._refreshFilters();
+  }
+
+  /**
+   * Ramp an effect node's parameter to a target value over time. This is the
+   * uniform automation handle for filter-chain effects: pass a node obtained
+   * from {@link addFilter} (or the {@link filters} getter) and the name of the
+   * parameter to drive.
+   *
+   * Parameter resolution:
+   * - If `node` exposes a worklet-style `parameters` AudioParamMap, the param
+   *   is resolved via `parameters.get(paramName)` (e.g. a worklet effect's
+   *   named params).
+   * - Otherwise, if `node[paramName]` is itself an AudioParam (native nodes
+   *   such as a biquad expose `.frequency` / `.Q` / `.gain` directly), that is
+   *   used.
+   *
+   * Ramp shape (mirrors the codebase fade convention): the target time base is
+   * `node.context.currentTime`. With no `duration` (or `duration <= 0`) the
+   * value is set immediately via `setValueAtTime(value, now)`. Otherwise the
+   * start is pinned with `setValueAtTime(param.value, now)` and the value ramps
+   * to `now + duration / 1000` (milliseconds) using `linearRampToValueAtTime`
+   * (default) or `exponentialRampToValueAtTime` when `type` is `"exponential"`
+   * (an exponential target of 0 is floored to 0.0001, matching `fadeTo`).
+   *
+   * Automation degrades gracefully: if `node` is not on this bus, or the
+   * parameter cannot be resolved to an AudioParam, a warning is logged and the
+   * call is a no-op. The only condition that throws is a destroyed bus.
+   *
+   * @param node A filter node currently on this bus (from {@link addFilter}).
+   * @param paramName The name of the parameter to automate.
+   * @param value The target value.
+   * @param options.duration Ramp duration in milliseconds. Absent/`<= 0` sets
+   *   the value immediately.
+   * @param options.type Ramp curve, `"linear"` (default) or `"exponential"`.
+   * @throws if the bus has been destroyed.
+   */
+  rampFilterParam(
+    node: AudioNode,
+    paramName: string,
+    value: number,
+    options?: { duration?: number; type?: FadeType },
+  ): void {
+    this._throwIfDestroyed();
+    if (!this._filterNodes.includes(node)) {
+      console.warn(`Bus.rampFilterParam: node is not a filter on this bus; ignoring automation of '${paramName}'.`);
+      return;
+    }
+
+    const param = this._resolveAudioParam(node, paramName);
+    if (!param) {
+      console.warn(`Bus.rampFilterParam: could not resolve AudioParam '${paramName}' on the given node; ignoring.`);
+      return;
+    }
+
+    const now = node.context.currentTime;
+    const duration = options?.duration;
+    if (duration === undefined || duration <= 0) {
+      param.setValueAtTime(value, now);
+      return;
+    }
+
+    const endTime = now + duration / 1000;
+    param.setValueAtTime(param.value, now);
+    if (options?.type === "exponential") {
+      param.exponentialRampToValueAtTime(value === 0 ? 0.0001 : value, endTime);
+    } else {
+      param.linearRampToValueAtTime(value, endTime);
+    }
+  }
+
+  /**
+   * Resolve the named {@link AudioParam} on a node. Tries the worklet
+   * `parameters` map first, then a directly-exposed native param
+   * (`node[paramName]`). Returns `undefined` if neither yields an AudioParam.
+   *
+   * Detection is structural (duck-typed), never `instanceof` — the mocked test
+   * context may not provide the `AudioParam` global.
+   */
+  private _resolveAudioParam(node: AudioNode, paramName: string): AudioParam | undefined {
+    const parameters = (node as AudioWorkletNode).parameters;
+    if (parameters && typeof parameters.get === "function") {
+      const workletParam = parameters.get(paramName);
+      if (this._isAudioParam(workletParam)) {
+        return workletParam;
+      }
+    }
+
+    const nativeParam = (node as unknown as Record<string, unknown>)[paramName];
+    if (this._isAudioParam(nativeParam)) {
+      return nativeParam;
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Structural AudioParam check: a value is treated as an AudioParam if it
+   * exposes the ramp scheduling methods. Avoids `instanceof AudioParam` so it
+   * works under the standardized-audio-context mock (which may lack the global).
+   */
+  private _isAudioParam(value: unknown): value is AudioParam {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      typeof (value as AudioParam).setValueAtTime === "function" &&
+      typeof (value as AudioParam).linearRampToValueAtTime === "function" &&
+      typeof (value as AudioParam).exponentialRampToValueAtTime === "function"
+    );
   }
 
   /**

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -327,6 +327,42 @@ export class FdnReverbEffect implements CacophonyEffect {
 }
 
 /**
+ * String aliases for the integer mode indices that {@link WaveshaperOptions},
+ * {@link TremoloOptions} and {@link ModulatedDelayOptions} flow straight through
+ * as `parameterData`. An AudioParam can only carry a number, so these maps are
+ * applied inside each effect's `build()` to translate a string mode into its
+ * integer index BEFORE the options become `parameterData`. The index assignments
+ * mirror the worklet shells' `*_BY_INDEX` arrays exactly
+ * (`processors/waveshaper.ts`, `processors/tremolo.ts`,
+ * `processors/modulated-delay.ts`). Declared locally so this module does not
+ * import from the worklet/processor modules (keeping that boundary intact).
+ */
+const WAVESHAPER_SHAPE_TO_INDEX = { hardclip: 0, tanh: 1 } as const;
+type WaveshaperShapeAlias = keyof typeof WAVESHAPER_SHAPE_TO_INDEX;
+
+const TREMOLO_SHAPE_TO_INDEX = { sine: 0, triangle: 1, square: 2 } as const;
+type TremoloShapeAlias = keyof typeof TREMOLO_SHAPE_TO_INDEX;
+
+const MODULATED_DELAY_INTERPOLATION_TO_INDEX = { cubic: 0, linear: 1 } as const;
+type ModulatedDelayInterpolationAlias = keyof typeof MODULATED_DELAY_INTERPOLATION_TO_INDEX;
+
+/**
+ * Resolve a mode field that may be a number (pass through unchanged, exactly as
+ * today) or a string alias (translate to its integer index). An unknown/invalid
+ * string maps to index 0, mirroring the worklet's `?? first` fallback. Returns
+ * `undefined` when the field is absent so the worklet keeps its own default.
+ */
+function resolveModeIndex(value: number | string | undefined, table: Record<string, number>): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value === "number") {
+    return value;
+  }
+  return table[value] ?? 0;
+}
+
+/**
  * Construction-time configuration for a {@link WaveshaperEffect}, mirroring the
  * `waveshaper` AudioWorkletProcessor's AudioParam set (see
  * {@link import('./processors/waveshaper').WaveshaperWorkletProcessor}). All
@@ -341,8 +377,13 @@ export class FdnReverbEffect implements CacophonyEffect {
 export interface WaveshaperOptions {
   /** Pre-gain (drive) into the nonlinearity. Default 1. Range 0..100; >1 = harder saturation. */
   drive?: number;
-  /** Nonlinearity index: 0 = hard clip (polynomial F0, eq.25), 1 = tanh soft clip (F0 = log cosh, eq.20). Default 0. */
-  shape?: number;
+  /**
+   * Nonlinearity: 0 = hard clip (polynomial F0, eq.25), 1 = tanh soft clip
+   * (F0 = log cosh, eq.20). Default 0. Accepts either the integer index or the
+   * matching string alias (`"hardclip"` = 0, `"tanh"` = 1), translated to the
+   * index in `build()`.
+   */
+  shape?: number | WaveshaperShapeAlias;
   /** Wet/dry mix (0..1); 0 = dry bypass, 1 = fully shaped. Default 1. */
   mix?: number;
   /** Post-nonlinearity output gain (linear). Default 1. Range 0..4. */
@@ -366,7 +407,12 @@ export class WaveshaperEffect implements CacophonyEffect {
 
   async build(context: BaseContext): Promise<AudioWorkletNode> {
     await this.host.loadWaveshaper(undefined, context);
-    return this.host.createWaveshaperNode({ parameterData: this.options as Record<string, number> }, context);
+    const parameterData: Record<string, number> = { ...this.options } as Record<string, number>;
+    const shapeIndex = resolveModeIndex(this.options.shape, WAVESHAPER_SHAPE_TO_INDEX);
+    if (shapeIndex !== undefined) {
+      parameterData.shape = shapeIndex;
+    }
+    return this.host.createWaveshaperNode({ parameterData }, context);
   }
 }
 
@@ -398,8 +444,12 @@ export interface ModulatedDelayOptions {
   blend?: number;
   /** Wet (modulated tap) gain (feedforward). Default 0.7071. Range 0..1. */
   feedforward?: number;
-  /** Interpolation index: 0 = cubic (4-tap Lagrange N=3), 1 = linear (2-tap N=1). Default 0. */
-  interpolation?: number;
+  /**
+   * Interpolation: 0 = cubic (4-tap Lagrange N=3), 1 = linear (2-tap N=1).
+   * Default 0. Accepts either the integer index or the matching string alias
+   * (`"cubic"` = 0, `"linear"` = 1), translated to the index in `build()`.
+   */
+  interpolation?: number | ModulatedDelayInterpolationAlias;
 }
 
 /**
@@ -419,7 +469,12 @@ export class ModulatedDelayEffect implements CacophonyEffect {
 
   async build(context: BaseContext): Promise<AudioWorkletNode> {
     await this.host.loadModulatedDelay(undefined, context);
-    return this.host.createModulatedDelayNode({ parameterData: this.options as Record<string, number> }, context);
+    const parameterData: Record<string, number> = { ...this.options } as Record<string, number>;
+    const interpolationIndex = resolveModeIndex(this.options.interpolation, MODULATED_DELAY_INTERPOLATION_TO_INDEX);
+    if (interpolationIndex !== undefined) {
+      parameterData.interpolation = interpolationIndex;
+    }
+    return this.host.createModulatedDelayNode({ parameterData }, context);
   }
 }
 
@@ -491,8 +546,12 @@ export interface TremoloOptions {
   rate?: number;
   /** Modulation depth (0 = bypass, 1 = full 0..1 swing). Default 0.5. Range 0..1. */
   depth?: number;
-  /** LFO shape index: 0 = sine, 1 = triangle, 2 = square. Default 0. */
-  shape?: number;
+  /**
+   * LFO shape: 0 = sine, 1 = triangle, 2 = square. Default 0. Accepts either
+   * the integer index or the matching string alias (`"sine"` = 0,
+   * `"triangle"` = 1, `"square"` = 2), translated to the index in `build()`.
+   */
+  shape?: number | TremoloShapeAlias;
   /** Per-channel LFO phase offset in degrees (0 = mono, 90 = quadrature, 180 = auto-pan). Default 0. Range 0..180. */
   stereoPhase?: number;
 }
@@ -513,7 +572,12 @@ export class TremoloEffect implements CacophonyEffect {
 
   async build(context: BaseContext): Promise<AudioWorkletNode> {
     await this.host.loadTremolo(undefined, context);
-    return this.host.createTremoloNode({ parameterData: this.options as Record<string, number> }, context);
+    const parameterData: Record<string, number> = { ...this.options } as Record<string, number>;
+    const shapeIndex = resolveModeIndex(this.options.shape, TREMOLO_SHAPE_TO_INDEX);
+    if (shapeIndex !== undefined) {
+      parameterData.shape = shapeIndex;
+    }
+    return this.host.createTremoloNode({ parameterData }, context);
   }
 }
 

--- a/src/modulated-delay-effect.test.ts
+++ b/src/modulated-delay-effect.test.ts
@@ -138,6 +138,43 @@ describe("Cacophony modulated-delay factories (createDelay / createChorus / crea
   });
 });
 
+describe("Cacophony modulated-delay string-mode interpolation aliases", () => {
+  beforeEach(() => {
+    mockAudioWorklet();
+  });
+
+  const interpolationOf = (spy: ReturnType<typeof vi.spyOn>): unknown =>
+    (spy.mock.calls[0]?.[0] as { parameterData: Record<string, unknown> }).parameterData.interpolation;
+
+  it("translates interpolation: 'linear' to index 1 in parameterData", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createModulatedDelayNode").mockResolvedValue({} as never);
+    await cacophony.createDelay({ interpolation: "linear" }).build(cacophony.context);
+    expect(interpolationOf(createNodeSpy)).toBe(1);
+    createNodeSpy.mockRestore();
+  });
+
+  it("translates interpolation: 'cubic' to index 0 in parameterData", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createModulatedDelayNode").mockResolvedValue({} as never);
+    await cacophony.createDelay({ interpolation: "cubic" }).build(cacophony.context);
+    expect(interpolationOf(createNodeSpy)).toBe(0);
+    createNodeSpy.mockRestore();
+  });
+
+  it("leaves a numeric interpolation unchanged (backward compatible)", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createModulatedDelayNode").mockResolvedValue({} as never);
+    await cacophony.createDelay({ interpolation: 1 }).build(cacophony.context);
+    expect(interpolationOf(createNodeSpy)).toBe(1);
+    createNodeSpy.mockRestore();
+  });
+
+  it("falls back to index 0 for an unknown interpolation string", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createModulatedDelayNode").mockResolvedValue({} as never);
+    await cacophony.createDelay({ interpolation: "bogus" as never }).build(cacophony.context);
+    expect(interpolationOf(createNodeSpy)).toBe(0);
+    createNodeSpy.mockRestore();
+  });
+});
+
 describe("modulated-delay effect Bus integration", () => {
   beforeEach(() => {
     mockAudioWorklet();

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -21,7 +21,7 @@
  * instances of a sound with different settings, without requiring the user to manually manage each playback instance.
  */
 
-import type { Bus } from "./bus";
+import type { Bus, BusRoutedSource } from "./bus";
 import type {
   BaseSound,
   Cacophony,
@@ -48,7 +48,7 @@ type SoundCloneOverrides = PanCloneOverrides &
     filters?: BiquadFilterNode[];
   };
 
-export class Sound extends PlaybackContainer(FilterManager) implements BaseSound {
+export class Sound extends PlaybackContainer(FilterManager) implements BaseSound, BusRoutedSource {
   public declare playbacks: Playback[];
   buffer?: AudioBuffer;
   context: BaseContext;
@@ -625,9 +625,29 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
     // master.input === globalGainNode — normalize to null in either case so
     // there is one canonical "route to master" state.
     const collapseToMaster = bus.input === this.globalGainNode;
+    const oldTarget = this._routeTarget;
     const oldTargetNode = this._resolveRouteTargetNode();
     this._routeTarget = collapseToMaster ? null : bus;
+    const newTarget = this._routeTarget;
     const newTargetNode = this._resolveRouteTargetNode();
+    // Maintain inbound source-tracking driven by the route-target BUS IDENTITY,
+    // independent of whether the resolved AudioNode changed. A bus-identity
+    // transition (e.g. off a destroyed bus that resolves to globalGainNode, onto
+    // master which is ALSO globalGainNode) leaves the resolved nodes equal — so
+    // this must run BEFORE the node-equality early-return below, or the
+    // unregister of the old bus is skipped and the sound leaks in the old bus's
+    // `_routedSources`. (master/null is excluded because it is `null`.)
+    if (oldTarget !== newTarget) {
+      if (oldTarget) {
+        oldTarget._unregisterRoutedSource(this);
+      }
+      if (newTarget) {
+        newTarget._registerRoutedSource(this);
+      }
+    }
+    // The node-equality guard gates only the live-playback rewire: when the
+    // resolved primary AudioNode is unchanged there is nothing to disconnect/
+    // reconnect. Registration bookkeeping has already been settled above.
     if (oldTargetNode === newTargetNode) {
       return;
     }
@@ -651,6 +671,9 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
       throw new Error(`Cannot add a send to destroyed bus '${bus.name ?? "<anonymous>"}'`);
     }
     this._sends.set(bus, gainValue);
+    // A sound that sends to a bus is an inbound source of it too, so it must
+    // be drained off when the bus is torn down.
+    bus._registerRoutedSource(this);
     // Establish send edges on existing playbacks. The per-playback Map is
     // the canonical owner of the GainNode lifecycle (so cleanup can iterate
     // and disconnect every send).
@@ -673,8 +696,49 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
     }
   }
 
+  /**
+   * Reroute this sound off `bus` onto `target` when `bus` is being drained
+   * (typically just before it is destroyed). A sound may be BOTH primary-routed
+   * to `bus` AND have a send to it — both edges move.
+   */
+  _onBusDrained(bus: Bus, target: Bus): void {
+    // Primary route: reuse _setPrimary so live playbacks are rewired and the
+    // source-registration (un)registers through the normal path.
+    if (this._routeTarget === bus) {
+      this._setPrimary(target);
+    }
+    // Send: capture the gain, tear down the old send (map entry + per-playback
+    // GainNode for `bus`), then re-establish an equivalent send to `target`.
+    if (this._sends.has(bus)) {
+      const gainValue = this._sends.get(bus) as number;
+      this._sends.delete(bus);
+      for (const playback of this.playbacks) {
+        const sendGain = playback._sendGains.get(bus);
+        if (!sendGain) {
+          continue;
+        }
+        // Same per-playback send-teardown shape as Playback.cleanup.
+        try {
+          sendGain.disconnect();
+        } catch {
+          // Best-effort — node may already have been disconnected externally.
+        }
+        playback._sendGains.delete(bus);
+      }
+      this._addSend(target, gainValue);
+    }
+  }
+
   cleanup(): void {
     this._cacophony?.unregisterSoundCleanup(this._unregisterToken);
+    // Drop ourselves from the source-tracking of every bus we route to, so a
+    // later drain/destroy of that bus does not touch this dead sound.
+    if (this._routeTarget) {
+      this._routeTarget._unregisterRoutedSource(this);
+    }
+    for (const bus of this._sends.keys()) {
+      bus._unregisterRoutedSource(this);
+    }
     this._holdings.sources.length = 0;
     this._holdings.gainNodes.length = 0;
     this._holdings.mediaElements.length = 0;

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -638,7 +638,7 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
     // unregister of the old bus is skipped and the sound leaks in the old bus's
     // `_routedSources`. (master/null is excluded because it is `null`.)
     if (oldTarget !== newTarget) {
-      if (oldTarget) {
+      if (oldTarget && !this._sends.has(oldTarget)) {
         oldTarget._unregisterRoutedSource(this);
       }
       if (newTarget) {

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -1,4 +1,4 @@
-import type { Bus } from "./bus";
+import type { Bus, BusRoutedSource } from "./bus";
 import type { BaseSound, Cacophony, PanType, SoundType } from "./cacophony";
 import { PlaybackContainer } from "./container";
 import type { BaseContext, GainNode, OscillatorNode } from "./context";
@@ -13,7 +13,7 @@ import type { VolumeCloneOverrides } from "./volumeMixin";
 
 type SynthCloneOverrides = FilterCloneOverrides & OscillatorCloneOverrides & PanCloneOverrides & VolumeCloneOverrides;
 
-export class Synth extends PlaybackContainer(FilterManager) implements BaseSound {
+export class Synth extends PlaybackContainer(FilterManager) implements BaseSound, BusRoutedSource {
   _oscillatorOptions: Partial<OscillatorOptions>;
   playbacks: SynthPlayback[] = [];
   private eventEmitter: TypedEventEmitter<SynthEvents> = new TypedEventEmitter<SynthEvents>();
@@ -266,9 +266,19 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
       throw new Error(`Cannot route to destroyed bus '${bus.name ?? "<anonymous>"}'`);
     }
     const collapseToMaster = bus.input === this.globalGainNode;
+    const oldTarget = this._routeTarget;
     const oldTargetNode = this._resolveRouteTargetNode();
     this._routeTarget = collapseToMaster ? null : bus;
+    const newTarget = this._routeTarget;
     const newTargetNode = this._resolveRouteTargetNode();
+    if (oldTarget !== newTarget) {
+      if (oldTarget && !this._sends.has(oldTarget)) {
+        oldTarget._unregisterRoutedSource(this);
+      }
+      if (newTarget) {
+        newTarget._registerRoutedSource(this);
+      }
+    }
     if (oldTargetNode === newTargetNode) {
       return;
     }
@@ -287,6 +297,7 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
       throw new Error(`Cannot add a send to destroyed bus '${bus.name ?? "<anonymous>"}'`);
     }
     this._sends.set(bus, gainValue);
+    bus._registerRoutedSource(this);
     for (const playback of this.playbacks) {
       const existing = playback._sendGains.get(bus);
       if (existing) {
@@ -302,6 +313,27 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
       }
       sendGain.connect(bus.input);
       playback._sendGains.set(bus, sendGain);
+    }
+  }
+
+  _onBusDrained(bus: Bus, target: Bus): void {
+    if (this._routeTarget === bus) {
+      this._setPrimary(target);
+    }
+    if (this._sends.has(bus)) {
+      const gainValue = this._sends.get(bus) as number;
+      this._sends.delete(bus);
+      for (const playback of this.playbacks) {
+        const sendGain = playback._sendGains.get(bus);
+        if (!sendGain) {
+          continue;
+        }
+        try {
+          sendGain.disconnect();
+        } catch {}
+        playback._sendGains.delete(bus);
+      }
+      this._addSend(target, gainValue);
     }
   }
 

--- a/src/tremolo-effect.test.ts
+++ b/src/tremolo-effect.test.ts
@@ -83,6 +83,47 @@ describe("Cacophony tremolo factories (createTremolo / createAutoPan)", () => {
   });
 });
 
+describe("Cacophony tremolo string-mode shape aliases", () => {
+  beforeEach(() => {
+    mockAudioWorklet();
+  });
+
+  it("translates shape: 'triangle' to index 1 in parameterData", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createTremoloNode").mockResolvedValue({} as never);
+    await cacophony.createTremolo({ rate: 8, shape: "triangle" }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { rate: 8, shape: 1 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+
+  it("translates shape: 'square' to index 2 in parameterData", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createTremoloNode").mockResolvedValue({} as never);
+    await cacophony.createTremolo({ shape: "square" }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { shape: 2 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+
+  it("translates shape: 'sine' to index 0 in parameterData", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createTremoloNode").mockResolvedValue({} as never);
+    await cacophony.createTremolo({ shape: "sine" }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { shape: 0 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+
+  it("leaves a numeric shape unchanged (backward compatible)", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createTremoloNode").mockResolvedValue({} as never);
+    await cacophony.createTremolo({ shape: 2 }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { shape: 2 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+
+  it("falls back to index 0 for an unknown shape string", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createTremoloNode").mockResolvedValue({} as never);
+    await cacophony.createTremolo({ shape: "bogus" as never }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { shape: 0 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+});
+
 describe("tremolo effect Bus integration", () => {
   beforeEach(() => {
     mockAudioWorklet();

--- a/src/waveshaper-effect.test.ts
+++ b/src/waveshaper-effect.test.ts
@@ -82,6 +82,50 @@ describe("Cacophony waveshaper factories (createWaveshaper / createDistortion)",
   });
 });
 
+describe("Cacophony waveshaper string-mode shape aliases", () => {
+  beforeEach(() => {
+    mockAudioWorklet();
+  });
+
+  it("translates shape: 'tanh' to index 1 in parameterData", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createWaveshaperNode").mockResolvedValue({} as never);
+    const effect = cacophony.createWaveshaper({ drive: 2, shape: "tanh", mix: 0.8 });
+    await effect.build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { drive: 2, shape: 1, mix: 0.8 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+
+  it("translates shape: 'hardclip' to index 0 in parameterData", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createWaveshaperNode").mockResolvedValue({} as never);
+    await cacophony.createWaveshaper({ shape: "hardclip" }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { shape: 0 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+
+  it("leaves a numeric shape unchanged (backward compatible)", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createWaveshaperNode").mockResolvedValue({} as never);
+    await cacophony.createWaveshaper({ shape: 1 }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { shape: 1 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+
+  it("falls back to index 0 for an unknown shape string", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createWaveshaperNode").mockResolvedValue({} as never);
+    // Unknown string is not part of the public union, but the runtime fallback
+    // must still map it to 0 (mirroring the worklet's `?? first` behavior).
+    await cacophony.createWaveshaper({ shape: "bogus" as never }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { shape: 0 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+
+  it("does not add a shape key when shape is omitted", async () => {
+    const createNodeSpy = vi.spyOn(cacophony, "createWaveshaperNode").mockResolvedValue({} as never);
+    await cacophony.createWaveshaper({ drive: 3 }).build(cacophony.context);
+    expect(createNodeSpy).toHaveBeenCalledWith({ parameterData: { drive: 3 } }, cacophony.context);
+    createNodeSpy.mockRestore();
+  });
+});
+
 describe("waveshaper effect Bus integration", () => {
   beforeEach(() => {
     mockAudioWorklet();


### PR DESCRIPTION
## Summary
- Add live bus-management APIs for effect chains: `addFilter()` returns the built node, `setFilterOrder()`, per-filter bypass, and `rampFilterParam()` for AudioParam automation.
- Make bus filter-chain refresh incremental so reorder/bypass/remove operations only touch changed internal edges instead of rebuilding the whole chain.
- Add `Bus.drainTo()` / `destroy({ drainTo })` and route/send source tracking so live `Sound` and `Synth` instances can be moved off a bus before teardown.
- Accept string aliases for mode-like effect params (`waveshaper.shape`, `tremolo.shape`, `modulatedDelay.interpolation`) while preserving numeric indices.

## Tests
- `npm run typecheck`
- `npm test` (926 tests)
- `npm run lint` (passes; reports 5 unrelated Biome info suggestions in `src/pitch-shift-resurrection.test.ts`)
- `npm run build:worklets` (passes; unrelated regenerated bundle churn restored afterward)