### PR TITLE
Update docs workflow actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,10 +10,10 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7.0.1
 
     - name: Set up Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v6.4.0
       with:
         node-version: '24'
 


### PR DESCRIPTION
## Summary

- update `actions/checkout` from v3 to the latest release, v7.0.1
- update `actions/setup-node` from v2 to the latest release, v6.4.0

## Why

The successful Deploy Docs run still emitted a deprecation annotation because both old action versions targeted the retired Node 20 action runtime. The latest releases use the current action runtime and remove that warning source.

## Validation

- verified both exact tags against the official GitHub Action release pages
- the diff changes only the two `uses:` pins
- GitHub Actions will validate both updated actions before merge
