### PR TITLE
Forward offline runtime options

### DIFF
--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -394,12 +394,13 @@ export class Cacophony {
    *
    * @param options - Offline context configuration (channels, length, sampleRate)
    * @param cache - Optional cache implementation
+   * @param runtimeOptions - Optional runtime configuration
    * @returns A Cacophony instance backed by OfflineAudioContext
    */
-  static createOffline(options: OfflineOptions, cache?: ICache): Cacophony {
+  static createOffline(options: OfflineOptions, cache?: ICache, runtimeOptions?: RuntimeOptions): Cacophony {
     const offlineContext =
       options.context ?? new OfflineAudioContext(options.numberOfChannels, options.length, options.sampleRate);
-    return new Cacophony(offlineContext, cache);
+    return new Cacophony(offlineContext, cache, runtimeOptions);
   }
 
   /**

--- a/src/node.test.ts
+++ b/src/node.test.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { nodeBackendAvailable } from "./backend-available";
+import { Cacophony } from "./cacophony";
 import { createOfflineNodeCacophony, decodeAudioFile } from "./node";
 
 // These tests run against the REAL node-web-audio-api backend (the same one the
@@ -21,6 +22,36 @@ function peak(buffer: AudioBuffer): number {
 // Skipped when the optional native backend is absent (e.g. Node < 22, where its
 // `engines` exclude it and npm omits the optionalDependency). See backend-available.ts.
 describe.skipIf(!nodeBackendAvailable)("cacophony/node adapter", () => {
+  it("constructs offline instances through Cacophony.createOffline", async () => {
+    const createOfflineSpy = vi.spyOn(Cacophony, "createOffline");
+
+    try {
+      const { context } = await createOfflineNodeCacophony({
+        numberOfChannels: 1,
+        length: 128,
+        sampleRate: 48000,
+        quiet: true,
+      });
+
+      expect(createOfflineSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          numberOfChannels: 1,
+          length: 128,
+          sampleRate: 48000,
+          context,
+        }),
+        undefined,
+        expect.objectContaining({
+          createAudioWorkletNode: expect.any(Function),
+          resolveWorkletUrl: expect.any(Function),
+          quiet: true,
+        }),
+      );
+    } finally {
+      createOfflineSpy.mockRestore();
+    }
+  });
+
   it("renders a bare oscillator synth to a non-silent buffer (real Node backend)", async () => {
     const { cacophony, context } = await createOfflineNodeCacophony({
       length: Math.round(48000 * 0.1),

--- a/src/node.ts
+++ b/src/node.ts
@@ -192,12 +192,6 @@ export async function createNodeCacophony(options: NodeCacophonyOptions = {}): P
 /**
  * Create an offline (render-mode) Cacophony wired to the `node-web-audio-api`
  * backend. Drive it with `await context.startRendering()`.
- *
- * NOTE: this constructs the OfflineAudioContext and `new Cacophony(...)`
- * DIRECTLY rather than going through `Cacophony.createOffline()`, because that
- * static helper does not forward `runtimeOptions` — so the
- * `createAudioWorkletNode` seam would be lost and any worklet-backed effect
- * (reverb, distortion, dynamics, ...) would fail to construct.
  */
 export async function createOfflineNodeCacophony(options: OfflineNodeCacophonyOptions): Promise<OfflineNodeCacophony> {
   const backend = await loadBackend();
@@ -206,12 +200,21 @@ export async function createOfflineNodeCacophony(options: OfflineNodeCacophonyOp
     length: options.length,
     sampleRate: options.sampleRate,
   });
-  const cacophony = new Cacophony(context as unknown as BaseContext, options.cache, {
-    createAudioWorkletNode: makeCreateAudioWorkletNode(backend.AudioWorkletNode),
-    resolveWorkletUrl,
-    logger: options.logger,
-    quiet: options.quiet,
-  });
+  const cacophony = Cacophony.createOffline(
+    {
+      numberOfChannels: options.numberOfChannels ?? 2,
+      length: options.length,
+      sampleRate: options.sampleRate,
+      context: context as unknown as BaseContext & { startRendering(): Promise<AudioBuffer> },
+    },
+    options.cache,
+    {
+      createAudioWorkletNode: makeCreateAudioWorkletNode(backend.AudioWorkletNode),
+      resolveWorkletUrl,
+      logger: options.logger,
+      quiet: options.quiet,
+    },
+  );
   return { cacophony, context };
 }
 

--- a/src/offline.test.ts
+++ b/src/offline.test.ts
@@ -59,6 +59,28 @@ describe("OfflineAudioContext support", () => {
       expect(cacophony.isOffline).toBe(true);
       expect(cacophony.context).toBe(offlineCtx);
     });
+
+    it("forwards runtime options to worklet-backed effects", async () => {
+      const offlineCtx = createOfflineContextMock(128);
+      Object.defineProperty(offlineCtx, "audioWorklet", {
+        value: { addModule: vi.fn().mockResolvedValue(undefined) },
+        configurable: true,
+      });
+      const createAudioWorkletNode = vi.fn(() => offlineCtx.createGain());
+      const cacophony = Cacophony.createOffline(
+        { numberOfChannels: 1, length: 128, sampleRate: 44100, context: offlineCtx },
+        mockCache,
+        { createAudioWorkletNode },
+      );
+
+      await cacophony.createReverb().build(offlineCtx);
+
+      expect(createAudioWorkletNode).toHaveBeenCalledWith(
+        offlineCtx,
+        "dattorro-reverb",
+        expect.objectContaining({ parameterData: {} }),
+      );
+    });
   });
 
   describe("isOffline", () => {


### PR DESCRIPTION
## Summary

- add `runtimeOptions` to `Cacophony.createOffline` and forward them to the constructor
- route `createOfflineNodeCacophony` through the public offline factory
- cover the public worklet-effect seam and Node factory delegation with regression tests

## Root cause

The public offline factory accepted only context options and a cache, so it discarded the constructor's runtime seams. The Node adapter had to bypass the public factory to retain its worklet constructor, URL resolver, and logging configuration.

## Impact

Offline callers can now inject `createAudioWorkletNode`, `resolveWorkletUrl`, and logging options through the public factory, including for worklet-backed effects. The Node adapter uses the same public path instead of maintaining a direct-construction exception.

## Validation

- `npm run ci:test -- src/offline.test.ts src/node.test.ts`
- `npm run lint`
- `npm run ci:test` (1,040 passed, 2 skipped; no type errors)
- `npm run build`

Closes #108