### PR TITLE
Add graph wiring assertions

### DIFF
--- a/src/bus-drainto.test.ts
+++ b/src/bus-drainto.test.ts
@@ -7,7 +7,7 @@
 
 import { AudioBuffer } from "standardized-audio-context-mock";
 import { describe, expect, it, vi } from "vitest";
-import { cacophony } from "./setupTests";
+import { cacophony, expectPath } from "./setupTests";
 
 const buildSound = async () => {
   const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
@@ -21,16 +21,12 @@ describe("Bus.drainTo: primary route", () => {
     const busB = cacophony.createBus("drain-primary-b");
     sound.routeTo(busA);
     const [playback] = sound.play();
-    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
-    const connectSpy = vi.spyOn(playback.outputNode, "connect");
 
     busA.drainTo(busB);
 
     // _routeTarget is now busB.
     expect((sound as unknown as { _routeTarget: unknown })._routeTarget).toBe(busB);
-    // Live playback was rewired off busA.input onto busB.input.
-    expect(disconnectSpy).toHaveBeenCalledWith(busA.input);
-    expect(connectSpy).toHaveBeenCalledWith(busB.input);
+    expectPath(playback.outputNode, [], busB.input);
 
     busA.destroy();
     busB.destroy();
@@ -49,18 +45,6 @@ describe("Bus.drainTo: send", () => {
     expect(oldSendGain).toBeDefined();
     const oldSendGainDisconnect = vi.spyOn(oldSendGain!, "disconnect");
 
-    // Capture the new sendGain that _addSend(busB, ...) will allocate so we can
-    // assert its outgoing edge targets busB.input.
-    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
-    const allocated: Array<{ node: any; connect: ReturnType<typeof vi.fn> }> = [];
-    vi.spyOn(cacophony.context, "createGain").mockImplementationOnce(() => {
-      const node = realCreateGain();
-      const connectSpy = vi.fn(node.connect.bind(node));
-      Object.assign(node, { connect: connectSpy });
-      allocated.push({ node, connect: connectSpy });
-      return node;
-    });
-
     busA.drainTo(busB);
 
     const sends = (sound as unknown as { _sends: Map<unknown, number> })._sends;
@@ -69,10 +53,10 @@ describe("Bus.drainTo: send", () => {
     // Old per-playback sendGain to busA was disconnected and dropped.
     expect(oldSendGainDisconnect).toHaveBeenCalled();
     expect(playback._sendGains.has(busA)).toBe(false);
-    // New sendGain → busB.input.
-    expect(allocated.length).toBe(1);
-    expect(allocated[0]?.node.gain.value).toBe(0.3);
-    expect(allocated[0]?.connect).toHaveBeenCalledWith(busB.input);
+    const newSendGain = playback._sendGains.get(busB);
+    expect(newSendGain).toBeDefined();
+    expect(newSendGain!.gain.value).toBe(0.3);
+    expectPath(playback.outputNode, [newSendGain!], busB.input);
 
     busA.destroy();
     busB.destroy();
@@ -86,14 +70,11 @@ describe("Bus.drainTo: synth sources", () => {
     const busB = cacophony.createBus("drain-synth-primary-b");
     synth.routeTo(busA);
     const [playback] = synth.play();
-    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
-    const connectSpy = vi.spyOn(playback.outputNode, "connect");
 
     busA.drainTo(busB);
 
     expect((synth as unknown as { _routeTarget: unknown })._routeTarget).toBe(busB);
-    expect(disconnectSpy).toHaveBeenCalledWith(busA.input);
-    expect(connectSpy).toHaveBeenCalledWith(busB.input);
+    expectPath(playback.outputNode, [], busB.input);
 
     busA.destroy();
     busB.destroy();
@@ -117,6 +98,9 @@ describe("Bus.drainTo: synth sources", () => {
     expect(sends.get(busB)).toBe(0.25);
     expect(playback._sendGains.has(busA)).toBe(false);
     expect(oldSendGainDisconnect).toHaveBeenCalled();
+    const newSendGain = playback._sendGains.get(busB);
+    expect(newSendGain).toBeDefined();
+    expectPath(playback.outputNode, [newSendGain!], busB.input);
 
     busA.destroy();
     busB.destroy();

--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -136,31 +136,15 @@ describe("Bus: per-edge gain on connect", () => {
   it("allocates a sendGain when gain !== 1; output → sendGain → target.input", () => {
     const a = new Bus(cacophony.context, null);
     const b = new Bus(cacophony.context, null);
-    // Wrap createGain so the allocated sendGain's connect call is observable.
-    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
-    const allocated: Array<{ node: any; connect: ReturnType<typeof vi.fn> }> = [];
-    vi.spyOn(cacophony.context, "createGain").mockImplementation(() => {
-      const node = realCreateGain();
-      const connectSpy = vi.fn(node.connect.bind(node));
-      Object.assign(node, { connect: connectSpy });
-      allocated.push({ node, connect: connectSpy });
-      return node;
-    });
-    const outputConnectSpy = vi.spyOn(a.output, "connect");
     a.connect(b, 0.5);
-    // First hop: a.output → sendGain (not b.input directly).
-    expect(outputConnectSpy).toHaveBeenCalled();
-    const firstCallTarget = outputConnectSpy.mock.calls[0]?.[0] as { gain?: { value: number } };
-    expect(firstCallTarget).toBeDefined();
-    expect(firstCallTarget).not.toBe(b.input);
-    expect(firstCallTarget.gain?.value).toBe(0.5);
-    // Second hop: sendGain → b.input. The sendGain was the LAST allocated
-    // gain in this connect call (a.output and b.input were allocated earlier
-    // when the buses were constructed).
-    const sendGainRecord = allocated[allocated.length - 1];
-    expect(sendGainRecord).toBeDefined();
-    expect(sendGainRecord.node).toBe(firstCallTarget);
-    expect(sendGainRecord.connect).toHaveBeenCalledWith(b.input);
+    const sendGain = (
+      a as unknown as {
+        _sendGains: Map<Bus, GainNode>;
+      }
+    )._sendGains.get(b);
+    expect(sendGain).toBeDefined();
+    expect(sendGain!.gain.value).toBe(0.5);
+    expectPath(a.output, [sendGain!], b.input);
   });
 
   it("connects to a raw AudioNode target", () => {
@@ -352,6 +336,7 @@ describe("Bus: filter chain refresh", () => {
     await bus.addFilter(f1);
     await bus.addFilter(f2);
     expect(bus.filters).toEqual([f1, f2]);
+    expectPath(bus.input, [f1, f2], bus.output);
   });
 
   it("removeFilter removes by identity and rebuilds the chain", async () => {
@@ -362,6 +347,7 @@ describe("Bus: filter chain refresh", () => {
     await bus.addFilter(f2);
     bus.removeFilter(f1);
     expect(bus.filters).toEqual([f2]);
+    expectPath(bus.input, [f2], bus.output);
   });
 
   it("removeFilter tears down an owned endpoint graph after removing its chain edges", async () => {

--- a/src/mediaStream.test.ts
+++ b/src/mediaStream.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Cacophony } from "./cacophony";
 import { MediaStreamPlayback, MediaStreamSound } from "./mediaStream";
+import { expectPath } from "./setupTests";
 
 function createMockTrack(): MediaStreamTrack {
   return {
@@ -33,6 +34,7 @@ describe("MediaStreamSound", () => {
   let stream: MediaStream;
   let source: ReturnType<typeof createMockMediaStreamSource>;
   let globalGainNode: ReturnType<AudioContext["createGain"]>;
+  let destination: AudioContext["destination"];
 
   beforeEach(() => {
     context = new AudioContext();
@@ -40,6 +42,8 @@ describe("MediaStreamSound", () => {
     stream = createMockStream([track]);
     source = createMockMediaStreamSource(stream);
     globalGainNode = context.createGain();
+    destination = context.destination;
+    globalGainNode.connect(destination);
     vi.spyOn(context as any, "createMediaStreamSource").mockReturnValue(source);
   });
 
@@ -59,6 +63,7 @@ describe("MediaStreamSound", () => {
     expect(secondPlay[0]).toBe(firstPlay[0]);
     expect(context.createMediaStreamSource).toHaveBeenCalledTimes(1);
     expect(sound.isPlaying).toBe(true);
+    expectPath(source, [firstPlay[0].panner!, firstPlay[0].outputNode, globalGainNode], destination);
   });
 
   it("applies volume and HRTF position to the live playback", () => {

--- a/src/microphone.test.ts
+++ b/src/microphone.test.ts
@@ -1,6 +1,8 @@
 import { AudioContext } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Cacophony } from "./cacophony";
 import { MicrophonePlayback, MicrophoneStream } from "./microphone";
+import { expectPath } from "./setupTests";
 
 function createMockTrack(): MediaStreamTrack {
   return {
@@ -240,25 +242,27 @@ describe("MicrophoneStream", () => {
     // See notes/scout-routing-graph.md ("MicrophonePlayback" / dangling
     // gain node observation).
     const outputNode = context.createGain();
-    const gainConnectSpy = vi.fn();
-    const realCreateGain = (context as any).createGain.bind(context);
-    let firstGain: any;
-    vi.spyOn(context as any, "createGain").mockImplementation(() => {
-      const node = realCreateGain();
-      if (!firstGain) {
-        firstGain = node;
-        const realConnect = node.connect.bind(node);
-        node.connect = (...args: any[]) => {
-          gainConnectSpy(...args);
-          return realConnect(...args);
-        };
+    const microphone = new MicrophoneStream(context, mockStream, outputNode);
+    const microphoneGainNode = (
+      microphone as unknown as {
+        microphoneGainNode: GainNode;
       }
-      return node;
-    });
+    ).microphoneGainNode;
 
-    const _mic = new MicrophoneStream(context, mockStream, outputNode);
+    expectPath(microphoneGainNode, [], outputNode);
+  });
 
-    expect(gainConnectSpy).toHaveBeenCalled();
-    expect(gainConnectSpy.mock.calls.some((call) => call[0] === outputNode)).toBe(true);
+  it.skip("routes Cacophony microphone monitoring through the master bus (#102)", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const cacophony = new Cacophony(context as any);
+
+    const microphone = await cacophony.getMicrophoneStream();
+    const microphoneGainNode = (
+      microphone as unknown as {
+        microphoneGainNode: GainNode;
+      }
+    ).microphoneGainNode;
+
+    expectPath(microphoneGainNode, [], cacophony.master.input);
   });
 });

--- a/src/playback.test.ts
+++ b/src/playback.test.ts
@@ -1,7 +1,7 @@
 import { AudioBuffer, type AudioBufferSourceNode } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Playback } from "./playback";
-import { audioContextMock, cacophony } from "./setupTests";
+import { audioContextMock, cacophony, expectPath, expectReachable } from "./setupTests";
 import { Sound } from "./sound";
 
 describe("Playback class", () => {
@@ -9,6 +9,7 @@ describe("Playback class", () => {
   let buffer: AudioBuffer;
   let source: AudioBufferSourceNode;
   let gainNode: GainNode;
+  let destination: (typeof audioContextMock)["destination"];
   let sound: Sound;
 
   beforeEach(() => {
@@ -16,6 +17,8 @@ describe("Playback class", () => {
     source = audioContextMock.createBufferSource();
     source.buffer = buffer;
     gainNode = audioContextMock.createGain();
+    destination = audioContextMock.destination;
+    gainNode.connect(destination);
     sound = new Sound("test-url", buffer, audioContextMock, gainNode);
     playback = new Playback(sound, source, gainNode);
 
@@ -45,6 +48,16 @@ describe("Playback class", () => {
     expect(playback.isPlaying).toBe(true);
     playback.stop();
     expect(playback.isPlaying).toBe(false);
+  });
+
+  it("wires the source through its panner and gain node to the destination", () => {
+    expectPath(source, [playback.panner!, gainNode], destination);
+  });
+
+  it.skip("keeps the source wired after changing the pan type (#101)", () => {
+    playback.setPanType("stereo", audioContextMock);
+
+    expectPath(source, [playback.panner!, gainNode], destination);
   });
 
   it("can pause and resume", () => {
@@ -185,6 +198,7 @@ describe("Playback cloning", () => {
   let buffer: AudioBuffer;
   let source: AudioBufferSourceNode;
   let gainNode: GainNode;
+  let destination: (typeof audioContextMock)["destination"];
   let sound: Sound;
 
   beforeEach(() => {
@@ -192,6 +206,8 @@ describe("Playback cloning", () => {
     source = audioContextMock.createBufferSource();
     source.buffer = buffer;
     gainNode = audioContextMock.createGain();
+    destination = audioContextMock.destination;
+    gainNode.connect(destination);
     sound = new Sound("test-url", buffer, audioContextMock, gainNode);
     originalPlayback = new Playback(sound, source, gainNode);
 
@@ -221,6 +237,12 @@ describe("Playback cloning", () => {
     expect(clone.playbackRate).toBe(originalPlayback.playbackRate);
     expect(clone.loopCount).toBe(originalPlayback.loopCount);
     expect(clone.panType).toBe(originalPlayback.panType);
+  });
+
+  it.skip("keeps a clone reachable from the destination (#100)", () => {
+    const clone = originalPlayback.clone();
+
+    expectReachable(clone.source!, destination);
   });
 
   it("creates a clone with independent properties", () => {
@@ -440,6 +462,7 @@ describe("Playback filters chain", () => {
   let buffer: AudioBuffer;
   let source: AudioBufferSourceNode;
   let gainNode: GainNode;
+  let destination: (typeof audioContextMock)["destination"];
   let sound: Sound;
 
   beforeEach(() => {
@@ -447,6 +470,8 @@ describe("Playback filters chain", () => {
     source = audioContextMock.createBufferSource();
     source.buffer = buffer;
     gainNode = audioContextMock.createGain();
+    destination = audioContextMock.destination;
+    gainNode.connect(destination);
     sound = new Sound("test-url", buffer, audioContextMock, gainNode);
     playback = new Playback(sound, source, gainNode);
   });
@@ -476,6 +501,7 @@ describe("Playback filters chain", () => {
     expect(playback._filters.length).toBe(2);
     expect(playback._filters[0].type).toBe(filter1.type);
     expect(playback._filters[1].type).toBe(filter2.type);
+    expectPath(source, [playback.panner!, filter1, filter2, gainNode], destination);
   });
 });
 

--- a/src/routeTo.test.ts
+++ b/src/routeTo.test.ts
@@ -6,7 +6,7 @@
 
 import { AudioBuffer } from "standardized-audio-context-mock";
 import { describe, expect, it, vi } from "vitest";
-import { cacophony } from "./setupTests";
+import { cacophony, expectPath, expectReachable } from "./setupTests";
 
 const buildSound = async () => {
   const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
@@ -29,13 +29,15 @@ describe("Sound.routeTo: primary redirection", () => {
       return wrapped;
     });
     sound.routeTo(bus);
-    sound.play();
+    const [playback] = sound.play();
     // The most recently created gain (the playback's gainNode) should have
     // been connected to bus.input. Walk created from the back since other
     // calls (sendGains, etc.) may also be allocated.
     const playbackGain = created[created.length - 1];
     expect(playbackGain).toBeDefined();
     expect(playbackGain.connect).toHaveBeenCalledWith(bus.input);
+    expectPath(playback.outputNode, [], bus.input);
+    expectReachable(playback.source!, bus.output);
     bus.destroy();
   });
 
@@ -60,7 +62,8 @@ describe("Sound.routeTo: primary redirection", () => {
     sound.routeTo(bus);
     sound.routeTo(cacophony.master);
     // Future playbacks should connect to globalGainNode (master.input).
-    sound.play();
+    const [playback] = sound.play();
+    expectPath(playback.outputNode, [], cacophony.master.input);
     bus.destroy();
   });
 
@@ -68,11 +71,9 @@ describe("Sound.routeTo: primary redirection", () => {
     const sound = await buildSound();
     const [playback] = sound.play();
     const bus = cacophony.createBus("live-redirect");
-    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
-    const connectSpy = vi.spyOn(playback.outputNode, "connect");
+    expectPath(playback.outputNode, [], cacophony.master.input);
     sound.routeTo(bus);
-    expect(disconnectSpy).toHaveBeenCalled();
-    expect(connectSpy).toHaveBeenCalledWith(bus.input);
+    expectPath(playback.outputNode, [], bus.input);
     bus.destroy();
   });
 
@@ -100,34 +101,12 @@ describe("Sound.routeTo: additive send", () => {
     const sound = await buildSound();
     const bus = cacophony.createBus("send-test");
     const [playback] = sound.play();
-    // The primary edge already exists from preplay: playback.outputNode →
-    // globalGainNode (master.input). Establishing a send must NOT remove it.
-    // Snapshot the primary edge by spying on outputNode.disconnect — it must
-    // not be invoked. Then capture the send-gain allocation + its outgoing
-    // connect to assert the new edge actually targets bus.input.
-    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
-    const allocatedSendGains: Array<{ node: any; connect: ReturnType<typeof vi.fn> }> = [];
-    vi.spyOn(cacophony.context, "createGain").mockImplementationOnce(() => {
-      const node = realCreateGain();
-      const connectSpy = vi.fn(node.connect.bind(node));
-      Object.assign(node, { connect: connectSpy });
-      allocatedSendGains.push({ node, connect: connectSpy });
-      return node;
-    });
-    const playbackConnectSpy = vi.spyOn(playback.outputNode, "connect");
-    const playbackDisconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
     sound.routeTo(bus, 0.3);
-    // Primary edge to master untouched.
-    expect(playbackDisconnectSpy).not.toHaveBeenCalled();
-    // New send edge from the playback's outputNode goes to the allocated sendGain.
-    expect(playbackConnectSpy).toHaveBeenCalled();
-    expect(allocatedSendGains.length).toBe(1);
-    const sendGain = allocatedSendGains[0];
-    expect(sendGain.node.gain.value).toBe(0.3);
-    expect(playbackConnectSpy).toHaveBeenCalledWith(sendGain.node);
-    // Send edge's second hop: sendGain → bus.input. This is the additive
-    // "playback also reaches the bus" half of the contract.
-    expect(sendGain.connect).toHaveBeenCalledWith(bus.input);
+    const sendGain = playback._sendGains.get(bus);
+    expect(sendGain).toBeDefined();
+    expect(sendGain!.gain.value).toBe(0.3);
+    expectPath(playback.outputNode, [], cacophony.master.input);
+    expectPath(playback.outputNode, [sendGain!], bus.input);
     // And after destroy + cleanup, the sendGain (owned by the playback) must
     // have its disconnect called — see playback._sendGains teardown.
     bus.destroy();
@@ -159,6 +138,10 @@ describe("Sound.routeTo: additive send", () => {
     // No playback yet; play and check no throw.
     const [playback] = sound.play();
     expect(playback).toBeDefined();
+    const sendGain = playback._sendGains.get(bus);
+    expect(sendGain).toBeDefined();
+    expectPath(playback.outputNode, [], cacophony.master.input);
+    expectPath(playback.outputNode, [sendGain!], bus.input);
     bus.destroy();
   });
 
@@ -185,8 +168,9 @@ describe("Synth.routeTo", () => {
     const synth = cacophony.createOscillator({});
     const bus = cacophony.createBus("synth-route");
     synth.routeTo(bus);
-    synth.play();
-    // No throw — the connect happened against bus.input.
+    const [playback] = synth.play();
+    expectPath(playback.outputNode, [], bus.input);
+    expectReachable(playback.source!, bus.output);
     bus.destroy();
   });
 
@@ -194,19 +178,21 @@ describe("Synth.routeTo", () => {
     const synth = cacophony.createOscillator({});
     const [playback] = synth.play();
     const bus = cacophony.createBus("synth-live");
-    const disconnectSpy = vi.spyOn(playback.outputNode, "disconnect");
-    const connectSpy = vi.spyOn(playback.outputNode, "connect");
+    expectPath(playback.outputNode, [], cacophony.master.input);
     synth.routeTo(bus);
-    expect(disconnectSpy).toHaveBeenCalled();
-    expect(connectSpy).toHaveBeenCalledWith(bus.input);
+    expectPath(playback.outputNode, [], bus.input);
     bus.destroy();
   });
 
   it("routeTo with sendGain adds a send", () => {
     const synth = cacophony.createOscillator({});
-    synth.play();
+    const [playback] = synth.play();
     const bus = cacophony.createBus("synth-send");
     expect(() => synth.routeTo(bus, 0.2)).not.toThrow();
+    const sendGain = playback._sendGains.get(bus);
+    expect(sendGain).toBeDefined();
+    expectPath(playback.outputNode, [], cacophony.master.input);
+    expectPath(playback.outputNode, [sendGain!], bus.input);
     bus.destroy();
   });
 

--- a/src/sound.test.ts
+++ b/src/sound.test.ts
@@ -1,6 +1,6 @@
 import { AudioBuffer } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
-import { audioContextMock, cacophony } from "./setupTests";
+import { audioContextMock, cacophony, expectPath, expectReachable } from "./setupTests";
 import { Sound } from "./sound";
 
 describe("Sound playback and state management", () => {
@@ -25,6 +25,8 @@ describe("Sound playback and state management", () => {
     expect(sound.isPlaying).toBe(true);
     expect(playbacks1.length).toBe(1);
     expect(playbacks1[0].isPlaying).toBe(true);
+    expectPath(playbacks1[0].source!, [playbacks1[0].panner!, playbacks1[0].outputNode], cacophony.master.input);
+    expectReachable(playbacks1[0].source!, cacophony.master.output);
 
     sound.stop();
     expect(sound.isPlaying).toBe(false);
@@ -35,6 +37,30 @@ describe("Sound playback and state management", () => {
     expect(playbacks2.length).toBe(1);
     expect(playbacks2[0].isPlaying).toBe(true);
     expect(playbacks2[0]).not.toBe(playbacks1[0]); // New playback instance
+  });
+
+  it("keeps the primary path while adding a send edge", () => {
+    const bus = cacophony.createBus("sound-test-send");
+    const [playback] = sound.play();
+
+    sound.routeTo(bus, 0.4);
+
+    const sendGain = playback._sendGains.get(bus);
+    expect(sendGain).toBeDefined();
+    expectPath(playback.outputNode, [], cacophony.master.input);
+    expectPath(playback.outputNode, [sendGain!], bus.input);
+    bus.destroy();
+  });
+
+  it("rewires a live playback from its old primary route to the new one", () => {
+    const bus = cacophony.createBus("sound-test-primary");
+    const [playback] = sound.play();
+    expectPath(playback.outputNode, [], cacophony.master.input);
+
+    sound.routeTo(bus);
+
+    expectPath(playback.outputNode, [], bus.input);
+    bus.destroy();
   });
 
   it("can pause and resume", () => {

--- a/src/synth.test.ts
+++ b/src/synth.test.ts
@@ -1,15 +1,21 @@
 import { AudioContext } from "standardized-audio-context-mock";
 import { beforeEach, describe, expect, it } from "vitest";
+import { expectPath } from "./setupTests";
 import { Synth } from "./synth";
 import { SynthPlayback } from "./synthPlayback";
 
 describe("Synth class", () => {
   let synth: Synth;
   let audioContextMock: AudioContext;
+  let masterInput: ReturnType<AudioContext["createGain"]>;
+  let destination: AudioContext["destination"];
 
   beforeEach(() => {
     audioContextMock = new AudioContext();
-    synth = new Synth(audioContextMock, audioContextMock.createGain());
+    masterInput = audioContextMock.createGain();
+    destination = audioContextMock.destination;
+    masterInput.connect(destination);
+    synth = new Synth(audioContextMock, masterInput);
   });
 
   it("is created with correct default properties", () => {
@@ -23,6 +29,7 @@ describe("Synth class", () => {
     const playbacks = synth.preplay();
     expect(playbacks.length).toBe(1);
     expect(playbacks[0]).toBeInstanceOf(SynthPlayback);
+    expectPath(playbacks[0].source!, [playbacks[0].panner!, playbacks[0].outputNode, masterInput], destination);
   });
 
   it("can play and stop a synth", () => {
@@ -147,6 +154,18 @@ describe("Synth class", () => {
     expect(playbacks[0].filters[0]).not.toBe(filter);
     expect(playbacks[0].filters[0].type).toBe(filter.type);
     expect(playbacks[0].filters[0].frequency.value).toBe(filter.frequency.value);
+  });
+
+  it.skip("wires cloned filters into the synth playback path (#41)", () => {
+    const filter = audioContextMock.createBiquadFilter();
+    synth.addFilter(filter);
+    const [playback] = synth.preplay();
+
+    expectPath(
+      playback.source!,
+      [playback.panner!, playback.filters[0], playback.outputNode, masterInput],
+      destination,
+    );
   });
 
   it("prevents adding same filter instance twice", () => {

--- a/src/synthPlayback-output.test.ts
+++ b/src/synthPlayback-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { cacophony } from "./setupTests";
+import { cacophony, expectPath } from "./setupTests";
 
 describe("SynthPlayback: outputNode / connect / disconnect parity with Playback", () => {
   it("exposes outputNode (a GainNode) on a live synth playback", () => {
@@ -8,6 +8,7 @@ describe("SynthPlayback: outputNode / connect / disconnect parity with Playback"
     expect(playback.outputNode).toBeDefined();
     // outputNode should be a GainNode (has .gain.value).
     expect((playback.outputNode as unknown as { gain: { value: number } }).gain.value).toBeDefined();
+    expectPath(playback.source!, [playback.panner!, playback.outputNode], cacophony.master.input);
     synth.stop();
   });
 


### PR DESCRIPTION
Closes #99.

## What changed

- Adopt the #98 graph-reachability assertions across playback, synth, media-stream, bus, routing, drain, and Sound suites.
- Replace wiring checks that only observed spy calls with assertions against the active audio graph.
- Keep explicit skipped regression gates for #100, #101, #102, and the synth-filter wiring gap related to #41.

## Why

Property values and connect-call spies can stay green while the audible path is disconnected. These tests now verify the actual source-to-output chains, filter order, additive sends, primary routes, and drain targets.

## TDD evidence

- Baseline: 8 files, 252 tests passed.
- Red: 276 passed; exactly four real wiring defects failed.
- Green: 277 passed; those four downstream defect gates are explicitly skipped and linked to their issues.

## Validation

- `npm run lint`
- `npm run ci:test` — 66 files, 1,017 passed, 4 skipped, no type errors
- `npm run build` — exited 0; the existing declaration-plugin TS4094 diagnostics and TypeDoc warnings were still emitted
