### PR TITLE
Fix media and timing paper cuts

### DIFF
--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -325,6 +325,7 @@ describe("Cacophony advanced features", () => {
       const controller = new AbortController();
       const htmlAudio = createControllableAudioElement();
       const streamingAudio = createControllableAudioElement();
+      const createMediaElementSourceSpy = vi.spyOn(audioContextMock, "createMediaElementSource");
 
       // Set up spy to track cache calls
       const getAudioBufferSpy = vi.spyOn(mockCache, "getAudioBuffer");
@@ -354,6 +355,13 @@ describe("Cacophony advanced features", () => {
       expect(streamSound.soundType).toBe("streaming");
       expect(streamSound.url).toBe(url);
       expect(getAudioBufferSpy).not.toHaveBeenCalled();
+
+      htmlSound.preplay();
+      streamSound.preplay();
+
+      expect(global.Audio).toHaveBeenCalledTimes(2);
+      expect(createMediaElementSourceSpy).toHaveBeenCalledWith(htmlAudio.audio);
+      expect(createMediaElementSourceSpy).toHaveBeenCalledWith(streamingAudio.audio);
     });
 
     it("createSound with HTML throws AbortError when signal is aborted during media load", async () => {

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -813,7 +813,7 @@ export class Cacophony {
 
       const handleLoadedMetadata = () => {
         settle(() => {
-          resolve(new Sound(url, undefined, this.context, this.globalGainNode, soundType, panType, this));
+          resolve(new Sound(url, undefined, this.context, this.globalGainNode, soundType, panType, this, audio));
         });
       };
 

--- a/src/mediaStream.test.ts
+++ b/src/mediaStream.test.ts
@@ -6,9 +6,15 @@ import { MediaStreamPlayback, MediaStreamSound } from "./mediaStream";
 import { expectNotReachable, expectPath, expectReachable } from "./setupTests";
 
 function createMockTrack(): MediaStreamTrack {
+  let readyState: MediaStreamTrackState = "live";
   return {
     enabled: true,
-    stop: vi.fn(),
+    get readyState() {
+      return readyState;
+    },
+    stop: vi.fn(() => {
+      readyState = "ended";
+    }),
   } as unknown as MediaStreamTrack;
 }
 
@@ -97,6 +103,19 @@ describe("MediaStreamSound", () => {
     sound.stop();
 
     expect(track.stop).toHaveBeenCalledOnce();
+  });
+
+  it("throws when replaying after the default stop ends every track", () => {
+    const cacophony = new Cacophony(context as any);
+    vi.spyOn(context as any, "createMediaStreamSource").mockReturnValue(source);
+    const sound = cacophony.createMediaStreamSound(stream, {
+      primeWithMediaElement: false,
+    });
+
+    sound.play();
+    sound.stop();
+
+    expect(() => sound.play()).toThrow("Cannot play a media stream whose tracks have ended");
   });
 
   it("pauses and resumes by toggling track enabled state", () => {

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -105,7 +105,11 @@ export class MediaStreamPlayback extends BasePlayback {
     if (this.isPlaying) {
       return [this];
     }
-    this.source.mediaStream.getTracks().forEach((track) => (track.enabled = true));
+    const tracks = this.source.mediaStream.getTracks();
+    if (tracks.length > 0 && tracks.every((track) => track.readyState === "ended")) {
+      throw new Error("Cannot play a media stream whose tracks have ended");
+    }
+    tracks.forEach((track) => (track.enabled = true));
     // Muted autoplay is always permitted, so this needs no user gesture; the
     // returned promise is ignored because failure only loses Chromium priming.
     this.primeElement?.play().catch(() => {});

--- a/src/offline.test.ts
+++ b/src/offline.test.ts
@@ -109,6 +109,25 @@ describe("OfflineAudioContext support", () => {
       expect(playbacks.length).toBeGreaterThan(0);
       expect(playbacks[0].isPlaying).toBe(true);
     });
+
+    it("schedules fades without waiting on a wall-clock timer", async () => {
+      vi.useFakeTimers();
+      try {
+        const offlineCtx = createOfflineContextMock();
+        const cacophony = new Cacophony(offlineCtx, mockCache);
+        const buffer = new AudioBuffer({ length: 100, sampleRate: 44100 }) as unknown as CacophonyAudioBuffer;
+        const sound = await cacophony.createSound(buffer, "buffer");
+        const [playback] = sound.play();
+
+        const fade = playback.fadeTo(0.25, 10_000);
+
+        expect(vi.getTimerCount()).toBe(0);
+        await fade;
+        expect(playback.isFading).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("createOscillator on offline context", () => {

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -62,6 +62,7 @@ export class Sound extends RoutableSource implements BaseSound {
   private eventEmitter: TypedEventEmitter<SoundEvents> = new TypedEventEmitter<SoundEvents>();
   private _holdings: SoundCleanupHoldings = { sources: [], gainNodes: [], mediaElements: [] };
   private _unregisterToken: object = {};
+  private _preparedMediaElement?: HTMLAudioElement;
   /**
    * Per-playback unsubscribe functions for the listeners that Sound attaches
    * to each playback in {@link preplay}. Tracked so the Sound→playback
@@ -79,10 +80,12 @@ export class Sound extends RoutableSource implements BaseSound {
     public soundType: SoundType = "buffer",
     public panType: PanType = "HRTF",
     private _cacophony?: Cacophony,
+    preparedMediaElement?: HTMLAudioElement,
   ) {
     super();
     this.buffer = buffer;
     this.context = context;
+    this._preparedMediaElement = preparedMediaElement;
     this._cacophony?.registerSoundForCleanup(this, this._holdings, this._unregisterToken);
   }
 
@@ -194,12 +197,15 @@ export class Sound extends RoutableSource implements BaseSound {
             "Media element sources are not supported on this audio context (e.g. OfflineAudioContext). Use buffer-based sounds instead.",
           );
         }
-        const audio = new Audio();
+        const audio = this._preparedMediaElement ?? new Audio();
         audio.crossOrigin = "anonymous";
         audio.src = this.url;
         audio.preload = "auto";
         // we have the audio, let's make a buffer source node out of it
         source = this.context.createMediaElementSource(audio);
+        if (audio === this._preparedMediaElement) {
+          this._preparedMediaElement = undefined;
+        }
       }
       createdSource = source;
       const gainNode = this.context.createGain();
@@ -517,6 +523,12 @@ export class Sound extends RoutableSource implements BaseSound {
 
   cleanup(): void {
     this._cacophony?.unregisterSoundCleanup(this._unregisterToken);
+    if (this._preparedMediaElement) {
+      this._preparedMediaElement.pause();
+      this._preparedMediaElement.src = "";
+      this._preparedMediaElement.load();
+      this._preparedMediaElement = undefined;
+    }
     this._holdings.sources.length = 0;
     this._holdings.gainNodes.length = 0;
     this._holdings.mediaElements.length = 0;

--- a/src/synthGroup.test.ts
+++ b/src/synthGroup.test.ts
@@ -57,6 +57,10 @@ describe("SynthGroup class", () => {
     expect(new SynthGroup().volume).toBe(1);
   });
 
+  it("returns detune 0 for an empty group", () => {
+    expect(new SynthGroup().detune).toBe(0);
+  });
+
   it("delegates stereo pan to grouped stereo synths", () => {
     const stereoSynth1 = cacophony.createOscillator({ frequency: 220, type: "sine" }, "stereo");
     const stereoSynth2 = cacophony.createOscillator({ frequency: 330, type: "triangle" }, "stereo");

--- a/src/synthGroup.ts
+++ b/src/synthGroup.ts
@@ -108,7 +108,7 @@ export class SynthGroup {
   }
 
   get detune(): number {
-    return this.synths[0]?.detune as number;
+    return this.synths[0]?.detune ?? 0;
   }
 
   set detune(detune: number) {

--- a/src/volumeMixin.ts
+++ b/src/volumeMixin.ts
@@ -75,7 +75,8 @@ export function VolumeMixin<TBase extends Constructor>(Base: TBase) {
      * @param {number} value - The target volume (0 to 1).
      * @param {number} duration - The fade duration in milliseconds.
      * @param {FadeType} type - The fade curve type, "linear" or "exponential". Defaults to "linear".
-     * @returns {Promise<void>} Resolves when the fade completes.
+     * @returns {Promise<void>} Resolves when the fade completes on a live context, or when its automation has been
+     * scheduled on an offline context.
      */
     fadeTo(value: number, duration: number, type: FadeType = "linear"): Promise<void> {
       if (!this.gainNode) {
@@ -96,6 +97,14 @@ export function VolumeMixin<TBase extends Constructor>(Base: TBase) {
         node.gain.exponentialRampToValueAtTime(value === 0 ? 0.0001 : value, endTime);
       } else {
         node.gain.linearRampToValueAtTime(value, endTime);
+      }
+
+      if ("startRendering" in node.context) {
+        if (value === 0 && type === "exponential") {
+          node.gain.setValueAtTime(0, endTime);
+        }
+        this._isFading = false;
+        return Promise.resolve();
       }
 
       this._isFading = true;


### PR DESCRIPTION
## What changed

- reuse the metadata-loaded media element for the first HTML/streaming playback
- return `0` for `SynthGroup.detune` on an empty group
- resolve offline fade promises after scheduling context-time automation instead of using a wall-clock timer
- reject replay after the default media-stream stop has ended every track

## Why

These four public API paths had independent paper-cut defects: media was fetched twice, an empty group violated its getter defaults, offline rendering could be delayed by real time, and stopped streams could report a dead replay as active.

## Validation

- `npm test -- src/cacophony.test.ts src/synthGroup.test.ts src/offline.test.ts src/mediaStream.test.ts` (101 passed)
- `npm run lint`
- `npm run ci:test` (1,032 passed, 2 skipped, no type errors)
- `npm run build` (passed with existing TS4094 and TypeDoc warnings)

Closes #114