### PR TITLE
Fix group playback delegation

### DIFF
--- a/src/group.test.ts
+++ b/src/group.test.ts
@@ -38,12 +38,12 @@ describe("Group class", () => {
   });
 
   it("performs collective operations on grouped sounds", () => {
-    const preplaySpy1 = vi.spyOn(sound1, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
-    const preplaySpy2 = vi.spyOn(sound2, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+    const playSpy1 = vi.spyOn(sound1, "play").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+    const playSpy2 = vi.spyOn(sound2, "play").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
 
     group.play();
-    expect(preplaySpy1).toHaveBeenCalled();
-    expect(preplaySpy2).toHaveBeenCalled();
+    expect(playSpy1).toHaveBeenCalled();
+    expect(playSpy2).toHaveBeenCalled();
 
     const stopSpy1 = vi.spyOn(sound1, "stop");
     const stopSpy2 = vi.spyOn(sound2, "stop");
@@ -57,23 +57,61 @@ describe("Group class", () => {
     expect(sound2.volume).toBe(0.5);
   });
 
+  it("emits each member Sound's play event", () => {
+    const playListener1 = vi.fn();
+    const playListener2 = vi.fn();
+    sound1.on("play", playListener1);
+    sound2.on("play", playListener2);
+
+    const [playback1, playback2] = group.play();
+
+    expect(playListener1).toHaveBeenCalledWith(playback1);
+    expect(playListener2).toHaveBeenCalledWith(playback2);
+  });
+
+  it("forwards PlayOptions to every sound", () => {
+    const options = {
+      fadeIn: 500,
+      fadeOut: 250,
+      fadeType: "exponential" as const,
+      fadeInPerLoop: true,
+    };
+    const playback1 = { play: vi.fn() } as unknown as Playback;
+    const playback2 = { play: vi.fn() } as unknown as Playback;
+    const playSpy1 = vi.spyOn(sound1, "play").mockReturnValue([playback1]);
+    const playSpy2 = vi.spyOn(sound2, "play").mockReturnValue([playback2]);
+
+    expect(group.play(options)).toEqual([playback1, playback2]);
+    expect(playSpy1).toHaveBeenCalledWith(options);
+    expect(playSpy2).toHaveBeenCalledWith(options);
+  });
+
   it("plays sounds in order", () => {
-    const preplaySpy1 = vi.spyOn(sound1, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
-    const preplaySpy2 = vi.spyOn(sound2, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+    const playSpy1 = vi.spyOn(sound1, "play").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+    const playSpy2 = vi.spyOn(sound2, "play").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
 
     const playback1 = group.playOrdered();
-    expect(preplaySpy1).toHaveBeenCalled();
-    expect(preplaySpy2).not.toHaveBeenCalled();
+    expect(playSpy1).toHaveBeenCalled();
+    expect(playSpy2).not.toHaveBeenCalled();
     expect(playback1).toBeDefined();
 
     const playback2 = group.playOrdered();
-    expect(preplaySpy2).toHaveBeenCalled();
+    expect(playSpy2).toHaveBeenCalled();
     expect(playback2).toBeDefined();
   });
 
+  it("forwards PlayOptions when playing sounds in order", () => {
+    const options = { fadeIn: 500 };
+    const playback = { play: vi.fn() } as unknown as Playback;
+    const playSpy = vi.spyOn(sound1, "play").mockReturnValue([playback]);
+
+    expect(group.playOrdered(false, options)).toBe(playback);
+    expect(playSpy).toHaveBeenCalledWith(options);
+  });
+
   it("playOrdered(false) returns undefined after exhausting all sounds", () => {
-    vi.spyOn(sound1, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
-    vi.spyOn(sound2, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+    vi.spyOn(sound1, "play").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+    vi.spyOn(sound2, "play").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
 
     const playback1 = group.playOrdered(false);
     expect(playback1).toBeDefined();
@@ -90,15 +128,32 @@ describe("Group class", () => {
     expect(playback4).toBeUndefined();
   });
 
+  it("can reset and replay an exhausted non-looping order", () => {
+    const playback1 = { play: vi.fn() } as unknown as Playback;
+    const playback2 = { play: vi.fn() } as unknown as Playback;
+    const playSpy1 = vi.spyOn(sound1, "play").mockReturnValue([playback1]);
+    vi.spyOn(sound2, "play").mockReturnValue([playback2]);
+
+    expect(group.playOrdered(false)).toBe(playback1);
+    expect(group.playOrdered(false)).toBe(playback2);
+    expect(group.playOrdered(false)).toBeUndefined();
+
+    group.resetOrder();
+
+    expect(group.playOrdered(false)).toBe(playback1);
+    expect(playSpy1).toHaveBeenCalledTimes(2);
+  });
+
   it("plays random sounds", () => {
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.7);
-    const preplaySpy1 = vi.spyOn(sound1, "preplay").mockReturnValue([]);
-    const preplaySpy2 = vi.spyOn(sound2, "preplay").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
+    const options = { fadeOut: 500 };
+    const playSpy1 = vi.spyOn(sound1, "play").mockReturnValue([]);
+    const playSpy2 = vi.spyOn(sound2, "play").mockReturnValue([{ play: vi.fn() } as unknown as Playback]);
 
-    const playback = group.playRandom();
+    const playback = group.playRandom(options);
     expect(randomSpy).toHaveBeenCalled();
-    expect(preplaySpy2).toHaveBeenCalled();
-    expect(preplaySpy1).not.toHaveBeenCalled();
+    expect(playSpy2).toHaveBeenCalledWith(options);
+    expect(playSpy1).not.toHaveBeenCalled();
     expect(playback).toBeDefined();
   });
 

--- a/src/group.ts
+++ b/src/group.ts
@@ -1,5 +1,5 @@
 import type { Bus } from "./bus";
-import type { BaseSound, FadeType, LoopCount, Position } from "./cacophony";
+import type { BaseSound, FadeType, LoopCount, PlayOptions, Position } from "./cacophony";
 import type { BiquadFilterNode } from "./context";
 import type { Playback } from "./playback";
 import type { Sound } from "./sound";
@@ -26,14 +26,14 @@ export class Group implements BaseSound {
 
   /**
    * Plays a random sound from the group.
+   * @param options - Options for configuring fade behavior.
    * @returns The playback object representing the played sound, or undefined if the group is empty.
    */
-  playRandom(): Playback | undefined {
-    const playback = this.preplayRandom();
-    if (playback) {
-      playback.play();
+  playRandom(options?: PlayOptions): Playback | undefined {
+    if (this.sounds.length === 0) {
+      return undefined;
     }
-    return playback;
+    return this.randomSound().play(options)[0];
   }
 
   /**
@@ -65,14 +65,29 @@ export class Group implements BaseSound {
    * Plays the sounds in the group in a specific order.
    *
    * @param shouldLoop - Indicates whether the sounds should be played in a loop.
+   * @param options - Options for configuring fade behavior.
    * @returns The playback object representing the first sound being played, or undefined if the group is empty.
    */
-  playOrdered(shouldLoop: boolean = true): Playback | undefined {
-    const playback = this.preplayOrdered(shouldLoop);
-    if (playback) {
-      playback.play();
+  playOrdered(shouldLoop: boolean = true, options?: PlayOptions): Playback | undefined {
+    if (this.sounds.length === 0 || this.playIndex >= this.sounds.length) {
+      return undefined;
     }
-    return playback;
+    const playbacks = this.sounds[this.playIndex].play(options);
+    if (playbacks.length === 0) {
+      return undefined;
+    }
+    this.playIndex = (this.playIndex + 1) % this.sounds.length;
+    if (!shouldLoop && this.playIndex === 0) {
+      this.playIndex = this.sounds.length;
+    }
+    return playbacks[0];
+  }
+
+  /**
+   * Restarts ordered playback from the first sound in the group.
+   */
+  resetOrder(): void {
+    this.playIndex = 0;
   }
 
   get duration() {
@@ -109,15 +124,8 @@ export class Group implements BaseSound {
    *  @returns {Playback[]} An array of Playback objects, one for each sound in the group.
    */
 
-  play(): Playback[] {
-    // const playbacks = this.preplay().map((playback) => playback.play()[0]);
-    const playbacks: Playback[] = [];
-    // preplay returns an array, and then play on each of those also returns an array, and we only want one array of playbacks
-    this.preplay().forEach((playback) => {
-      playback.play();
-      playbacks.push(playback);
-    });
-    return playbacks;
+  play(options?: PlayOptions): Playback[] {
+    return this.sounds.flatMap((sound) => sound.play(options));
   }
 
   /**


### PR DESCRIPTION
## Summary

- delegate group-wide, random, and ordered playback to each member's existing `Sound.play(options)` implementation
- forward `PlayOptions` so group playback receives the same fade behavior as direct sound playback
- add `resetOrder()` so exhausted non-looping ordered playback can restart
- cover member `play` events, option forwarding, and ordered reset/replay with regression tests

## Root cause

`Group` called `Sound.preplay()` and then invoked `Playback.play()` directly. That bypassed the `Sound.play()` layer that emits member Sound `play` events and applies `PlayOptions` fades.

## Impact

Playing sounds through a group now has the same event and fade behavior as playing those sounds directly, while preserving the existing playback return values and ordered exhaustion behavior.

## Validation

- `npm test -- src/group.test.ts` (26 passed)
- `npm run lint`
- `npm run ci:test` (1,044 passed, 2 skipped; no type errors)
- `npm run build` (exit 0; existing TS4094 and TypeDoc warnings remain)

Closes #109