### PR TITLE
Consolidate playback state on BasePlayback

### DIFF
--- a/src/basePlayback.test.ts
+++ b/src/basePlayback.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { BasePlayback } from "./basePlayback";
+import type { PlaybackContainer } from "./container";
+
+class TestPlayback extends BasePlayback {
+  play(): [this] {
+    this.markPlaying();
+    return [this];
+  }
+
+  pause(): void {
+    this.markPaused();
+  }
+
+  stop(): void {
+    this.markStopped();
+  }
+}
+
+describe("BasePlayback state", () => {
+  it("owns the playback state transitions", () => {
+    const playback = new TestPlayback({} as PlaybackContainer);
+
+    expect(playback.isPlaying).toBe(false);
+    expect(playback.isPaused).toBe(false);
+
+    playback.play();
+    expect(playback.isPlaying).toBe(true);
+    expect(playback.isPaused).toBe(false);
+
+    playback.pause();
+    expect(playback.isPlaying).toBe(false);
+    expect(playback.isPaused).toBe(true);
+
+    playback.play();
+    expect(playback.isPlaying).toBe(true);
+    expect(playback.isPaused).toBe(false);
+
+    playback.stop();
+    expect(playback.isPlaying).toBe(false);
+    expect(playback.isPaused).toBe(false);
+  });
+});

--- a/src/basePlayback.ts
+++ b/src/basePlayback.ts
@@ -7,9 +7,11 @@ import { FilterManager } from "./filters";
 import { PannerMixin } from "./pannerMixin";
 import { VolumeMixin } from "./volumeMixin";
 
+export type PlaybackState = "unplayed" | "playing" | "paused" | "stopped";
+
 export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager)) {
   public source?: AudioNode;
-  _playing: boolean = false;
+  protected _state: PlaybackState = "unplayed";
   public origin: PlaybackContainer;
   public eventEmitter: TypedEventEmitter<PlaybackEvents> = new TypedEventEmitter<PlaybackEvents>();
 
@@ -27,10 +29,23 @@ export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager
    */
 
   get isPlaying(): boolean {
-    if (!this.source) {
-      return false;
-    }
-    return this._playing;
+    return this._state === "playing";
+  }
+
+  get isPaused(): boolean {
+    return this._state === "paused";
+  }
+
+  protected markPlaying(): void {
+    this._state = "playing";
+  }
+
+  protected markPaused(): void {
+    this._state = "paused";
+  }
+
+  protected markStopped(): void {
+    this._state = "stopped";
   }
 
   /**

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -34,7 +34,6 @@ export interface MediaStreamSoundOptions {
 export class MediaStreamPlayback extends BasePlayback {
   public declare origin: MediaStreamSound;
   public declare source?: MediaStreamAudioSourceNode;
-  private hasStarted: boolean = false;
   private stopTracksOnStop: boolean;
   /**
    * Muted media element that keeps Chromium's decode pipeline alive for the
@@ -104,15 +103,14 @@ export class MediaStreamPlayback extends BasePlayback {
     if (!this.source) {
       throw new Error("Cannot play a media stream that has been cleaned up");
     }
-    if (this._playing) {
+    if (this.isPlaying) {
       return [this];
     }
     this.source.mediaStream.getTracks().forEach((track) => (track.enabled = true));
     // Muted autoplay is always permitted, so this needs no user gesture; the
     // returned promise is ignored because failure only loses Chromium priming.
     this.primeElement?.play().catch(() => {});
-    this.hasStarted = true;
-    this._playing = true;
+    this.markPlaying();
     this.emit("play", this);
     this.origin.cacophony?.emit("globalPlay", {
       source: this.origin,
@@ -122,12 +120,12 @@ export class MediaStreamPlayback extends BasePlayback {
   }
 
   pause(): void {
-    if (!this.source || !this._playing) {
+    if (!this.source || !this.isPlaying) {
       return;
     }
     this.source.mediaStream.getTracks().forEach((track) => (track.enabled = false));
     this.primeElement?.pause();
-    this._playing = false;
+    this.markPaused();
     this.emit("pause", undefined);
     this.origin.cacophony?.emit("globalPause", {
       source: this.origin,
@@ -143,13 +141,12 @@ export class MediaStreamPlayback extends BasePlayback {
     if (!this.source) {
       throw new Error("Cannot stop a media stream that has been cleaned up");
     }
-    const shouldEmitStop = this.hasStarted;
+    const shouldEmitStop = this._state === "playing" || this._state === "paused";
     if (this.stopTracksOnStop) {
       this.source.mediaStream.getTracks().forEach((track) => track.stop());
     }
     this.teardownPrimeElement();
-    this.hasStarted = false;
-    this._playing = false;
+    this.markStopped();
     if (shouldEmitStop) {
       this.emit("stop", undefined);
       this.origin.cacophony?.emit("globalStop", {
@@ -214,7 +211,7 @@ export class MediaStreamPlayback extends BasePlayback {
     if (!this.source) {
       return;
     }
-    this._playing = false;
+    this.markStopped();
     this.teardownPrimeElement();
     this.source.disconnect();
     this.source = undefined;

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -39,8 +39,6 @@ type PlaybackCloneOverrides = {
   panType: PanType;
 };
 
-type PlaybackState = "unplayed" | "playing" | "paused" | "stopped";
-
 export class Playback extends BasePlayback implements BaseSound {
   private context: BaseContext;
   public declare source?: SourceNode;
@@ -49,7 +47,6 @@ export class Playback extends BasePlayback implements BaseSound {
   private buffer?: AudioBuffer;
   private _offset: number = 0;
   private _startTime: number = 0;
-  private _state: PlaybackState = "unplayed";
   private _playbackRate: number = 1;
   /**
    * Promise that tracks an in-flight media-element `.play()` settlement.
@@ -136,14 +133,6 @@ export class Playback extends BasePlayback implements BaseSound {
     } else {
       throw new Error("Unsupported source type");
     }
-  }
-
-  get isPlaying(): boolean {
-    return this._state === "playing";
-  }
-
-  get isPaused(): boolean {
-    return this._state === "paused";
   }
 
   /**
@@ -320,7 +309,6 @@ export class Playback extends BasePlayback implements BaseSound {
 
       if (mediaPlayPromise) {
         // For media-element sources, defer state and events until browser accepts playback
-        const previousState = this._state;
         // Stash the pending promise so loopEnded (and any future caller that
         // needs to sequence after the deferred state transition) can await it
         // rather than racing source-state mutations against it.
@@ -328,7 +316,7 @@ export class Playback extends BasePlayback implements BaseSound {
           .then(
             () => {
               this._startTime = this.context.currentTime;
-              this._state = "playing";
+              this.markPlaying();
               this.emit("play", this);
               if (isResume) {
                 this.emit("resume", undefined);
@@ -339,7 +327,6 @@ export class Playback extends BasePlayback implements BaseSound {
               });
             },
             (error: Error) => {
-              this._state = previousState;
               void this.emitAsync("error", {
                 error,
                 errorType: "source",
@@ -357,7 +344,7 @@ export class Playback extends BasePlayback implements BaseSound {
       } else {
         // For buffer sources, state transition is immediate (start() is synchronous)
         this._startTime = this.context.currentTime;
-        this._state = "playing";
+        this.markPlaying();
         this.emit("play", this);
         if (isResume) {
           this.emit("resume", undefined);
@@ -396,7 +383,7 @@ export class Playback extends BasePlayback implements BaseSound {
       this.source.stop();
     }
 
-    this._state = "paused";
+    this.markPaused();
     this.emit("pause", undefined);
 
     // Emit globalPause for all playback
@@ -426,7 +413,7 @@ export class Playback extends BasePlayback implements BaseSound {
 
     this._offset = 0;
     this._startTime = 0;
-    this._state = "stopped";
+    this.markStopped();
     this.emit("stop", undefined);
 
     // Emit globalStop for all playback
@@ -592,7 +579,7 @@ export class Playback extends BasePlayback implements BaseSound {
     }
     this._offset = 0;
     this._startTime = 0;
-    this._state = "stopped";
+    this.markStopped();
     this.currentLoop = 0;
     this.source.disconnect();
     this.source = undefined;
@@ -862,8 +849,10 @@ export class Playback extends BasePlayback implements BaseSound {
     clone.volume = this.volume;
     clone.playbackRate = this._playbackRate;
     clone._offset = this._offset;
-    if (this._state !== "playing") {
-      clone._state = this._state;
+    if (this._state === "paused") {
+      clone.markPaused();
+    } else if (this._state === "stopped") {
+      clone.markStopped();
     }
 
     // Deep clone filters

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -4,11 +4,8 @@ import type { AudioNode, AudioParam, BaseContext, GainNode, OscillatorNode } fro
 import { OscillatorMixin } from "./oscillatorMixin";
 import type { Synth } from "./synth";
 
-type SynthPlaybackState = "unplayed" | "playing" | "paused" | "stopped";
-
 export class SynthPlayback extends OscillatorMixin implements BaseSound {
   context: BaseContext;
-  private _state: SynthPlaybackState = "unplayed";
   /**
    * Per-playback send-gain allocations: bus → allocated GainNode. Mirrors
    * {@link Playback._sendGains}. Owned/teardown contract is identical:
@@ -48,10 +45,6 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     };
   }
 
-  get isPaused(): boolean {
-    return this._state === "paused";
-  }
-
   play(): [this] {
     if (!this.source || !this.panner) {
       throw new Error("Cannot play a synth that has been cleaned up");
@@ -70,8 +63,7 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     if (this.oscillatorOptions.type) this.source.type = this.oscillatorOptions.type;
 
     this.source.start();
-    this._playing = true;
-    this._state = "playing";
+    this.markPlaying();
     return [this];
   }
 
@@ -81,8 +73,7 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     }
 
     this.source.stop();
-    this._playing = false;
-    this._state = "paused";
+    this.markPaused();
   }
 
   stop(): void {
@@ -94,8 +85,7 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
       this.source.stop();
     }
 
-    this._playing = false;
-    this._state = "stopped";
+    this.markStopped();
   }
 
   /**
@@ -131,7 +121,7 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     }
     this.source = undefined;
     this.panner = undefined;
-    this._state = "stopped";
+    this.markStopped();
     // Tear down per-playback send-gain nodes before super.cleanup() severs
     // the gainNode edges they feed off of.
     for (const sendGain of this._sendGains.values()) {


### PR DESCRIPTION
## What changed

- move the single `PlaybackState` field and `isPlaying`/`isPaused` derivation to `BasePlayback`
- centralize `markPlaying`, `markPaused`, and `markStopped` transitions there
- remove duplicate `_playing`, subclass `_state`, and `hasStarted` storage from playback implementations
- add one BasePlayback-level transition test

## Why

Playback, synth playback, and media-stream playback maintained overlapping state flags, allowing their lifecycle reporting to drift. The shared state machine gives every playback implementation one source of truth while preserving the point-fix behavior already covered by the clone and resume regressions.

## TDD

The new BasePlayback transition test was added first and failed because `isPaused` and the shared transition methods did not exist. It passes after the consolidation.

## Validation

- `npm run lint`
- `npm run ci:test` — 1,028 passed, 2 skipped, no type errors
- `npm run build` — passed; existing declaration-plugin TS4094 diagnostics remain non-fatal

Closes #106