### PR TITLE
Fix Rollup glob import after dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@rollup/plugin-typescript": "^11.1.6",
         "@types/audioworklet": "^0.0.87",
         "@types/node": "^22.18.1",
+        "glob": "^13.0.6",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "rimraf": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@rollup/plugin-typescript": "^11.1.6",
     "@types/audioworklet": "^0.0.87",
     "@types/node": "^22.18.1",
+    "glob": "^13.0.6",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "rimraf": "^6.1.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,9 +2,9 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import replace from '@rollup/plugin-replace';
 import typescript from '@rollup/plugin-typescript';
-import glob from 'glob'; // Ensure you have the 'glob' package installed
+import { globSync } from 'glob';
 
-const inputFiles = glob.sync('src/processors/**/*.ts').filter((file) => {
+const inputFiles = globSync('src/processors/**/*.ts', { posix: true }).filter((file) => {
   // exclude tests and definitions
   return !file.endsWith('.test.ts') && !file.endsWith('.d.ts');
 });


### PR DESCRIPTION
## What changed

- declare `glob` as a direct development dependency instead of relying on a transitive install
- use the `globSync` named export supported by `glob@13`
- request POSIX path separators so the existing processor filename extraction remains cross-platform

## Why

The dependency update on `master` installs `glob@13`, which no longer provides the default export used by `rollup.config.js`. Every CI matrix test failed or was cancelled before tests while loading the Rollup config.

## Validation

- clean `npm ci` reproduced the original import failure
- `npm run build:worklets`
- `npm run lint`
- `npm run ci:test` — 1,027 passed, 2 skipped, no type errors
- `npm run build` — passed with the repository's existing non-fatal TS4094 declaration diagnostics

Unblocks #125.