### PR TITLE
Resume only paused playbacks

### DIFF
--- a/src/playback.ts
+++ b/src/playback.ts
@@ -142,6 +142,10 @@ export class Playback extends BasePlayback implements BaseSound {
     return this._state === "playing";
   }
 
+  get isPaused(): boolean {
+    return this._state === "paused";
+  }
+
   /**
    * Gets the duration of the audio in seconds.
    * @returns {number} The duration of the audio or NaN if the duration is unknown.

--- a/src/sound.test.ts
+++ b/src/sound.test.ts
@@ -76,6 +76,20 @@ describe("Sound playback and state management", () => {
     expect(newPlaybacks[0].isPlaying).toBe(true);
   });
 
+  it("resumes only paused playbacks", () => {
+    const paused = sound.play()[0];
+    const stopped = sound.play()[0];
+    const unplayed = sound.preplay()[0];
+
+    paused.pause();
+    stopped.stop();
+    sound.resume();
+
+    expect(paused.isPlaying).toBe(true);
+    expect(stopped.isPlaying).toBe(false);
+    expect(unplayed.isPlaying).toBe(false);
+  });
+
   it("stops all playbacks when sound is stopped", () => {
     const playbacks1 = sound.play();
     const playbacks2 = sound.play();

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -433,7 +433,7 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
   }
 
   resume(): void {
-    this.playbacks.forEach((playback) => playback.play());
+    this.playbacks.filter((playback) => playback.isPaused).forEach((playback) => playback.play());
     this.emit("resume", undefined);
   }
 

--- a/src/synth.test.ts
+++ b/src/synth.test.ts
@@ -74,6 +74,20 @@ describe("Synth class", () => {
     expect(playback.filters[0].frequency.value).toBe(900);
   });
 
+  it("resumes only paused playbacks", () => {
+    const paused = synth.play()[0];
+    const stopped = synth.play()[0];
+    const unplayed = synth.preplay()[0];
+
+    paused.pause();
+    stopped.stop();
+    synth.resume();
+
+    expect(paused.isPlaying).toBe(true);
+    expect(stopped.isPlaying).toBe(false);
+    expect(unplayed.isPlaying).toBe(false);
+  });
+
   it("applies synth and playback changes made while paused when resumed", () => {
     const filter = audioContextMock.createBiquadFilter();
     filter.type = "lowpass";

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -175,7 +175,7 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
   }
 
   resume(): void {
-    this.playbacks.forEach((playback) => playback.play());
+    this.playbacks.filter((playback) => playback.isPaused).forEach((playback) => playback.play());
     this.emit("resume", undefined);
     this.cacophony?.emit("globalPlay", { source: this, timestamp: Date.now() });
   }

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -48,6 +48,10 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     };
   }
 
+  get isPaused(): boolean {
+    return this._state === "paused";
+  }
+
   play(): [this] {
     if (!this.source || !this.panner) {
       throw new Error("Cannot play a synth that has been cleaned up");


### PR DESCRIPTION
## What changed

- expose paused state on buffer and synth playbacks
- make `Sound.resume()` and `Synth.resume()` call `play()` only for paused entries
- add regression coverage for paused, stopped, and unplayed playbacks

## Why

Container-level resume previously restarted stopped and unplayed entries. That could replay audio a caller had explicitly stopped.

## Validation

- `npm test -- src/sound.test.ts src/synth.test.ts`
- `npm run lint`
- `npm run ci:test`
- `npm run build`

Closes #105