### PR TITLE
Extract shared RoutableSource routing

### DIFF
--- a/src/basePlayback.ts
+++ b/src/basePlayback.ts
@@ -1,6 +1,7 @@
+import type { Bus } from "./bus";
 import type { FadeType } from "./cacophony";
 import type { PlaybackContainer } from "./container";
-import type { AudioNode } from "./context";
+import type { AudioNode, GainNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { PlaybackEvents } from "./events";
 import { FilterManager } from "./filters";
@@ -11,6 +12,11 @@ export type PlaybackState = "unplayed" | "playing" | "paused" | "stopped";
 
 export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager)) {
   public source?: AudioNode;
+  /**
+   * Per-playback send-gain allocations owned by the shared routing state
+   * machine. Cleanup disconnects every allocation deterministically.
+   */
+  _sendGains: Map<Bus, GainNode> = new Map();
   protected _state: PlaybackState = "unplayed";
   public origin: PlaybackContainer;
   public eventEmitter: TypedEventEmitter<PlaybackEvents> = new TypedEventEmitter<PlaybackEvents>();
@@ -93,6 +99,14 @@ export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager
   }
 
   cleanup(): void {
+    for (const sendGain of this._sendGains.values()) {
+      try {
+        sendGain.disconnect();
+      } catch {
+        // The node may already have been disconnected externally.
+      }
+    }
+    this._sendGains.clear();
     this.eventEmitter.removeAllListeners();
     super.cleanup();
   }

--- a/src/mediaStream.test.ts
+++ b/src/mediaStream.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Cacophony } from "./cacophony";
 import { MediaStreamPlayback, MediaStreamSound } from "./mediaStream";
-import { expectPath } from "./setupTests";
+import { expectNotReachable, expectPath, expectReachable } from "./setupTests";
 
 function createMockTrack(): MediaStreamTrack {
   return {
@@ -130,6 +130,27 @@ describe("MediaStreamSound", () => {
 
     expect(sound).toBeInstanceOf(MediaStreamSound);
     expect(events).toEqual(["play", "pause", "stop"]);
+  });
+
+  it("routes a live stream through a bus via the public Cacophony API", () => {
+    const cacophony = new Cacophony(context as any);
+    vi.spyOn(context as any, "createMediaStreamSource").mockReturnValue(source);
+    const sound = cacophony.createMediaStreamSound(stream, {
+      primeWithMediaElement: false,
+      stopTracksOnStop: false,
+    });
+    const bus = cacophony.createBus("media-stream-route");
+    bus.disconnect(cacophony.master);
+    const [playback] = sound.play();
+
+    sound.routeTo(bus);
+
+    expectPath(playback.outputNode, [], bus.input);
+    expectReachable(source, bus.output);
+    expectNotReachable(playback.outputNode, cacophony.master.input);
+
+    sound.cleanup();
+    bus.destroy();
   });
 });
 

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -1,6 +1,5 @@
 import { BasePlayback } from "./basePlayback";
 import type { BaseSound, Cacophony, LoopCount, PanType } from "./cacophony";
-import { PlaybackContainer } from "./container";
 import type {
   AudioNode,
   AudioParam,
@@ -9,7 +8,7 @@ import type {
   GainNode,
   MediaStreamAudioSourceNode,
 } from "./context";
-import { FilterManager } from "./filters";
+import { RoutableSource } from "./routableSource";
 
 export interface MediaStreamSoundOptions {
   panType?: PanType;
@@ -219,10 +218,10 @@ export class MediaStreamPlayback extends BasePlayback {
   }
 }
 
-export class MediaStreamSound extends PlaybackContainer(FilterManager) implements BaseSound {
+export class MediaStreamSound extends RoutableSource implements BaseSound {
   public declare playbacks: MediaStreamPlayback[];
-  private context: BaseContext;
-  private globalGainNode: GainNode;
+  protected context: BaseContext;
+  protected globalGainNode: GainNode;
   private stream: MediaStream;
   private stopTracksOnStop: boolean;
   private panType: PanType;
@@ -267,11 +266,12 @@ export class MediaStreamSound extends PlaybackContainer(FilterManager) implement
       source,
       gainNode,
       this.context,
-      this.globalGainNode,
+      this._resolveRouteTargetNode(),
       this.panType,
       this.stopTracksOnStop,
       this.primeWithMediaElement,
     );
+    this._wireRouteSends(playback);
     playback.volume = this.volume;
     if (this.panType === "HRTF") {
       playback.threeDOptions = this.threeDOptions;

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -19,7 +19,6 @@
  */
 
 import { BasePlayback } from "./basePlayback";
-import type { Bus } from "./bus";
 import type { BaseSound, FadeType, LoopCount, PanType } from "./cacophony";
 import type {
   AudioBuffer,
@@ -59,18 +58,6 @@ export class Playback extends BasePlayback implements BaseSound {
   _fadeInConfig?: { duration: number; type: FadeType; perLoop: boolean; targetVolume: number };
   _fadeOutConfig?: { duration: number; type: FadeType };
   _loopEndCallback?: () => void;
-  /**
-   * Per-playback send-gain allocations: bus → allocated GainNode. Sounds
-   * record send intent in `Sound._sends` (value-only), and the actual
-   * GainNode lifecycle is owned here — allocated at preplay or
-   * `Sound.routeTo(bus, gain)`, torn down in {@link cleanup}.
-   *
-   * Iterable Map (not WeakMap) so cleanup can walk every send and call
-   * `disconnect()` on it; relying on GC for disconnect would leave the bus
-   * graph holding the allocation indirectly.
-   */
-  _sendGains: Map<Bus, GainNode> = new Map();
-
   /**
    * Desired pitch-shift factor (1 = no shift, 2 = +1 octave, 0.5 = -1 octave).
    * Stored even before the worklet node exists so a value set on a cleaned-up /
@@ -583,17 +570,6 @@ export class Playback extends BasePlayback implements BaseSound {
     this.currentLoop = 0;
     this.source.disconnect();
     this.source = undefined;
-    // Tear down any per-playback send-gain nodes allocated by Sound.routeTo
-    // (or preplay) before the gainNode is severed by super.cleanup(). The
-    // gainNode → sendGain → bus.input chain is now fully disconnected.
-    for (const sendGain of this._sendGains.values()) {
-      try {
-        sendGain.disconnect();
-      } catch {
-        // Best-effort — node may already have been disconnected externally.
-      }
-    }
-    this._sendGains.clear();
     // Tear down the phase-vocoder pitch-shift worklet node if one was spliced in.
     if (this._pitchShiftNode) {
       try {

--- a/src/routableSource.ts
+++ b/src/routableSource.ts
@@ -1,0 +1,181 @@
+import type { BasePlayback } from "./basePlayback";
+import type { Bus, BusRoutedSource } from "./bus";
+import type { Cacophony } from "./cacophony";
+import { PlaybackContainer } from "./container";
+import type { BaseContext, GainNode } from "./context";
+import { FilterManager } from "./filters";
+
+/**
+ * Shared routing state machine for playback-producing sources.
+ *
+ * The concrete source supplies its audio context, master output, owning
+ * Cacophony instance, and playback list. This mixin owns primary-route state,
+ * additive sends, bus registration, live rewiring, drain handling, and route
+ * cleanup for every source type.
+ */
+export abstract class RoutableSource extends PlaybackContainer(FilterManager) implements BusRoutedSource {
+  protected abstract context: BaseContext;
+  protected abstract globalGainNode: GainNode;
+  abstract get cacophony(): Cacophony | undefined;
+
+  /** Primary route target. `null` is the canonical master route. */
+  protected _routeTarget: Bus | null = null;
+  /** Additional send target to gain-value mappings. */
+  protected _sends: Map<Bus, number> = new Map();
+
+  /**
+   * Route this source to a bus, or add an independent send when `sendGain`
+   * is provided.
+   */
+  routeTo(target: Bus | string, sendGain?: number): void {
+    const bus = this._resolveBusArg(target);
+    if (sendGain !== undefined) {
+      this._addSend(bus, sendGain);
+      return;
+    }
+    this._setPrimary(bus);
+  }
+
+  private _resolveBusArg(target: Bus | string): Bus {
+    if (typeof target !== "string") {
+      return target;
+    }
+    const bus = this.cacophony?.getBus(target);
+    if (!bus) {
+      throw new Error(`No bus registered with name '${target}'`);
+    }
+    return bus;
+  }
+
+  /**
+   * Resolve the node used by future playbacks for their primary output.
+   * Sources left on a subsequently destroyed bus fall back to master.
+   */
+  _resolveRouteTargetNode(): GainNode {
+    if (!this._routeTarget) {
+      return this.globalGainNode;
+    }
+    if (this._routeTarget.destroyed) {
+      console.warn(
+        `${this.constructor.name} routed to destroyed bus '${this._routeTarget.name ?? "<anonymous>"}'; falling back to master`,
+      );
+      return this.globalGainNode;
+    }
+    return this._routeTarget.input;
+  }
+
+  /**
+   * Establish every configured send on a newly created playback.
+   */
+  protected _wireRouteSends(playback: BasePlayback): void {
+    const outputNode = (playback as BasePlayback & { readonly outputNode: GainNode }).outputNode;
+    for (const [bus, gainValue] of this._sends) {
+      if (bus.destroyed) {
+        console.warn(`${this.constructor.name} has a send to destroyed bus '${bus.name ?? "<anonymous>"}'; skipping`);
+        continue;
+      }
+      const sendGain = this.context.createGain();
+      sendGain.gain.value = gainValue;
+      outputNode.connect(sendGain);
+      sendGain.connect(bus.input);
+      playback._sendGains.set(bus, sendGain);
+    }
+  }
+
+  private _setPrimary(bus: Bus): void {
+    if (bus.destroyed) {
+      throw new Error(`Cannot route to destroyed bus '${bus.name ?? "<anonymous>"}'`);
+    }
+    const collapseToMaster = bus.input === this.globalGainNode;
+    const oldTarget = this._routeTarget;
+    const oldTargetNode = this._resolveRouteTargetNode();
+    this._routeTarget = collapseToMaster ? null : bus;
+    const newTarget = this._routeTarget;
+    const newTargetNode = this._resolveRouteTargetNode();
+
+    // Bus registration follows bus identity, not resolved node identity. A
+    // destroyed bus and master can resolve to the same node while still
+    // requiring the old bus registration to be removed.
+    if (oldTarget !== newTarget) {
+      if (oldTarget && !this._sends.has(oldTarget)) {
+        oldTarget._unregisterRoutedSource(this);
+      }
+      if (newTarget) {
+        newTarget._registerRoutedSource(this);
+      }
+    }
+    if (oldTargetNode === newTargetNode) {
+      return;
+    }
+    for (const playback of this.playbacks as Array<BasePlayback & { readonly outputNode: GainNode }>) {
+      try {
+        playback.outputNode.disconnect(oldTargetNode);
+      } catch {
+        // A playback may already have been disconnected during cleanup.
+      }
+      try {
+        playback.outputNode.connect(newTargetNode);
+      } catch {
+        // Live rewiring is best-effort for externally disconnected nodes.
+      }
+    }
+  }
+
+  private _addSend(bus: Bus, gainValue: number): void {
+    if (bus.destroyed) {
+      throw new Error(`Cannot add a send to destroyed bus '${bus.name ?? "<anonymous>"}'`);
+    }
+    this._sends.set(bus, gainValue);
+    bus._registerRoutedSource(this);
+    for (const playback of this.playbacks as Array<BasePlayback & { readonly outputNode: GainNode }>) {
+      const existing = playback._sendGains.get(bus);
+      if (existing) {
+        existing.gain.value = gainValue;
+        continue;
+      }
+      const sendGain = this.context.createGain();
+      sendGain.gain.value = gainValue;
+      try {
+        playback.outputNode.connect(sendGain);
+      } catch {
+        continue;
+      }
+      sendGain.connect(bus.input);
+      playback._sendGains.set(bus, sendGain);
+    }
+  }
+
+  _onBusDrained(bus: Bus, target: Bus): void {
+    if (this._routeTarget === bus) {
+      this._setPrimary(target);
+    }
+    if (!this._sends.has(bus)) {
+      return;
+    }
+    const gainValue = this._sends.get(bus) as number;
+    this._sends.delete(bus);
+    for (const playback of this.playbacks as Array<BasePlayback & { readonly outputNode: GainNode }>) {
+      const sendGain = playback._sendGains.get(bus);
+      if (!sendGain) {
+        continue;
+      }
+      try {
+        sendGain.disconnect();
+      } catch {
+        // The node may already have been disconnected externally.
+      }
+      playback._sendGains.delete(bus);
+    }
+    this._addSend(target, gainValue);
+  }
+
+  cleanup(): void {
+    if (this._routeTarget) {
+      this._routeTarget._unregisterRoutedSource(this);
+    }
+    for (const bus of this._sends.keys()) {
+      bus._unregisterRoutedSource(this);
+    }
+    super.cleanup();
+  }
+}

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -21,7 +21,6 @@
  * instances of a sound with different settings, without requiring the user to manually manage each playback instance.
  */
 
-import type { Bus, BusRoutedSource } from "./bus";
 import type {
   BaseSound,
   Cacophony,
@@ -31,14 +30,13 @@ import type {
   SoundCleanupHoldings,
   SoundType,
 } from "./cacophony";
-import { PlaybackContainer } from "./container";
 import type { AudioBuffer, BaseContext, BiquadFilterNode, GainNode, SourceNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { SoundEvents } from "./events";
-import { FilterManager } from "./filters";
 import type { PanCloneOverrides } from "./pannerMixin";
 import { Playback } from "./playback";
 import type { TimeStretchOptions } from "./processors/timestretch-core";
+import { RoutableSource } from "./routableSource";
 import type { VolumeCloneOverrides } from "./volumeMixin";
 
 type SoundCloneOverrides = PanCloneOverrides &
@@ -48,7 +46,7 @@ type SoundCloneOverrides = PanCloneOverrides &
     filters?: BiquadFilterNode[];
   };
 
-export class Sound extends PlaybackContainer(FilterManager) implements BaseSound, BusRoutedSource {
+export class Sound extends RoutableSource implements BaseSound {
   public declare playbacks: Playback[];
   buffer?: AudioBuffer;
   context: BaseContext;
@@ -73,30 +71,11 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
    * tied to the playback identity.
    */
   private _playbackUnsubscribes: WeakMap<Playback, Array<() => void>> = new WeakMap();
-  /**
-   * Primary route target for this Sound. `null` means master (the default —
-   * preplay connects to {@link globalGainNode} which IS `master.input`).
-   * When a Bus is assigned via {@link routeTo}, future playbacks connect to
-   * `bus.input` instead, and live playbacks are rewired.
-   */
-  private _routeTarget: Bus | null = null;
-  /**
-   * Additional send edges established by {@link routeTo}(bus, sendGain).
-   * Keyed by target bus → send gain value. At preplay we allocate one
-   * GainNode per send per playback so each playback has its own send edges
-   * (a per-Sound shared sendGain would crash the second simultaneous
-   * playback because both gainNodes would connect into the same single
-   * sendGain, doubling the dry signal). The actual GainNode lifecycle is
-   * owned by each Playback in {@link Playback._sendGains} — iterable so
-   * cleanup can walk every send and call `disconnect()`.
-   */
-  private _sends: Map<Bus, number> = new Map();
-
   constructor(
     public url: string,
     buffer: AudioBuffer | undefined,
     context: BaseContext,
-    private globalGainNode: GainNode,
+    protected globalGainNode: GainNode,
     public soundType: SoundType = "buffer",
     public panType: PanType = "HRTF",
     private _cacophony?: Cacophony,
@@ -231,23 +210,7 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
       const primaryTargetNode = this._resolveRouteTargetNode();
       gainNode.connect(primaryTargetNode);
       const playback = new Playback(this, source, gainNode);
-      // Establish send edges (per-playback allocation so each playback owns
-      // its own send-gain nodes — see _sends docstring). The allocated
-      // GainNode lives on the Playback (`playback._sendGains`) so it gets
-      // torn down explicitly in Playback.cleanup().
-      if (this._sends.size > 0) {
-        for (const [bus, gainValue] of this._sends) {
-          if (bus.destroyed) {
-            console.warn(`Sound has a send to destroyed bus '${bus.name ?? "<anonymous>"}'; skipping`);
-            continue;
-          }
-          const sendGain = this.context.createGain();
-          sendGain.gain.value = gainValue;
-          gainNode.connect(sendGain);
-          sendGain.connect(bus.input);
-          playback._sendGains.set(bus, sendGain);
-        }
-      }
+      this._wireRouteSends(playback);
       this._holdings.sources.push(source);
       this._holdings.gainNodes.push(gainNode);
       if ("mediaElement" in source && source.mediaElement) {
@@ -552,193 +515,8 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
     await Promise.all(this.playbacks.map((p) => p.setPitchShift(factor)));
   }
 
-  /**
-   * Routes this Sound to a Bus (or back to master). Two modes:
-   *
-   * - `routeTo(target)` — replace primary routing. Live playbacks are
-   *   rewired: each playback's outputNode is disconnected from its current
-   *   target and re-connected to the new target's input. Future playbacks
-   *   read the stored target at preplay.
-   * - `routeTo(target, sendGain)` — ADD a send (does not change primary
-   *   routing). An additional edge is created from each live playback
-   *   through an allocated GainNode set to `sendGain`. Future playbacks
-   *   get the same send at preplay.
-   *
-   * `target` may be a Bus instance or the name of a registered bus (string
-   *  lookup via `cacophony.getBus`). A string with no matching bus throws.
-   *
-   * Passing the master bus (or `cacophony.master`) as `target` (no
-   *  sendGain) is the canonical way to reset primary routing back to master.
-   */
-  routeTo(target: Bus | string, sendGain?: number): void {
-    const bus = this._resolveBusArg(target);
-    if (sendGain !== undefined) {
-      this._addSend(bus, sendGain);
-      return;
-    }
-    this._setPrimary(bus);
-  }
-
-  private _resolveBusArg(target: Bus | string): Bus {
-    if (typeof target !== "string") {
-      return target;
-    }
-    const bus = this._cacophony?.getBus(target);
-    if (!bus) {
-      throw new Error(`No bus registered with name '${target}'`);
-    }
-    return bus;
-  }
-
-  /**
-   * Returns the AudioNode that future playbacks should connect to as their
-   * primary target. Handles the master bus alias and the destroyed-bus
-   * fallback (which warns).
-   */
-  _resolveRouteTargetNode(): GainNode {
-    if (!this._routeTarget) {
-      return this.globalGainNode;
-    }
-    if (this._routeTarget.destroyed) {
-      console.warn(
-        `Sound routed to destroyed bus '${this._routeTarget.name ?? "<anonymous>"}'; falling back to master`,
-      );
-      return this.globalGainNode;
-    }
-    return this._routeTarget.input;
-  }
-
-  /**
-   * Apply a new primary route. If a bus is passed and it's the master bus,
-   * collapse to `null` so the canonical "route to master" representation is
-   * always `null` (matches the default).
-   *
-   * @throws if `bus` is destroyed. Symmetric with {@link _addSend}'s guard;
-   *   a destroyed bus is an invalid mutation target. (Sounds already routed
-   *   BEFORE the bus was destroyed still fall back to master at preplay via
-   *   {@link _resolveRouteTargetNode} — that path is separate.)
-   */
-  private _setPrimary(bus: Bus): void {
-    if (bus.destroyed) {
-      throw new Error(`Cannot route to destroyed bus '${bus.name ?? "<anonymous>"}'`);
-    }
-    // master.input === globalGainNode — normalize to null in either case so
-    // there is one canonical "route to master" state.
-    const collapseToMaster = bus.input === this.globalGainNode;
-    const oldTarget = this._routeTarget;
-    const oldTargetNode = this._resolveRouteTargetNode();
-    this._routeTarget = collapseToMaster ? null : bus;
-    const newTarget = this._routeTarget;
-    const newTargetNode = this._resolveRouteTargetNode();
-    // Maintain inbound source-tracking driven by the route-target BUS IDENTITY,
-    // independent of whether the resolved AudioNode changed. A bus-identity
-    // transition (e.g. off a destroyed bus that resolves to globalGainNode, onto
-    // master which is ALSO globalGainNode) leaves the resolved nodes equal — so
-    // this must run BEFORE the node-equality early-return below, or the
-    // unregister of the old bus is skipped and the sound leaks in the old bus's
-    // `_routedSources`. (master/null is excluded because it is `null`.)
-    if (oldTarget !== newTarget) {
-      if (oldTarget && !this._sends.has(oldTarget)) {
-        oldTarget._unregisterRoutedSource(this);
-      }
-      if (newTarget) {
-        newTarget._registerRoutedSource(this);
-      }
-    }
-    // The node-equality guard gates only the live-playback rewire: when the
-    // resolved primary AudioNode is unchanged there is nothing to disconnect/
-    // reconnect. Registration bookkeeping has already been settled above.
-    if (oldTargetNode === newTargetNode) {
-      return;
-    }
-    for (const playback of this.playbacks) {
-      try {
-        playback.outputNode.disconnect(oldTargetNode);
-      } catch {
-        // Some playbacks may already have been disconnected (cleanup, manual
-        // disconnect). Tolerate.
-      }
-      try {
-        playback.outputNode.connect(newTargetNode);
-      } catch {
-        // Best-effort live rewire.
-      }
-    }
-  }
-
-  private _addSend(bus: Bus, gainValue: number): void {
-    if (bus.destroyed) {
-      throw new Error(`Cannot add a send to destroyed bus '${bus.name ?? "<anonymous>"}'`);
-    }
-    this._sends.set(bus, gainValue);
-    // A sound that sends to a bus is an inbound source of it too, so it must
-    // be drained off when the bus is torn down.
-    bus._registerRoutedSource(this);
-    // Establish send edges on existing playbacks. The per-playback Map is
-    // the canonical owner of the GainNode lifecycle (so cleanup can iterate
-    // and disconnect every send).
-    for (const playback of this.playbacks) {
-      const existing = playback._sendGains.get(bus);
-      if (existing) {
-        existing.gain.value = gainValue;
-        continue;
-      }
-      const sendGain = this.context.createGain();
-      sendGain.gain.value = gainValue;
-      try {
-        playback.outputNode.connect(sendGain);
-      } catch {
-        // Playback may have been cleaned up; skip.
-        continue;
-      }
-      sendGain.connect(bus.input);
-      playback._sendGains.set(bus, sendGain);
-    }
-  }
-
-  /**
-   * Reroute this sound off `bus` onto `target` when `bus` is being drained
-   * (typically just before it is destroyed). A sound may be BOTH primary-routed
-   * to `bus` AND have a send to it — both edges move.
-   */
-  _onBusDrained(bus: Bus, target: Bus): void {
-    // Primary route: reuse _setPrimary so live playbacks are rewired and the
-    // source-registration (un)registers through the normal path.
-    if (this._routeTarget === bus) {
-      this._setPrimary(target);
-    }
-    // Send: capture the gain, tear down the old send (map entry + per-playback
-    // GainNode for `bus`), then re-establish an equivalent send to `target`.
-    if (this._sends.has(bus)) {
-      const gainValue = this._sends.get(bus) as number;
-      this._sends.delete(bus);
-      for (const playback of this.playbacks) {
-        const sendGain = playback._sendGains.get(bus);
-        if (!sendGain) {
-          continue;
-        }
-        // Same per-playback send-teardown shape as Playback.cleanup.
-        try {
-          sendGain.disconnect();
-        } catch {
-          // Best-effort — node may already have been disconnected externally.
-        }
-        playback._sendGains.delete(bus);
-      }
-      this._addSend(target, gainValue);
-    }
-  }
-
   cleanup(): void {
     this._cacophony?.unregisterSoundCleanup(this._unregisterToken);
-    // Drop ourselves from the source-tracking of every bus we route to, so a
-    // later drain/destroy of that bus does not touch this dead sound.
-    if (this._routeTarget) {
-      this._routeTarget._unregisterRoutedSource(this);
-    }
-    for (const bus of this._sends.keys()) {
-      bus._unregisterRoutedSource(this);
-    }
     this._holdings.sources.length = 0;
     this._holdings.gainNodes.length = 0;
     this._holdings.mediaElements.length = 0;
@@ -752,5 +530,6 @@ export class Sound extends PlaybackContainer(FilterManager) implements BaseSound
     });
     this.playbacks = [];
     this.eventEmitter.removeAllListeners();
+    super.cleanup();
   }
 }

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -1,27 +1,20 @@
-import type { Bus, BusRoutedSource } from "./bus";
 import type { BaseSound, Cacophony, PanType, SoundType } from "./cacophony";
-import { PlaybackContainer } from "./container";
 import type { BaseContext, GainNode, OscillatorNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { SynthEvents } from "./events";
 import type { FilterCloneOverrides } from "./filters";
-import { FilterManager } from "./filters";
 import type { OscillatorCloneOverrides } from "./oscillatorMixin";
 import type { PanCloneOverrides } from "./pannerMixin";
+import { RoutableSource } from "./routableSource";
 import { SynthPlayback } from "./synthPlayback";
 import type { VolumeCloneOverrides } from "./volumeMixin";
 
 type SynthCloneOverrides = FilterCloneOverrides & OscillatorCloneOverrides & PanCloneOverrides & VolumeCloneOverrides;
 
-export class Synth extends PlaybackContainer(FilterManager) implements BaseSound, BusRoutedSource {
+export class Synth extends RoutableSource implements BaseSound {
   _oscillatorOptions: Partial<OscillatorOptions>;
   playbacks: SynthPlayback[] = [];
   private eventEmitter: TypedEventEmitter<SynthEvents> = new TypedEventEmitter<SynthEvents>();
-  /** Primary route target. `null` means master. See Sound for full notes. */
-  private _routeTarget: Bus | null = null;
-  /** Send target → send gain value. See Sound._sends for notes. */
-  private _sends: Map<Bus, number> = new Map();
-
   /**
    * Register event listener.
    * @returns Cleanup function
@@ -47,15 +40,19 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
 
   constructor(
     public context: BaseContext,
-    private globalGainNode: GainNode,
+    protected globalGainNode: GainNode,
     public soundType: SoundType = "oscillator",
     public panType: PanType = "HRTF",
     oscillatorOptions: Partial<OscillatorOptions> = {},
-    private cacophony?: Cacophony,
+    private _cacophony?: Cacophony,
   ) {
     super();
     this.context = context;
     this._oscillatorOptions = oscillatorOptions;
+  }
+
+  get cacophony(): Cacophony | undefined {
+    return this._cacophony;
   }
 
   /**
@@ -83,7 +80,7 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
       this.soundType,
       panType,
       oscillatorOptions,
-      this.cacophony,
+      this._cacophony,
     );
     clone._volume = volume;
     clone._position = position;
@@ -119,22 +116,7 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
     const primaryTargetNode = this._resolveRouteTargetNode();
     gainNode.connect(primaryTargetNode);
     const playback = new SynthPlayback(this, oscillator, gainNode);
-    // Establish send edges (per-playback allocation; see Sound docstring).
-    // Send-gain GainNodes are owned by the playback (`playback._sendGains`)
-    // so cleanup can iterate and disconnect them explicitly.
-    if (this._sends.size > 0) {
-      for (const [bus, gainValue] of this._sends) {
-        if (bus.destroyed) {
-          console.warn(`Synth has a send to destroyed bus '${bus.name ?? "<anonymous>"}'; skipping`);
-          continue;
-        }
-        const sendGain = this.context.createGain();
-        sendGain.gain.value = gainValue;
-        gainNode.connect(sendGain);
-        sendGain.connect(bus.input);
-        playback._sendGains.set(bus, sendGain);
-      }
-    }
+    this._wireRouteSends(playback);
     playback.volume = this.volume;
     // Clone filters from synth to playback (each playback gets independent filter instances)
     this._filters.forEach((filter) => {
@@ -222,119 +204,6 @@ export class Synth extends PlaybackContainer(FilterManager) implements BaseSound
     this._oscillatorOptions.detune = detune;
     this.playbacks.forEach((p) => (p.detune = detune));
     this.emit("detuneChange", detune);
-  }
-
-  /**
-   * Routes this Synth to a Bus (or back to master). See Sound.routeTo for
-   * full semantics — Synth mirrors the behavior exactly.
-   */
-  routeTo(target: Bus | string, sendGain?: number): void {
-    const bus = this._resolveBusArg(target);
-    if (sendGain !== undefined) {
-      this._addSend(bus, sendGain);
-      return;
-    }
-    this._setPrimary(bus);
-  }
-
-  private _resolveBusArg(target: Bus | string): Bus {
-    if (typeof target !== "string") {
-      return target;
-    }
-    const bus = this.cacophony?.getBus(target);
-    if (!bus) {
-      throw new Error(`No bus registered with name '${target}'`);
-    }
-    return bus;
-  }
-
-  private _resolveRouteTargetNode(): GainNode {
-    if (!this._routeTarget) {
-      return this.globalGainNode;
-    }
-    if (this._routeTarget.destroyed) {
-      console.warn(
-        `Synth routed to destroyed bus '${this._routeTarget.name ?? "<anonymous>"}'; falling back to master`,
-      );
-      return this.globalGainNode;
-    }
-    return this._routeTarget.input;
-  }
-
-  private _setPrimary(bus: Bus): void {
-    if (bus.destroyed) {
-      throw new Error(`Cannot route to destroyed bus '${bus.name ?? "<anonymous>"}'`);
-    }
-    const collapseToMaster = bus.input === this.globalGainNode;
-    const oldTarget = this._routeTarget;
-    const oldTargetNode = this._resolveRouteTargetNode();
-    this._routeTarget = collapseToMaster ? null : bus;
-    const newTarget = this._routeTarget;
-    const newTargetNode = this._resolveRouteTargetNode();
-    if (oldTarget !== newTarget) {
-      if (oldTarget && !this._sends.has(oldTarget)) {
-        oldTarget._unregisterRoutedSource(this);
-      }
-      if (newTarget) {
-        newTarget._registerRoutedSource(this);
-      }
-    }
-    if (oldTargetNode === newTargetNode) {
-      return;
-    }
-    for (const playback of this.playbacks) {
-      try {
-        playback.outputNode.disconnect(oldTargetNode);
-      } catch {}
-      try {
-        playback.outputNode.connect(newTargetNode);
-      } catch {}
-    }
-  }
-
-  private _addSend(bus: Bus, gainValue: number): void {
-    if (bus.destroyed) {
-      throw new Error(`Cannot add a send to destroyed bus '${bus.name ?? "<anonymous>"}'`);
-    }
-    this._sends.set(bus, gainValue);
-    bus._registerRoutedSource(this);
-    for (const playback of this.playbacks) {
-      const existing = playback._sendGains.get(bus);
-      if (existing) {
-        existing.gain.value = gainValue;
-        continue;
-      }
-      const sendGain = this.context.createGain();
-      sendGain.gain.value = gainValue;
-      try {
-        playback.outputNode.connect(sendGain);
-      } catch {
-        continue;
-      }
-      sendGain.connect(bus.input);
-      playback._sendGains.set(bus, sendGain);
-    }
-  }
-
-  _onBusDrained(bus: Bus, target: Bus): void {
-    if (this._routeTarget === bus) {
-      this._setPrimary(target);
-    }
-    if (this._sends.has(bus)) {
-      const gainValue = this._sends.get(bus) as number;
-      this._sends.delete(bus);
-      for (const playback of this.playbacks) {
-        const sendGain = playback._sendGains.get(bus);
-        if (!sendGain) {
-          continue;
-        }
-        try {
-          sendGain.disconnect();
-        } catch {}
-        playback._sendGains.delete(bus);
-      }
-      this._addSend(target, gainValue);
-    }
   }
 
   get type(): OscillatorType {

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -1,4 +1,3 @@
-import type { Bus } from "./bus";
 import type { BaseSound } from "./cacophony";
 import type { AudioNode, AudioParam, BaseContext, GainNode, OscillatorNode } from "./context";
 import { OscillatorMixin } from "./oscillatorMixin";
@@ -6,13 +5,6 @@ import type { Synth } from "./synth";
 
 export class SynthPlayback extends OscillatorMixin implements BaseSound {
   context: BaseContext;
-  /**
-   * Per-playback send-gain allocations: bus → allocated GainNode. Mirrors
-   * {@link Playback._sendGains}. Owned/teardown contract is identical:
-   * Synth allocates send gains at preplay or `routeTo(bus, gain)`; cleanup
-   * walks this map and calls `disconnect()` on every send.
-   */
-  _sendGains: Map<Bus, GainNode> = new Map();
   /**
    * Live oscillator node. Set in the constructor; cleared to `undefined` in
    * {@link cleanup} (matches Playback's `source?` shape so post-cleanup
@@ -122,14 +114,6 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     this.source = undefined;
     this.panner = undefined;
     this.markStopped();
-    // Tear down per-playback send-gain nodes before super.cleanup() severs
-    // the gainNode edges they feed off of.
-    for (const sendGain of this._sendGains.values()) {
-      try {
-        sendGain.disconnect();
-      } catch {}
-    }
-    this._sendGains.clear();
     this.eventEmitter.removeAllListeners();
     // super.cleanup() (VolumeMixin) disconnects + clears `gainNode`; after
     // this call `outputNode` throws (parity with Playback.cleanup).


### PR DESCRIPTION
## Summary

- centralize primary routes, additive sends, bus registration, drain handling, and live rewiring in one `RoutableSource` implementation
- move per-playback send ownership and deterministic cleanup to `BasePlayback`
- give `MediaStreamSound` the same `routeTo` behavior as `Sound` and `Synth`
- add a public-API media-stream routing test with graph reachability assertions

## Root cause

`Sound` and `Synth` maintained parallel copies of the routing state machine, while `MediaStreamSound` bypassed that machinery and connected directly to master.

## Impact

All playback-producing source types now share one routing owner. Live media streams can be routed through buses, including their effects and metering paths, without duplicating routing logic.

## TDD

The new media-stream e2e test first failed with `TypeError: sound.routeTo is not a function`, then passed after the shared routing implementation was adopted.

## Validation

- `npm run lint`
- `npm run ci:test` — 68 files passed; 1,029 tests passed, 2 skipped; no type errors
- `npm run build` — exited 0; existing declaration and TypeDoc warnings remain

Closes #112