### PR TITLE
Add WebCodecs URL streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Cacophony supports three URL-backed sound labels:
 |------|--------|---------|---------|-------------------|----------|
 | **Buffer** (default) | High | None | Full | Yes | Sound effects, UI sounds, short music clips |
 | **HTML** | Medium | Low | Full | Yes | Media-element-backed background music, large audio files, and podcasts |
-| **Streaming** | Medium | Low | Full | Yes | The same media-element transport as HTML, labeled by `createStream()` |
+| **Streaming** | Bounded | Low | Range-backed | One stream per source | Sample-accurate URL audio with effects, panning, and metering |
 
 ```typescript
 // Buffer - entire file loaded into memory
@@ -144,16 +144,22 @@ const sfx = await cacophony.createSound('explosion.mp3', 'buffer');
 // HTML - media-element-backed playback, good for large files
 const music = await cacophony.createSound('bgm.mp3', 'html');
 
-// Streaming - the same transport with a distinct convenience label
+// Streaming - incremental demux + WebCodecs decode into a PCM worklet
 const radio = await cacophony.createStream('https://example.com/live-radio.mp3');
+console.log(radio.streamCapabilities);
+// { transport: 'webcodecs', seekable: false, live: true, duration: Infinity }
 ```
 
-Both `'html'` and `'streaming'` use an `HTMLAudioElement`; the browser handles
-progressive download, range requests, native buffering, and supported live
-radio streams. `createStream(url)` is a media-element-backed convenience with
-the transport semantics of `createSound(url, 'html')`, while preserving
-`sound.soundType === 'streaming'`. It does not select a separate streaming
-transport.
+`createStream(url)` uses a fetch → demux → WebCodecs `AudioDecoder` → PCM
+worklet path when WebCodecs is present and can decode the primary audio track.
+The returned source has `soundType === 'streaming'` and uses the same volume,
+pan/HRTF, filter, bus, send, and loudness-meter APIs as every other routable
+source. MP3, ADTS/MP4 AAC, Ogg, FLAC, and WAVE containers are supported.
+
+If WebCodecs is absent or the primary track has no WebCodecs decoder,
+`createStream()` falls back to a media-element `Sound`. Check
+`streamCapabilities.transport` for `'webcodecs'` or `'media-element'` rather
+than assuming a tier.
 
 Native HLS (`.m3u8`) playback is limited to Safari. Cross-browser HLS support
 requires an adapter such as the one tracked in the
@@ -773,12 +779,43 @@ try {
 
 ## Audio Streaming
 
-`createStream()` is a media-element-backed convenience for network audio. It
-uses the same `HTMLAudioElement` transport and playback controls as
-`createSound(url, 'html')`; the returned `Sound` keeps the `'streaming'` label.
-The browser, rather than a Cacophony chunk decoder, provides progressive
-download, range requests, native buffering, and live Icecast/SHOUTcast
-playback.
+`createStream()` incrementally fetches and demuxes MP3, ADTS/MP4 AAC, Ogg,
+FLAC, and WAVE audio. A WebCodecs `AudioDecoder` produces PCM chunks, which are
+resampled to the active audio context and written into the same AudioWorklet
+ring buffer used by `createPcmStreamSound()`. The returned stream is therefore
+sample-accurately scheduled, pannable, filterable, bus-routable, and meterable.
+
+```typescript
+const controller = new AbortController();
+const stream = await cacophony.createStream('/music.ogg', controller.signal);
+
+console.log(stream.streamCapabilities);
+// {
+//   transport: 'webcodecs',
+//   seekable: true,
+//   live: false,
+//   duration: 183.42,
+// }
+
+stream.routeTo(musicBus);
+stream.addFilter(cacophony.createBiquadFilter({ type: 'lowpass', frequency: 1800 }));
+await cacophony.createLoudnessMeter(musicBus);
+stream.play();
+stream.seek(30); // reopens the decoder at 30s when the server supports byte ranges
+
+controller.abort(); // cancels fetch/decoder work and tears down the PCM worklet
+```
+
+`seekable` becomes `true` only after the server answers a byte-range request
+with a range response. Live sources report `live: true`, `seekable: false`, and
+`duration: Infinity`; calling `seek()` on one throws a clear error. A finite
+file whose duration metadata is unavailable also reports `Infinity` rather
+than inventing a duration.
+
+When `AudioDecoder` is unavailable, or the primary audio track cannot be
+decoded by WebCodecs, `createStream()` returns the compatibility
+media-element tier. Its `streamCapabilities.transport` is `'media-element'`;
+the browser owns buffering, seeking, and live-stream behavior in that tier.
 
 For audio that arrives as decoded samples instead of a URL, use the
 AudioWorklet-backed push source:
@@ -818,8 +855,9 @@ Volume, stereo/HRTF pan, filters, buses, and sends use the same public APIs as
 other sources. Seek is not supported for a push PCM source. Loop is not
 supported because the source does not retain consumed samples.
 
-Native HLS playback is limited to Safari. An `.m3u8` URL therefore needs an
-adapter such as hls.js in other browsers; follow the
+Adaptive HLS/DASH and DRM are outside the WebCodecs pull transport. Native HLS
+playback is limited to Safari; use the media tier or an hls.js adapter for
+`.m3u8` URLs in other browsers. Follow the
 [hls.js adapter issue](https://github.com/ctoth/cacophony/issues/132) for that
 integration.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.28.0",
       "license": "ISC",
       "dependencies": {
-        "fft.js": "^4.0.4"
+        "fft.js": "^4.0.4",
+        "mediabunny": "^1.51.0"
       },
       "bin": {
         "cacophony": "bin/cacophony.mjs"
@@ -1222,6 +1223,21 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+      "integrity": "sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2501,6 +2517,24 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mediabunny": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.51.0.tgz",
+      "integrity": "sha512-u327374xU8Ho0gCaMII7fUK8t0PnqkabCox1k8uUwvgvGb9o6YQGZEG2Qr4DTe7nTMpzfL7ukgnHDvDROySZ+Q==",
+      "license": "MPL-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "environment": "node"
   },
   "dependencies": {
-    "fft.js": "^4.0.4"
+    "fft.js": "^4.0.4",
+    "mediabunny": "^1.51.0"
   },
   "optionalDependencies": {
     "node-web-audio-api": "^2.0.0"

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -53,9 +53,17 @@ import { DATTORRO_INV_SQRT2 } from "./processors/modulated-delay-core";
 import { type TimeStretchOptions, timeStretch } from "./processors/timestretch-core";
 import { Sound } from "./sound";
 import { Synth } from "./synth";
+import { WebCodecsPullAdapter, type WebCodecsStreamSound } from "./webCodecsStream";
 import { ALL_WORKLETS, WORKLETS, type WorkletModule } from "./worklets";
 
 export type SoundType = "html" | "streaming" | "buffer" | "oscillator";
+
+export interface StreamCapabilities {
+  transport: "webcodecs" | "media-element";
+  seekable: boolean;
+  live: boolean;
+  duration: number;
+}
 
 /**
  * Represents a 3D position in space.
@@ -109,6 +117,7 @@ export interface PlayOptions {
  */
 export interface BaseSound {
   isPlaying: boolean;
+  streamCapabilities?: StreamCapabilities;
   play(): BaseSound[];
   seek?(time: number): void;
   stop(): void;
@@ -815,7 +824,16 @@ export class Cacophony {
 
       const handleLoadedMetadata = () => {
         settle(() => {
-          resolve(new Sound(url, undefined, this.context, this.globalGainNode, soundType, panType, this, audio));
+          const sound = new Sound(url, undefined, this.context, this.globalGainNode, soundType, panType, this, audio);
+          if (soundType === "streaming") {
+            sound.streamCapabilities = {
+              duration: Number.isFinite(audio.duration) ? audio.duration : Number.POSITIVE_INFINITY,
+              live: audio.duration === Number.POSITIVE_INFINITY,
+              seekable: (audio.seekable?.length ?? 0) > 0,
+              transport: "media-element",
+            };
+          }
+          resolve(sound);
         });
       };
 
@@ -1052,19 +1070,32 @@ export class Cacophony {
   }
 
   /**
-   * Creates a media-element-backed Sound instance from a URL.
-   *
-   * This is a convenience for the transport semantics of
-   * `createSound(url, "html")`, while preserving the `"streaming"` sound type
-   * label. Both paths use an `HTMLAudioElement`; `createStream()` does not
-   * select a distinct streaming transport.
-   *
-   * @param url - URL for media-element-backed playback
-   * @param signal - Optional AbortSignal to cancel media loading
-   * @returns Promise that resolves to a media-element-backed Sound labeled `"streaming"`
+   * Creates a sample-accurate URL stream when WebCodecs can decode the primary
+   * audio track. Encoded media is fetched and demuxed incrementally, then its
+   * PCM is fed into the same routable AudioWorklet source returned by
+   * {@link createPcmStreamSound}. Browsers without WebCodecs, or without a
+   * decoder for the track, fall back to the media-element streaming tier.
    */
-  async createStream(url: string, signal?: AbortSignal): Promise<Sound> {
-    return this.createMediaSound(url, "streaming", "HRTF", signal);
+  async createStream(url: string, signal?: AbortSignal): Promise<Sound | WebCodecsStreamSound> {
+    if (typeof globalThis.AudioDecoder !== "function") {
+      return this.createMediaSound(url, "streaming", "HRTF", signal);
+    }
+
+    const adapter = await WebCodecsPullAdapter.open(url, this.context.sampleRate, signal);
+    if (!adapter) {
+      return this.createMediaSound(url, "streaming", "HRTF", signal);
+    }
+    try {
+      const sound = await this.createPcmStreamSound({
+        channelCount: adapter.channelCount,
+        panType: "HRTF",
+        signal,
+      });
+      return adapter.attach(sound);
+    } catch (error) {
+      adapter.cleanup();
+      throw error;
+    }
   }
 
   createMediaStreamSound(stream: MediaStream, options?: MediaStreamSoundOptions): MediaStreamSound {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export type {
   RuntimeOptions,
   SoundCleanupHoldings,
   SoundType,
+  StreamCapabilities,
 } from "./cacophony";
 export { Cacophony } from "./cacophony";
 export type {
@@ -129,3 +130,4 @@ export { Sound } from "./sound";
 export { encodeMonoToFoaSN3D } from "./spatial/foa-encode";
 export { Synth } from "./synth";
 export { SynthGroup } from "./synthGroup";
+export type { WebCodecsStreamSound } from "./webCodecsStream";

--- a/src/pcmStream.ts
+++ b/src/pcmStream.ts
@@ -1,5 +1,5 @@
 import { BasePlayback } from "./basePlayback";
-import type { BaseSound, Cacophony, LoopCount, PanType } from "./cacophony";
+import type { BaseSound, Cacophony, LoopCount, PanType, SoundType, StreamCapabilities } from "./cacophony";
 import type { AudioNode, AudioParam, AudioWorkletNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
 import { RoutableSource } from "./routableSource";
@@ -15,7 +15,13 @@ export type PcmStreamEvents = {
   underrun: PcmStreamBufferEvent;
   drain: PcmStreamBufferEvent;
   ended: undefined;
+  error: unknown;
 };
+
+export interface PcmStreamPullSource {
+  seek(time: number): void;
+  cleanup(): void;
+}
 
 export interface PcmStreamSoundOptions {
   /** Number of interleaved channels in every {@link PcmStreamSound.write} call. @default 1 */
@@ -180,6 +186,8 @@ export class PcmStreamPlayback extends BasePlayback {
 
 export class PcmStreamSound extends RoutableSource implements BaseSound {
   public declare playbacks: PcmStreamPlayback[];
+  public soundType?: SoundType;
+  public streamCapabilities?: StreamCapabilities;
   protected context: BaseContext;
   protected globalGainNode: GainNode;
   private readonly workletNode: AudioWorkletNode;
@@ -193,6 +201,7 @@ export class PcmStreamSound extends RoutableSource implements BaseSound {
   private inputEnded = false;
   private disposed = false;
   private state: PcmStreamState = "idle";
+  private pullSource?: PcmStreamPullSource;
 
   private readonly handleWorkletMessage = (event: MessageEvent<PcmWorkletMessage>): void => {
     switch (event.data.type) {
@@ -254,6 +263,10 @@ export class PcmStreamSound extends RoutableSource implements BaseSound {
     return this.bufferedFrames / this.context.sampleRate;
   }
 
+  get inputChannelCount(): number {
+    return this.channelCount;
+  }
+
   on<K extends keyof PcmStreamEvents>(event: K, listener: (data: PcmStreamEvents[K]) => void): () => void {
     return this.eventEmitter.on(event, listener);
   }
@@ -272,6 +285,21 @@ export class PcmStreamSound extends RoutableSource implements BaseSound {
     }
     this.state = state;
     this.emit("stateChange", state);
+  }
+
+  attachPullSource(source: PcmStreamPullSource, capabilities: StreamCapabilities): void {
+    if (this.disposed || this.pullSource) {
+      throw new Error("Cannot attach a pull source to this PCM stream");
+    }
+    this.pullSource = source;
+    this.soundType = "streaming";
+    this.streamCapabilities = capabilities;
+  }
+
+  handlePullError(error: unknown): void {
+    if (!this.disposed) {
+      this.emit("error", error);
+    }
   }
 
   /**
@@ -392,8 +420,11 @@ export class PcmStreamSound extends RoutableSource implements BaseSound {
     this.setState("stopped");
   }
 
-  seek(_time: number): void {
-    throw new Error("PCM streams do not support seeking");
+  seek(time: number): void {
+    if (!this.pullSource) {
+      throw new Error("PCM streams do not support seeking");
+    }
+    this.pullSource.seek(time);
   }
 
   loop(_loopCount?: LoopCount): LoopCount {
@@ -412,6 +443,8 @@ export class PcmStreamSound extends RoutableSource implements BaseSound {
     }
     this.stop();
     this.disposed = true;
+    this.pullSource?.cleanup();
+    this.pullSource = undefined;
     this.signal?.removeEventListener("abort", this.handleAbort);
     this.workletNode.port.removeEventListener("message", this.handleWorkletMessage as EventListener);
     this.workletNode.disconnect();

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -29,6 +29,7 @@ import type {
   PlayOptions,
   SoundCleanupHoldings,
   SoundType,
+  StreamCapabilities,
 } from "./cacophony";
 import type { AudioBuffer, BaseContext, BiquadFilterNode, GainNode, SourceNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
@@ -49,6 +50,7 @@ type SoundCloneOverrides = PanCloneOverrides &
 export class Sound extends RoutableSource implements BaseSound {
   public declare playbacks: Playback[];
   buffer?: AudioBuffer;
+  streamCapabilities?: StreamCapabilities;
   context: BaseContext;
   loopCount: LoopCount = 0;
   private _playbackRate: number = 1;

--- a/src/stream-control.test.ts
+++ b/src/stream-control.test.ts
@@ -66,13 +66,15 @@ describe("Stream control integration", () => {
 });
 
 describe("Stream contract documentation", () => {
-  it("describes media-element backing and removes the dead chunk decoder", () => {
+  it("describes WebCodecs streaming, the media fallback, and removes the dead chunk decoder", () => {
     const readme = readFileSync(join(process.cwd(), "README.md"), "utf8");
     const cacophonySource = readFileSync(join(process.cwd(), "src", "cacophony.ts"), "utf8");
 
     expect(readme).toMatch(/media-element-backed/i);
+    expect(readme).toMatch(/WebCodecs `AudioDecoder`/i);
     expect(readme).toMatch(/native HLS[^.]*Safari/i);
-    expect(cacophonySource).toMatch(/media-element-backed/i);
+    expect(cacophonySource).toMatch(/WebCodecsPullAdapter/);
+    expect(cacophonySource).toMatch(/createMediaSound\(url, "streaming"/);
     expect(existsSync(join(process.cwd(), "src", "stream.ts"))).toBe(false);
     expect(existsSync(join(process.cwd(), "src", "stream.test.ts"))).toBe(false);
   });

--- a/src/webCodecsStream.test.ts
+++ b/src/webCodecsStream.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PcmStreamSound } from "./pcmStream";
+import { audioContextMock, cacophony, expectReachable } from "./setupTests";
+import { Sound } from "./sound";
+
+const media = vi.hoisted(() => ({
+  formats: {
+    adts: Symbol("adts"),
+    flac: Symbol("flac"),
+    mp3: Symbol("mp3"),
+    mp4: Symbol("mp4"),
+    ogg: Symbol("ogg"),
+    wave: Symbol("wave"),
+  },
+  disposeCount: 0,
+  duration: 12,
+  fetchInits: [] as RequestInit[],
+  inputs: [] as Array<{ source: unknown }>,
+  live: false,
+  sample: {
+    allocationSize: vi.fn(() => 16),
+    close: vi.fn(),
+    copyTo: vi.fn((destination: AllowSharedBufferSource) => {
+      new Float32Array(destination as ArrayBuffer).set([0.25, -0.25, 0.5, -0.5]);
+    }),
+    numberOfChannels: 2,
+    numberOfFrames: 2,
+    sampleRate: 44_100,
+  },
+  sampleStarts: [] as number[],
+  sourceOptions: undefined as { fetchFn?: typeof fetch } | undefined,
+  sourceUrl: "",
+}));
+
+vi.mock("mediabunny", () => {
+  class UrlSource {
+    constructor(
+      public url: string,
+      public options: { fetchFn?: typeof fetch } = {},
+    ) {
+      media.sourceUrl = url;
+      media.sourceOptions = options;
+    }
+  }
+
+  class Input {
+    public source: UrlSource;
+
+    constructor({ source }: { source: UrlSource }) {
+      this.source = source;
+      media.inputs.push({ source });
+    }
+
+    async getPrimaryAudioTrack() {
+      await this.source.options.fetchFn?.(this.source.url, {
+        headers: { Range: "bytes=0-65535" },
+      });
+      return {
+        canDecode: vi.fn().mockResolvedValue(true),
+        getDurationFromMetadata: vi.fn().mockImplementation(async () => (media.live ? null : media.duration)),
+        getNumberOfChannels: vi.fn().mockResolvedValue(media.sample.numberOfChannels),
+        getSampleRate: vi.fn().mockResolvedValue(media.sample.sampleRate),
+        isLive: vi.fn().mockImplementation(async () => media.live),
+      };
+    }
+
+    dispose() {
+      media.disposeCount += 1;
+    }
+  }
+
+  class AudioSampleSink {
+    async *samples(start = 0) {
+      media.sampleStarts.push(start);
+      yield media.sample;
+    }
+  }
+
+  return {
+    ADTS: media.formats.adts,
+    AudioSampleSink,
+    FLAC: media.formats.flac,
+    Input,
+    MP3: media.formats.mp3,
+    MP4: media.formats.mp4,
+    OGG: media.formats.ogg,
+    UrlSource,
+    WAVE: media.formats.wave,
+  };
+});
+
+function mockAudioWorklet(): void {
+  Object.defineProperty(audioContextMock, "audioWorklet", {
+    configurable: true,
+    value: { addModule: vi.fn().mockResolvedValue(undefined) },
+    writable: true,
+  });
+}
+
+function enableAudioDecoder(): void {
+  Object.defineProperty(globalThis, "AudioDecoder", {
+    configurable: true,
+    value: vi.fn(),
+    writable: true,
+  });
+}
+
+function disableAudioDecoder(): void {
+  Reflect.deleteProperty(globalThis, "AudioDecoder");
+}
+
+describe("WebCodecs URL streaming", () => {
+  beforeEach(() => {
+    mockAudioWorklet();
+    enableAudioDecoder();
+    media.disposeCount = 0;
+    media.duration = 12;
+    media.fetchInits.length = 0;
+    media.inputs.length = 0;
+    media.live = false;
+    media.sample.allocationSize.mockClear();
+    media.sample.close.mockClear();
+    media.sample.copyTo.mockClear();
+    media.sample.sampleRate = audioContextMock.sampleRate;
+    media.sampleStarts.length = 0;
+    media.sourceOptions = undefined;
+    media.sourceUrl = "";
+    global.fetch = vi.fn(async (_input, init = {}) => {
+      media.fetchInits.push(init);
+      return new Response(new Uint8Array([0]), {
+        headers: {
+          "Accept-Ranges": "bytes",
+          "Content-Range": "bytes 0-0/1",
+        },
+        status: 206,
+      });
+    });
+  });
+
+  afterEach(() => {
+    disableAudioDecoder();
+  });
+
+  it("decodes URL audio into the existing routable PCM source through the public API", async () => {
+    const stream = await cacophony.createStream("https://example.com/music.ogg");
+
+    expect(stream).toBeInstanceOf(PcmStreamSound);
+    expect(stream.streamCapabilities).toEqual({
+      duration: 12,
+      live: false,
+      seekable: true,
+      transport: "webcodecs",
+    });
+
+    const bus = cacophony.createBus("decoded-stream");
+    stream.routeTo(bus);
+    stream.position = [1, 2, 3];
+    stream.addFilter(cacophony.createBiquadFilter({ frequency: 1_200 }));
+    const meter = await cacophony.createLoudnessMeter(bus);
+    const [playback] = stream.play();
+
+    await vi.waitFor(() => expect(media.sample.close).toHaveBeenCalledOnce());
+
+    expect(playback.filters).toHaveLength(1);
+    expect(playback.position).toEqual([1, 2, 3]);
+    expectReachable(playback.source!, bus.output);
+    expectReachable(playback.source!, meter.workletNode);
+    expect(playback.source!.port.postMessage).toHaveBeenCalledWith({
+      samples: new Float32Array([0.25, -0.25, 0.5, -0.5]),
+      type: "write",
+    });
+    expect(media.sourceUrl).toBe("https://example.com/music.ogg");
+  });
+
+  it("seeks by reopening the range-backed decoder at the requested timestamp", async () => {
+    const stream = await cacophony.createStream("https://example.com/music.mp3");
+
+    await vi.waitFor(() => expect(media.sampleStarts).toEqual([0]));
+    stream.seek(4.5);
+    await vi.waitFor(() => expect(media.sampleStarts).toEqual([0, 4.5]));
+
+    expect(media.disposeCount).toBe(1);
+    expect(media.fetchInits).toHaveLength(2);
+    expect(new Headers(media.fetchInits[1]?.headers).get("Range")).toBe("bytes=0-65535");
+  });
+
+  it("reports live sources as unseekable with infinite duration", async () => {
+    media.live = true;
+    global.fetch = vi.fn(async (_input, init = {}) => {
+      media.fetchInits.push(init);
+      return new Response(new Uint8Array([0]), { status: 200 });
+    });
+
+    const stream = await cacophony.createStream("https://example.com/live.aac");
+
+    expect(stream.streamCapabilities).toEqual({
+      duration: Number.POSITIVE_INFINITY,
+      live: true,
+      seekable: false,
+      transport: "webcodecs",
+    });
+    expect(() => stream.seek(2)).toThrow("Live streams do not support seeking");
+  });
+
+  it("aborts fetch, decoder, and PCM playback without logging", async () => {
+    const controller = new AbortController();
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const stream = await cacophony.createStream("https://example.com/music.flac", controller.signal);
+    const [playback] = stream.play();
+    const source = playback.source!;
+
+    controller.abort();
+    await Promise.resolve();
+
+    expect(media.disposeCount).toBe(1);
+    expect(source.disconnect).toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the media element when WebCodecs is unavailable", async () => {
+    disableAudioDecoder();
+
+    const stream = await cacophony.createStream("https://example.com/music.wav");
+
+    expect(stream).toBeInstanceOf(Sound);
+    expect(stream.streamCapabilities?.transport).toBe("media-element");
+    expect(global.Audio).toHaveBeenCalled();
+  });
+});

--- a/src/webCodecsStream.ts
+++ b/src/webCodecsStream.ts
@@ -1,0 +1,368 @@
+import { ADTS, AudioSampleSink, FLAC, Input, type InputAudioTrack, MP3, MP4, OGG, UrlSource, WAVE } from "mediabunny";
+import type { StreamCapabilities } from "./cacophony";
+import type { PcmStreamPullSource, PcmStreamSound } from "./pcmStream";
+
+interface DecoderSession {
+  channelCount: number;
+  duration: number;
+  input: Input;
+  live: boolean;
+  sampleRate: number;
+  seekable: boolean;
+  sink: AudioSampleSink;
+}
+
+interface OpenSessionResult {
+  session: DecoderSession | null;
+  unsupported: boolean;
+}
+
+export type WebCodecsStreamSound = PcmStreamSound & {
+  readonly soundType: "streaming";
+  readonly streamCapabilities: StreamCapabilities;
+};
+
+/**
+ * Pulls encoded URL media through Mediabunny's demuxers and WebCodecs-backed
+ * audio sink, then writes interleaved float PCM into the existing ring buffer.
+ */
+export class WebCodecsPullAdapter implements PcmStreamPullSource {
+  private currentRun?: AbortController;
+  private disposed = false;
+  private pendingInput?: Input;
+  private session?: DecoderSession;
+  private sound?: PcmStreamSound;
+
+  private readonly handleAbort = (): void => {
+    this.cleanup();
+  };
+
+  private constructor(
+    private readonly url: string,
+    private readonly targetSampleRate: number,
+    private readonly signal?: AbortSignal,
+  ) {
+    this.signal?.addEventListener("abort", this.handleAbort, { once: true });
+  }
+
+  static async open(url: string, targetSampleRate: number, signal?: AbortSignal): Promise<WebCodecsPullAdapter | null> {
+    signal?.throwIfAborted();
+    const adapter = new WebCodecsPullAdapter(url, targetSampleRate, signal);
+    try {
+      const result = await adapter.openSession();
+      if (result.unsupported || !result.session) {
+        adapter.cleanup();
+        return null;
+      }
+      adapter.session = result.session;
+      return adapter;
+    } catch (error) {
+      adapter.cleanup();
+      signal?.throwIfAborted();
+      if ((error as { name?: string } | null)?.name === "UnsupportedInputFormatError") {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  get channelCount(): number {
+    if (!this.session) {
+      throw new Error("WebCodecs stream adapter is not initialized");
+    }
+    return this.session.channelCount;
+  }
+
+  get capabilities(): StreamCapabilities {
+    if (!this.session) {
+      throw new Error("WebCodecs stream adapter is not initialized");
+    }
+    return {
+      duration: this.session.duration,
+      live: this.session.live,
+      seekable: this.session.seekable,
+      transport: "webcodecs",
+    };
+  }
+
+  attach(sound: PcmStreamSound): WebCodecsStreamSound {
+    if (this.disposed || !this.session) {
+      throw new Error("Cannot attach a disposed WebCodecs stream adapter");
+    }
+    this.sound = sound;
+    sound.attachPullSource(this, this.capabilities);
+    this.startPump(this.session, 0);
+    return sound as WebCodecsStreamSound;
+  }
+
+  seek(time: number): void {
+    if (!Number.isFinite(time) || time < 0) {
+      throw new RangeError("Stream seek time must be a finite non-negative number");
+    }
+    if (!this.session || !this.sound || this.disposed) {
+      throw new Error("Cannot seek a WebCodecs stream that has been cleaned up");
+    }
+    if (this.session.live) {
+      throw new Error("Live streams do not support seeking");
+    }
+    if (!this.session.seekable) {
+      throw new Error("This stream's server does not support range seeking");
+    }
+
+    const wasPlaying = this.sound.isPlaying;
+    this.sound.stop();
+    if (wasPlaying) {
+      this.sound.play();
+    }
+    this.currentRun?.abort();
+    this.session.input.dispose();
+    this.session = undefined;
+    void this.reopenAndPump(time);
+  }
+
+  cleanup(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.signal?.removeEventListener("abort", this.handleAbort);
+    this.currentRun?.abort();
+    this.pendingInput?.dispose();
+    this.pendingInput = undefined;
+    this.session?.input.dispose();
+    this.session = undefined;
+  }
+
+  private async reopenAndPump(time: number): Promise<void> {
+    try {
+      const result = await this.openSession();
+      if (this.disposed) {
+        result.session?.input.dispose();
+        return;
+      }
+      if (!result.session) {
+        return;
+      }
+      if (result.session.channelCount !== this.channelCountForSound()) {
+        result.session.input.dispose();
+        throw new Error("The audio channel count changed while seeking");
+      }
+      this.session = result.session;
+      this.startPump(result.session, time);
+    } catch (error) {
+      if (!this.disposed && !this.signal?.aborted) {
+        this.sound?.handlePullError(error);
+      }
+    }
+  }
+
+  private channelCountForSound(): number {
+    return this.sound?.inputChannelCount ?? 0;
+  }
+
+  private startPump(session: DecoderSession, startTime: number): void {
+    this.currentRun?.abort();
+    const run = new AbortController();
+    this.currentRun = run;
+    void this.pump(session, startTime, run.signal).catch((error: unknown) => {
+      if (!run.signal.aborted && !this.disposed && !this.signal?.aborted) {
+        this.sound?.handlePullError(error);
+      }
+    });
+  }
+
+  private async pump(session: DecoderSession, startTime: number, runSignal: AbortSignal): Promise<void> {
+    const sound = this.sound;
+    if (!sound) {
+      return;
+    }
+    const resampler = new StreamingPcmResampler(session.sampleRate, this.targetSampleRate, session.channelCount);
+
+    for await (const sample of session.sink.samples(startTime)) {
+      if (runSignal.aborted || this.disposed) {
+        sample.close();
+        return;
+      }
+      try {
+        const options = { format: "f32" as const, planeIndex: 0 };
+        const data = new ArrayBuffer(sample.allocationSize(options));
+        sample.copyTo(data, options);
+        const output = resampler.add(new Float32Array(data));
+        await this.enqueue(sound, output, session.channelCount, runSignal);
+      } finally {
+        sample.close();
+      }
+    }
+
+    const tail = resampler.finalize();
+    await this.enqueue(sound, tail, session.channelCount, runSignal);
+    if (!runSignal.aborted && !this.disposed) {
+      sound.end();
+    }
+  }
+
+  private async enqueue(
+    sound: PcmStreamSound,
+    samples: Float32Array,
+    channelCount: number,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const maximumFrames = Math.max(1, Math.floor(this.targetSampleRate / 4));
+    const maximumSamples = maximumFrames * channelCount;
+    for (let offset = 0; offset < samples.length; offset += maximumSamples) {
+      const chunk = samples.slice(offset, Math.min(samples.length, offset + maximumSamples));
+      let written = false;
+      while (!written) {
+        signal.throwIfAborted();
+        const before = sound.bufferedDuration;
+        const hasCapacity = sound.write(chunk);
+        written = sound.bufferedDuration > before;
+        if (!hasCapacity) {
+          await waitForDrain(sound, signal);
+        }
+      }
+    }
+  }
+
+  private async openSession(): Promise<OpenSessionResult> {
+    this.signal?.throwIfAborted();
+    let sawRangeResponse = false;
+    const source = new UrlSource(this.url, {
+      fetchFn: async (input, init) => {
+        const response = await globalThis.fetch(input, init);
+        if (response.status === 206 || response.headers.get("Accept-Ranges")?.toLowerCase() === "bytes") {
+          sawRangeResponse = true;
+        }
+        return response;
+      },
+    });
+    const input = new Input({ formats: [MP3, ADTS, MP4, OGG, FLAC, WAVE], source });
+    this.pendingInput = input;
+    try {
+      const track = await input.getPrimaryAudioTrack();
+      if (!track || !(await track.canDecode())) {
+        this.pendingInput = undefined;
+        input.dispose();
+        return { session: null, unsupported: true };
+      }
+      const session = await this.describeSession(input, track, sawRangeResponse);
+      this.signal?.throwIfAborted();
+      if (this.disposed) {
+        this.pendingInput = undefined;
+        input.dispose();
+        return { session: null, unsupported: false };
+      }
+      this.pendingInput = undefined;
+      return { session, unsupported: false };
+    } catch (error) {
+      if (this.pendingInput === input) {
+        this.pendingInput = undefined;
+        input.dispose();
+      }
+      throw error;
+    }
+  }
+
+  private async describeSession(
+    input: Input,
+    track: InputAudioTrack,
+    sawRangeResponse: boolean,
+  ): Promise<DecoderSession> {
+    const [channelCount, sampleRate, live, metadataDuration] = await Promise.all([
+      track.getNumberOfChannels(),
+      track.getSampleRate(),
+      track.isLive(),
+      track.getDurationFromMetadata({ skipLiveWait: true }),
+    ]);
+    return {
+      channelCount,
+      duration: live || metadataDuration === null ? Number.POSITIVE_INFINITY : metadataDuration,
+      input,
+      live,
+      sampleRate,
+      seekable: !live && sawRangeResponse,
+      sink: new AudioSampleSink(track),
+    };
+  }
+}
+
+function waitForDrain(sound: PcmStreamSound, signal: AbortSignal): Promise<void> {
+  signal.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const unsubscribe = sound.on("drain", () => {
+      cleanup();
+      resolve();
+    });
+    const handleAbort = () => {
+      cleanup();
+      reject(signal.reason);
+    };
+    const cleanup = () => {
+      unsubscribe();
+      signal.removeEventListener("abort", handleAbort);
+    };
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+}
+
+class StreamingPcmResampler {
+  private inputFrames = 0;
+  private nextSourcePosition = 0;
+  private previousFrame?: Float32Array;
+
+  constructor(
+    private readonly sourceRate: number,
+    private readonly targetRate: number,
+    private readonly channelCount: number,
+  ) {}
+
+  add(input: Float32Array): Float32Array {
+    if (this.sourceRate === this.targetRate) {
+      this.inputFrames += input.length / this.channelCount;
+      return input;
+    }
+    const frameCount = input.length / this.channelCount;
+    const firstFrame = this.inputFrames;
+    const lastFrame = firstFrame + frameCount - 1;
+    const output: number[] = [];
+
+    while (this.nextSourcePosition <= lastFrame) {
+      const leftFrame = Math.floor(this.nextSourcePosition);
+      const fraction = this.nextSourcePosition - leftFrame;
+      if (fraction > 0 && leftFrame + 1 > lastFrame) {
+        break;
+      }
+      for (let channel = 0; channel < this.channelCount; channel += 1) {
+        const left = this.sampleAt(input, firstFrame, leftFrame, channel);
+        const right = this.sampleAt(input, firstFrame, Math.min(leftFrame + 1, lastFrame), channel);
+        output.push(left + (right - left) * fraction);
+      }
+      this.nextSourcePosition += this.sourceRate / this.targetRate;
+    }
+
+    this.inputFrames += frameCount;
+    this.previousFrame = input.slice(input.length - this.channelCount);
+    return Float32Array.from(output);
+  }
+
+  finalize(): Float32Array {
+    if (this.sourceRate === this.targetRate || !this.previousFrame) {
+      return new Float32Array();
+    }
+    const output: number[] = [];
+    while (this.nextSourcePosition < this.inputFrames) {
+      for (const sample of this.previousFrame) {
+        output.push(sample);
+      }
+      this.nextSourcePosition += this.sourceRate / this.targetRate;
+    }
+    return Float32Array.from(output);
+  }
+
+  private sampleAt(input: Float32Array, firstFrame: number, frame: number, channel: number): number {
+    if (frame < firstFrame) {
+      return this.previousFrame?.[channel] ?? input[channel] ?? 0;
+    }
+    return input[(frame - firstFrame) * this.channelCount + channel] ?? 0;
+  }
+}


### PR DESCRIPTION
## Summary

- add a fetch/demux/WebCodecs pull adapter over the existing `PcmStreamSound` ring buffer
- expose honest transport, seeking, live, and duration capabilities with media-element fallback
- preserve panning, filters, bus routing, metering, backpressure, and abort teardown through the existing PCM path
- document supported MP3, AAC, Ogg, FLAC, and WAVE streaming behavior

## Root cause

`createStream()` was only a media-element alias, so callers could not own decoded samples for sample-accurate scheduling, effects, or metering. The repository already had the push PCM foundation but no URL pull/demux/decode layer feeding it.

## Validation

- `npm run lint`
- `npm run ci:test` (1049 passed, 2 skipped; no type errors)
- `npm run build` (succeeds with the repository's existing TS4094 and TypeDoc warnings)
- `npm audit --omit=dev` (0 vulnerabilities)

Closes #131