### PR TITLE
Fix silent orphaned playback clones

### DIFF
--- a/src/playback.test.ts
+++ b/src/playback.test.ts
@@ -239,10 +239,40 @@ describe("Playback cloning", () => {
     expect(clone.panType).toBe(originalPlayback.panType);
   });
 
-  it.skip("keeps a clone reachable from the destination (#100)", () => {
+  it("keeps a clone reachable from the destination (#100)", () => {
     const clone = originalPlayback.clone();
 
     expectReachable(clone.source!, destination);
+  });
+
+  it("starts a clone when the original playback is playing", () => {
+    vi.spyOn(audioContextMock, "createBufferSource").mockImplementation(
+      () =>
+        ({
+          buffer: null,
+          connect: vi.fn(),
+          disconnect: vi.fn(),
+          start: vi.fn(),
+          stop: vi.fn(),
+          onended: null,
+        }) as unknown as AudioBufferSourceNode,
+    );
+    originalPlayback.play();
+
+    const clone = originalPlayback.clone();
+
+    expect(clone.isPlaying).toBe(true);
+    expect(clone.source).toBeDefined();
+    expect(clone.source && "start" in clone.source ? clone.source.start : undefined).toHaveBeenCalledWith(0, 0);
+  });
+
+  it("registers a clone with its origin", () => {
+    const clone = originalPlayback.clone();
+
+    expect(sound.playbacks).toContain(clone);
+
+    sound.stop();
+    expect(clone.source).toBeUndefined();
   });
 
   it("creates a clone with independent properties", () => {

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -804,6 +804,7 @@ export class Playback extends BasePlayback implements BaseSound {
    * Creates a clone of the current Playback instance with optional overrides for certain properties.
    * This method allows for the creation of a new Playback instance that shares the same audio context
    * and source node but can have different settings such as loop count or pan type.
+   * The clone is connected to the origin Sound's primary route and registered with the Sound.
    * @throws {Error} Throws an error if the sound has been cleaned up.
    */
 
@@ -814,6 +815,7 @@ export class Playback extends BasePlayback implements BaseSound {
     const panType = overrides.panType ?? this.panType;
     // we'll need to create a new gain node
     const gainNode = this.context.createGain();
+    gainNode.connect(this.origin._resolveRouteTargetNode());
     // clone the source node
     let source: SourceNode;
     if ("buffer" in this.source && this.source.buffer) {
@@ -843,7 +845,9 @@ export class Playback extends BasePlayback implements BaseSound {
     clone.volume = this.volume;
     clone.playbackRate = this._playbackRate;
     clone._offset = this._offset;
-    clone._state = this._state;
+    if (this._state !== "playing") {
+      clone._state = this._state;
+    }
 
     // Deep clone filters
     this._filters.forEach((filter) => {
@@ -860,6 +864,7 @@ export class Playback extends BasePlayback implements BaseSound {
       clone.play();
     }
 
+    this.origin.playbacks.push(clone);
     return clone;
   }
 }

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -595,7 +595,7 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
    * primary target. Handles the master bus alias and the destroyed-bus
    * fallback (which warns).
    */
-  private _resolveRouteTargetNode(): GainNode {
+  _resolveRouteTargetNode(): GainNode {
     if (!this._routeTarget) {
       return this.globalGainNode;
     }


### PR DESCRIPTION
## Summary

- connect playback clones to their origin Sound's primary route
- genuinely start clones of playing buffer-backed playbacks
- register clones with `Sound.playbacks` so Sound-level lifecycle controls reach them
- activate the reachability acceptance test and add lifecycle regressions

## TDD

Red: `npm test -- src/playback.test.ts` — 3 expected failures for reachability, source start, and origin registration.

Green:

- `npm test -- src/playback.test.ts` — 57 passed, 1 unrelated skipped
- `npm run lint`
- `npm run ci:test` — 1,021 passed, 3 unrelated skipped, no type errors
- `npm run build` — passed with pre-existing declaration and TypeDoc warnings

Closes #100