### PR TITLE
Reconnect playback when pan type changes

### DIFF
--- a/src/playback.test.ts
+++ b/src/playback.test.ts
@@ -1,7 +1,14 @@
 import { AudioBuffer, type AudioBufferSourceNode } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Playback } from "./playback";
-import { audioContextMock, cacophony, expectPath, expectReachable } from "./setupTests";
+import {
+  audioContextMock,
+  cacophony,
+  expectNotReachable,
+  expectPath,
+  expectReachable,
+  graphSnapshot,
+} from "./setupTests";
 import { Sound } from "./sound";
 
 describe("Playback class", () => {
@@ -54,10 +61,16 @@ describe("Playback class", () => {
     expectPath(source, [playback.panner!, gainNode], destination);
   });
 
-  it.skip("keeps the source wired after changing the pan type (#101)", () => {
+  it("keeps the source wired after changing the pan type (#101)", () => {
+    const oldPanner = playback.panner!;
+    const filter = audioContextMock.createBiquadFilter();
+    playback.addFilter(filter);
+
     playback.setPanType("stereo", audioContextMock);
 
-    expectPath(source, [playback.panner!, gainNode], destination);
+    expectPath(source, [playback.panner!, filter, gainNode], destination);
+    expectNotReachable(source, oldPanner);
+    expect(graphSnapshot(oldPanner).edges).toEqual([]);
   });
 
   it("can pause and resume", () => {
@@ -294,6 +307,13 @@ describe("Playback cloning", () => {
     expect(clone.panType).toBe("HRTF");
     expect(clone.volume).toBe(originalPlayback.volume);
     expect(clone.playbackRate).toBe(originalPlayback.playbackRate);
+  });
+
+  it("keeps a clone wired when overriding its pan type (#101)", () => {
+    const clone = originalPlayback.clone({ panType: "stereo" });
+
+    expectPath(clone.source!, [clone.panner!, clone._filters[0]!, clone.gainNode!], gainNode);
+    expectReachable(clone.source!, destination);
   });
 
   it("clones filters correctly", () => {

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -115,6 +115,19 @@ export class Playback extends BasePlayback implements BaseSound {
     this.refreshFilters();
   }
 
+  override setPanType(panType: PanType, audioContext: BaseContext): void {
+    const previousPanner = this.panner;
+    super.setPanType(panType, audioContext);
+
+    if (this.panner === previousPanner || !this.panner || !this.source || !this.gainNode) {
+      return;
+    }
+
+    this.source.disconnect();
+    this.source.connect(this.panner);
+    this.refreshFilters();
+  }
+
   private setupSourceNode(source: SourceNode) {
     if ("mediaElement" in source && source.mediaElement) {
       source.mediaElement.onended = this.loopEnded;


### PR DESCRIPTION
## What changed

- reconnect the playback source when `setPanType` replaces its panner
- rebuild the existing filter/gain chain from the replacement panner
- activate and extend graph reachability coverage for live pan-type changes
- verify `Playback.clone({ panType })` remains reachable through its replacement panner and cloned filter

## Root cause and impact

`PannerMixin.setPanType` disconnected the old panner and created a replacement, but `Playback` did not reconnect its source or downstream chain. Live switches and clone pan-type overrides could therefore produce silent playback.

The regression tests assert the exact source → replacement panner → filter → gain path, end-to-end destination reachability for clones, source non-reachability to the old panner, and no remaining outgoing edges from the old panner.

## TDD and validation

- Red: both new regressions failed at the missing source → replacement panner edge
- Green: `npm test -- src/playback.test.ts` (59 passed)
- `npm run lint`
- `npm run ci:test` (1,023 passed, 2 skipped, no type errors)
- `npm run build`

Closes #101