### PR TITLE
Fix oscillator mixin inheritance

### DIFF
--- a/src/oscillatorMixin.test.ts
+++ b/src/oscillatorMixin.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { BasePlayback } from "./basePlayback";
+import { OscillatorMixin } from "./oscillatorMixin";
+
+describe("OscillatorMixin", () => {
+  it("is a BasePlayback subclass without playback implementations", () => {
+    expect(OscillatorMixin.prototype).toBeInstanceOf(BasePlayback);
+    expect(Object.hasOwn(OscillatorMixin.prototype, "play")).toBe(false);
+    expect(Object.hasOwn(OscillatorMixin.prototype, "pause")).toBe(false);
+    expect(Object.hasOwn(OscillatorMixin.prototype, "stop")).toBe(false);
+  });
+});

--- a/src/oscillatorMixin.ts
+++ b/src/oscillatorMixin.ts
@@ -5,95 +5,66 @@ export type OscillatorCloneOverrides = {
   oscillatorOptions?: Partial<OscillatorOptions>;
 };
 
-type Constructor<T = {}> = abstract new (...args: any[]) => T;
+export abstract class OscillatorMixin extends BasePlayback {
+  _oscillatorOptions: Partial<OscillatorOptions> = {};
+  public declare source?: OscillatorNode;
 
-export function OscillatorMixin<TBase extends Constructor>(Base: TBase) {
-  abstract class OscillatorMixin extends BasePlayback {
-    _oscillatorOptions: Partial<OscillatorOptions> = {};
-    public declare source?: OscillatorNode;
+  get oscillatorOptions(): Partial<OscillatorOptions> {
+    return this._oscillatorOptions;
+  }
 
-    get oscillatorOptions(): Partial<OscillatorOptions> {
-      return this._oscillatorOptions;
-    }
-
-    set oscillatorOptions(options: Partial<OscillatorOptions>) {
-      this._oscillatorOptions = options;
-      if (this.source) {
-        if (this.oscillatorOptions.detune !== undefined) this.source.detune.value = this.oscillatorOptions.detune;
-        if (this.oscillatorOptions.frequency !== undefined)
-          this.source.frequency.value = this.oscillatorOptions.frequency;
-        if (this.oscillatorOptions.type) this.source.type = this.oscillatorOptions.type;
-      }
-    }
-
-    play(): [this] {
-      if (!this.source) {
-        throw new Error("No source node found");
-      }
+  set oscillatorOptions(options: Partial<OscillatorOptions>) {
+    this._oscillatorOptions = options;
+    if (this.source) {
       if (this.oscillatorOptions.detune !== undefined) this.source.detune.value = this.oscillatorOptions.detune;
       if (this.oscillatorOptions.frequency !== undefined)
         this.source.frequency.value = this.oscillatorOptions.frequency;
       if (this.oscillatorOptions.type) this.source.type = this.oscillatorOptions.type;
-      this.source.start();
-      this._playing = true;
-      return [this];
-    }
-
-    stop() {
-      if (this.source?.stop) {
-        this.source.stop();
-        this._playing = false;
-      }
-    }
-
-    pause(): void {
-      this.stop();
-    }
-
-    get frequency(): number {
-      if (!this.source) {
-        throw new Error("No source node found");
-      }
-      return this.source.frequency.value;
-    }
-
-    set frequency(frequency: number) {
-      if (!this.source) {
-        throw new Error("No source node found");
-      }
-      this.source.frequency.value = frequency;
-      this.oscillatorOptions.frequency = frequency;
-    }
-
-    get detune(): number {
-      if (!this.source) {
-        throw new Error("No source node found");
-      }
-      return this.source.detune.value;
-    }
-
-    set detune(detune: number) {
-      if (!this.source) {
-        throw new Error("No source node found");
-      }
-      this.source.detune.value = detune;
-      this.oscillatorOptions.detune = detune;
-    }
-
-    get type(): OscillatorType {
-      if (!this.source) {
-        throw new Error("No source node found");
-      }
-      return this.source.type;
-    }
-
-    set type(type: OscillatorType) {
-      if (!this.source) {
-        throw new Error("No source node found");
-      }
-      this.source.type = type;
-      this.oscillatorOptions.type = type;
     }
   }
-  return OscillatorMixin;
+
+  get frequency(): number {
+    if (!this.source) {
+      throw new Error("No source node found");
+    }
+    return this.source.frequency.value;
+  }
+
+  set frequency(frequency: number) {
+    if (!this.source) {
+      throw new Error("No source node found");
+    }
+    this.source.frequency.value = frequency;
+    this.oscillatorOptions.frequency = frequency;
+  }
+
+  get detune(): number {
+    if (!this.source) {
+      throw new Error("No source node found");
+    }
+    return this.source.detune.value;
+  }
+
+  set detune(detune: number) {
+    if (!this.source) {
+      throw new Error("No source node found");
+    }
+    this.source.detune.value = detune;
+    this.oscillatorOptions.detune = detune;
+  }
+
+  get type(): OscillatorType {
+    if (!this.source) {
+      throw new Error("No source node found");
+    }
+    return this.source.type;
+  }
+
+  set type(type: OscillatorType) {
+    if (!this.source) {
+      throw new Error("No source node found");
+    }
+    this.source.type = type;
+    this.oscillatorOptions.type = type;
+  }
 }

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,15 +1,12 @@
 import type { Bus } from "./bus";
 import type { BaseSound } from "./cacophony";
 import type { AudioNode, AudioParam, BaseContext, GainNode, OscillatorNode } from "./context";
-import { FilterManager } from "./filters";
 import { OscillatorMixin } from "./oscillatorMixin";
-import { PannerMixin } from "./pannerMixin";
 import type { Synth } from "./synth";
-import { VolumeMixin } from "./volumeMixin";
 
 type SynthPlaybackState = "unplayed" | "playing" | "paused" | "stopped";
 
-export class SynthPlayback extends OscillatorMixin(PannerMixin(VolumeMixin(FilterManager))) implements BaseSound {
+export class SynthPlayback extends OscillatorMixin implements BaseSound {
   context: BaseContext;
   private _state: SynthPlaybackState = "unplayed";
   /**


### PR DESCRIPTION
## Summary

- replace the misleading `OscillatorMixin(Base)` factory with a plain abstract `BasePlayback` subclass
- make `SynthPlayback` extend that class directly
- delete the shadowed `play()`, `pause()`, and `stop()` implementations, removing the unconditional oscillator restart trap
- add a regression test for the runtime inheritance and playback-control surface

## Root cause

`OscillatorMixin` accepted a base class but ignored it at runtime, while its own playback controls were dead beneath `SynthPlayback` overrides. Making the passed filter/panner/volume chain the real base also discarded the `BasePlayback` lifecycle contract, so the supported issue resolution is to represent the actual inheritance directly.

## Validation

- RED: regression failed because `OscillatorMixin.prototype` was not a `BasePlayback`
- GREEN: regression passes and the class owns none of `play`, `pause`, or `stop`
- `npm run lint`
- `npm run ci:test` — 1,018 passed, 4 existing skips, no type errors
- `npm run build` — exit 0 (existing declaration-plugin and TypeDoc warnings remain)

Closes #111