### PR TITLE
Use Node 24 for docs deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v2
       with:
-        node-version: '18'
+        node-version: '24'
 
     - name: Install Dependencies
       run: npm install


### PR DESCRIPTION
## Summary

- run the Deploy Docs workflow on Node 24 instead of Node 18

## Root cause

`node-web-audio-api` requires Node 22 or newer. The docs workflow used Node 18, so npm omitted that optional dependency and TypeDoc failed with `TS2307` while resolving imports from `src/node.ts` and `src/cli/commands.ts`.

The same failure occurred on the two preceding master pushes, before PR #115.

## Validation

- `npm run docs` completed locally under Node 22.18.0 with existing warnings and no errors
- GitHub Actions will provide the exact Node 24 validation
