### PR TITLE
Add audio graph test assertions

### DIFF
--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { Bus } from "./bus";
-import { cacophony } from "./setupTests";
+import { cacophony, expectPath } from "./setupTests";
 
 describe("Bus: construction", () => {
   it("creates an anonymous bus with name=null when no name supplied", () => {
@@ -19,6 +19,12 @@ describe("Bus: construction", () => {
     expect(bus.input).toBeDefined();
     expect(bus.output).toBeDefined();
     expect(bus.input).not.toBe(bus.output);
+  });
+
+  it("wires the input directly to the output before filters are added", () => {
+    const bus = new Bus(cacophony.context, "dry");
+
+    expectPath(bus.input, [], bus.output);
   });
 
   it("uses the externally supplied input GainNode when provided", () => {

--- a/src/setupTests.test.ts
+++ b/src/setupTests.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { audioContextMock, expectNotReachable, expectPath, expectReachable, graphSnapshot } from "./setupTests";
+
+describe("audio graph assertions", () => {
+  it("asserts reachability and an exact ordered path", () => {
+    const source = audioContextMock.createGain();
+    const panner = audioContextMock.createStereoPanner();
+    const filter = audioContextMock.createBiquadFilter();
+    const gain = audioContextMock.createGain();
+    const destination = audioContextMock.destination;
+
+    source.connect(panner);
+    panner.connect(filter);
+    filter.connect(gain);
+    gain.connect(destination);
+
+    expectReachable(source, destination);
+    expectPath(source, [panner, filter, gain], destination);
+    expectNotReachable(destination, source);
+  });
+
+  it("removes destination-specific and blanket-disconnected edges", () => {
+    const source = audioContextMock.createGain();
+    const first = audioContextMock.createGain();
+    const second = audioContextMock.createGain();
+
+    source.connect(first);
+    source.connect(second);
+    source.disconnect(first);
+
+    expectNotReachable(source, first);
+    expectReachable(source, second);
+
+    source.disconnect();
+
+    expectNotReachable(source, second);
+  });
+
+  it("distinguishes splitter and merger port overloads", () => {
+    const splitter = audioContextMock.createChannelSplitter(2);
+    const merger = audioContextMock.createChannelMerger(2);
+
+    splitter.connect(merger, 0, 1);
+    splitter.connect(merger, 1, 0);
+    splitter.disconnect(merger, 0, 1);
+
+    expectReachable(splitter, merger);
+    expect(graphSnapshot(splitter)).toEqual({
+      nodes: [
+        { id: "n0", type: "ChannelSplitterNodeMock" },
+        { id: "n1", type: "ChannelMergerNodeMock" },
+      ],
+      edges: [{ source: "n0", destination: "n1", output: 1, input: 0 }],
+    });
+  });
+
+  it("records Vitest-mocked AudioWorkletNode connections", () => {
+    const worklet = new AudioWorkletNode(audioContextMock as unknown as BaseAudioContext, "test-processor");
+    const destination = audioContextMock.createGain();
+
+    worklet.connect(destination as unknown as globalThis.AudioNode);
+
+    expectReachable(worklet, destination);
+    expect(JSON.parse(JSON.stringify(graphSnapshot(worklet)))).toEqual(graphSnapshot(worklet));
+  });
+});

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,9 +1,276 @@
+/**
+ * Shared test setup and audio-graph assertions.
+ *
+ * The graph helpers read the observable `connect`/`disconnect` histories on
+ * nodes produced by `standardized-audio-context-mock` and the Vitest worklet
+ * mock. The upstream mock returns bare objects for channel splitters and
+ * mergers, so their factories are instrumented here with equivalent observable
+ * methods. `expectReachable()` and `expectNotReachable()` assert graph
+ * reachability, `expectPath()` asserts each edge in an ordered chain, and
+ * `graphSnapshot()` returns a JSON-safe reachable edge list with port metadata.
+ */
 import { AudioBuffer, AudioContext } from "standardized-audio-context-mock";
-import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, expect, vi } from "vitest";
 import { Cacophony } from "./cacophony";
 
 export let cacophony: Cacophony;
 export let audioContextMock: AudioContext;
+
+type GraphNode = object;
+
+interface GraphEdge {
+  source: GraphNode;
+  destination: GraphNode;
+  output: number;
+  input: number;
+}
+
+interface GraphInvocation {
+  args: readonly unknown[];
+  kind: "connect" | "disconnect";
+  order: number;
+}
+
+export interface AudioGraphSnapshot {
+  nodes: Array<{ id: string; type: string }>;
+  edges: Array<{
+    source: string;
+    destination: string;
+    output: number;
+    input: number;
+  }>;
+}
+
+const instrumentedNodeTypes = new WeakMap<GraphNode, string>();
+
+function isGraphNode(value: unknown): value is GraphNode {
+  return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+function callHistory(fn: unknown, kind: GraphInvocation["kind"]): GraphInvocation[] {
+  if (typeof fn !== "function") {
+    return [];
+  }
+
+  const observable = fn as {
+    getCalls?: () => Array<{ args?: readonly unknown[]; callId?: number }>;
+    mock?: {
+      calls?: readonly (readonly unknown[])[];
+      invocationCallOrder?: readonly number[];
+    };
+  };
+
+  if (typeof observable.getCalls === "function") {
+    return observable.getCalls().map((call, index) => ({
+      args: call.args ?? [],
+      kind,
+      order: call.callId ?? index,
+    }));
+  }
+
+  return (observable.mock?.calls ?? []).map((args, index) => ({
+    args,
+    kind,
+    order: observable.mock?.invocationCallOrder?.[index] ?? index,
+  }));
+}
+
+function activeEdges(source: GraphNode): GraphEdge[] {
+  const node = source as { connect?: unknown; disconnect?: unknown };
+  const invocations = [...callHistory(node.connect, "connect"), ...callHistory(node.disconnect, "disconnect")].sort(
+    (left, right) => left.order - right.order,
+  );
+  const edges: GraphEdge[] = [];
+
+  for (const invocation of invocations) {
+    if (invocation.kind === "connect") {
+      const [destination, output = 0, input = 0] = invocation.args;
+      if (!isGraphNode(destination)) {
+        continue;
+      }
+      const edge = {
+        source,
+        destination,
+        output: typeof output === "number" ? output : 0,
+        input: typeof input === "number" ? input : 0,
+      };
+      const duplicate = edges.some(
+        (existing) =>
+          existing.destination === edge.destination && existing.output === edge.output && existing.input === edge.input,
+      );
+      if (!duplicate) {
+        edges.push(edge);
+      }
+      continue;
+    }
+
+    const [destinationOrOutput, output, input] = invocation.args;
+    if (destinationOrOutput === undefined) {
+      edges.length = 0;
+      continue;
+    }
+    if (typeof destinationOrOutput === "number") {
+      for (let index = edges.length - 1; index >= 0; index -= 1) {
+        if (edges[index]?.output === destinationOrOutput) {
+          edges.splice(index, 1);
+        }
+      }
+      continue;
+    }
+    for (let index = edges.length - 1; index >= 0; index -= 1) {
+      const edge = edges[index];
+      if (
+        edge?.destination === destinationOrOutput &&
+        (typeof output !== "number" || edge.output === output) &&
+        (typeof input !== "number" || edge.input === input)
+      ) {
+        edges.splice(index, 1);
+      }
+    }
+  }
+
+  return edges;
+}
+
+function reachablePath(source: GraphNode, destination: GraphNode): GraphNode[] | undefined {
+  const queue: Array<{ node: GraphNode; path: GraphNode[] }> = [{ node: source, path: [source] }];
+  const visited = new WeakSet<GraphNode>([source]);
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current) {
+      break;
+    }
+    if (current.node === destination) {
+      return current.path;
+    }
+    for (const edge of activeEdges(current.node)) {
+      if (!visited.has(edge.destination)) {
+        visited.add(edge.destination);
+        queue.push({ node: edge.destination, path: [...current.path, edge.destination] });
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function graphNodeType(node: GraphNode): string {
+  const instrumentedType = instrumentedNodeTypes.get(node);
+  if (instrumentedType) {
+    return instrumentedType;
+  }
+  return (node as { constructor?: { name?: string } }).constructor?.name ?? "Object";
+}
+
+/**
+ * Assert that at least one active connection path leads from source to
+ * destination.
+ */
+export function expectReachable(source: GraphNode, destination: GraphNode): void {
+  expect(
+    reachablePath(source, destination),
+    `Expected ${graphNodeType(source)} to reach ${graphNodeType(destination)}`,
+  ).toBeDefined();
+}
+
+/**
+ * Assert that no active connection path leads from source to destination.
+ */
+export function expectNotReachable(source: GraphNode, destination: GraphNode): void {
+  expect(
+    reachablePath(source, destination),
+    `Expected ${graphNodeType(source)} not to reach ${graphNodeType(destination)}`,
+  ).toBeUndefined();
+}
+
+/**
+ * Assert an exact ordered chain of direct active edges:
+ * `source -> intermediates[0] -> ... -> destination`.
+ */
+export function expectPath(source: GraphNode, intermediates: readonly GraphNode[], destination: GraphNode): void {
+  const path = [source, ...intermediates, destination];
+  for (let index = 0; index < path.length - 1; index += 1) {
+    const from = path[index]!;
+    const to = path[index + 1]!;
+    expect(
+      activeEdges(from).some((edge) => edge.destination === to),
+      `Expected direct graph edge ${graphNodeType(from)} -> ${graphNodeType(to)}`,
+    ).toBe(true);
+  }
+}
+
+/**
+ * Return the active graph reachable from source as stable, JSON-safe node and
+ * edge arrays. Node IDs are local breadth-first IDs, so snapshots do not
+ * depend on test execution order.
+ */
+export function graphSnapshot(source: GraphNode): AudioGraphSnapshot {
+  const ids = new WeakMap<GraphNode, string>();
+  const queued = new WeakSet<GraphNode>();
+  const queue: GraphNode[] = [source];
+  const nodes: AudioGraphSnapshot["nodes"] = [];
+  const edges: AudioGraphSnapshot["edges"] = [];
+  ids.set(source, "n0");
+  queued.add(source);
+
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    const sourceId = ids.get(node)!;
+    nodes.push({ id: sourceId, type: graphNodeType(node) });
+    for (const edge of activeEdges(node)) {
+      let destinationId = ids.get(edge.destination);
+      if (!destinationId) {
+        destinationId = `n${idsForSnapshot(nodes, queue)}`;
+        ids.set(edge.destination, destinationId);
+      }
+      edges.push({
+        source: sourceId,
+        destination: destinationId,
+        output: edge.output,
+        input: edge.input,
+      });
+      if (!queued.has(edge.destination)) {
+        queued.add(edge.destination);
+        queue.push(edge.destination);
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+function idsForSnapshot(nodes: AudioGraphSnapshot["nodes"], queue: readonly GraphNode[]): number {
+  return nodes.length + queue.length;
+}
+
+function createInstrumentedGraphNode(context: AudioContext, type: string, inputs: number, outputs: number): GraphNode {
+  const node = {
+    channelCount: 2,
+    channelCountMode: "max",
+    channelInterpretation: "speakers",
+    connect: vi.fn((destination: GraphNode) => destination),
+    context,
+    disconnect: vi.fn(),
+    numberOfInputs: inputs,
+    numberOfOutputs: outputs,
+  };
+  instrumentedNodeTypes.set(node, type);
+  return node;
+}
+
+function instrumentIncompleteNodeFactories(context: AudioContext): void {
+  Object.defineProperty(context, "createChannelSplitter", {
+    configurable: true,
+    value: (numberOfOutputs = 6) => createInstrumentedGraphNode(context, "ChannelSplitterNodeMock", 1, numberOfOutputs),
+    writable: true,
+  });
+  Object.defineProperty(context, "createChannelMerger", {
+    configurable: true,
+    value: (numberOfInputs = 6) => createInstrumentedGraphNode(context, "ChannelMergerNodeMock", numberOfInputs, 1),
+    writable: true,
+  });
+}
 
 // Track which URLs have been loaded to simulate cache behavior
 const loadedUrls = new Set<string>();
@@ -182,14 +449,16 @@ beforeAll(() => {
 
   // Mock AudioWorkletNode constructor for worklet tests
   global.AudioWorkletNode = vi.fn().mockImplementation(function MockAudioWorkletNode() {
-    return {
-      connect: vi.fn(),
+    const node = {
+      connect: vi.fn((destination) => destination),
       disconnect: vi.fn(),
       port: {
         postMessage: vi.fn(),
         addEventListener: vi.fn(),
       },
     };
+    instrumentedNodeTypes.set(node, "AudioWorkletNode");
+    return node;
   });
 });
 
@@ -200,6 +469,7 @@ afterAll(() => {
 beforeEach(() => {
   vi.clearAllMocks();
   audioContextMock = new AudioContext();
+  instrumentIncompleteNodeFactories(audioContextMock);
   cacophony = new Cacophony(audioContextMock, mockCache);
 });
 


### PR DESCRIPTION
## Summary

- add shared `expectReachable`, `expectNotReachable`, and ordered `expectPath` audio-graph assertions
- add JSON-safe `graphSnapshot` output with channel splitter/merger port metadata
- instrument the upstream mock's incomplete splitter/merger factories and support Vitest-mocked worklet nodes
- adopt the ordered-path assertion in the existing Bus construction suite

## Root cause

The shared test setup exposed property mocks but had no way to reconstruct active Web Audio graph edges. Most standardized-audio-context mock nodes provide observable Sinon call histories, but its splitter and merger factories return bare objects, so those two factories need setup-level instrumentation.

## Validation

- TDD red run: 5 expected failures before the helper implementation
- `npm test -- src/setupTests.test.ts src/bus.test.ts` — 62 passed
- `npx biome ci .`
- `npm run typecheck`
- `npm run build`
- `npm test` — 1,014 passed

Closes #98