### PR TITLE
Add optional hls.js streaming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,19 @@ If WebCodecs is absent or the primary track has no WebCodecs decoder,
 `streamCapabilities.transport` for `'webcodecs'` or `'media-element'` rather
 than assuming a tier.
 
-Native HLS (`.m3u8`) playback is limited to Safari. Cross-browser HLS support
-requires an adapter such as the one tracked in the
-[hls.js adapter issue](https://github.com/ctoth/cacophony/issues/132).
+Native HLS (`.m3u8`) playback, notably in Safari, uses the media element
+directly. In browsers without native HLS, `createStream()` lazily uses
+`hls.js`, declared as an optional peer dependency:
+
+```bash
+npm install hls.js
+```
+
+If neither native HLS nor an installed, MSE-capable `hls.js` is available,
+`createStream()` rejects with install guidance instead of leaving a media
+element silently waiting. hls.js failures after loading are emitted through
+the Sound's `soundError` event, and `sound.cleanup()` detaches and destroys the
+hls.js instance.
 
 ### Format Fallback (Howler-style)
 
@@ -855,11 +865,11 @@ Volume, stereo/HRTF pan, filters, buses, and sends use the same public APIs as
 other sources. Seek is not supported for a push PCM source. Loop is not
 supported because the source does not retain consumed samples.
 
-Adaptive HLS/DASH and DRM are outside the WebCodecs pull transport. Native HLS
-playback is limited to Safari; use the media tier or an hls.js adapter for
-`.m3u8` URLs in other browsers. Follow the
-[hls.js adapter issue](https://github.com/ctoth/cacophony/issues/132) for that
-integration.
+Adaptive HLS/DASH and DRM are outside the WebCodecs pull transport. `.m3u8`
+URLs use the media tier: native HLS where `HTMLAudioElement.canPlayType()`
+reports support (notably Safari), then the optional `hls.js` peer in
+MSE-capable browsers. Install that peer with `npm install hls.js`. DASH and DRM
+remain outside this integration.
 
 ```typescript
 const cacophony = new Cacophony();

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/audioworklet": "^0.0.87",
         "@types/node": "^22.18.1",
         "glob": "^13.0.6",
+        "hls.js": "^1.6.16",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "rimraf": "^6.1.3",
@@ -39,9 +40,13 @@
         "node-web-audio-api": "^2.0.0"
       },
       "peerDependencies": {
+        "hls.js": "^1.6.16",
         "standardized-audio-context": ">=25.0.0"
       },
       "peerDependenciesMeta": {
+        "hls.js": {
+          "optional": true
+        },
         "standardized-audio-context": {
           "optional": true
         }
@@ -1915,6 +1920,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/husky": {
       "version": "9.1.7",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/audioworklet": "^0.0.87",
     "@types/node": "^22.18.1",
     "glob": "^13.0.6",
+    "hls.js": "^1.6.16",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "rimraf": "^6.1.3",
@@ -91,9 +92,13 @@
     "node-web-audio-api": "^2.0.0"
   },
   "peerDependencies": {
+    "hls.js": "^1.6.16",
     "standardized-audio-context": ">=25.0.0"
   },
   "peerDependenciesMeta": {
+    "hls.js": {
+      "optional": true
+    },
     "standardized-audio-context": {
       "optional": true
     }

--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -7,6 +7,42 @@ import { Group } from "./group";
 import { audioContextMock, cacophony, mockCache } from "./setupTests";
 import { Sound } from "./sound";
 
+const hlsMock = vi.hoisted(() => {
+  const instances: MockHls[] = [];
+  const isSupported = vi.fn(() => true);
+
+  class MockHls {
+    static readonly Events = { ERROR: "hlsError" };
+    static readonly isSupported = isSupported;
+
+    readonly listeners = new Map<string, (...args: any[]) => void>();
+    readonly attachMedia = vi.fn();
+    readonly detachMedia = vi.fn();
+    readonly destroy = vi.fn();
+    readonly loadSource = vi.fn();
+    readonly on = vi.fn((event: string, listener: (...args: any[]) => void) => {
+      this.listeners.set(event, listener);
+    });
+    readonly off = vi.fn((event: string, listener: (...args: any[]) => void) => {
+      if (this.listeners.get(event) === listener) {
+        this.listeners.delete(event);
+      }
+    });
+
+    constructor() {
+      instances.push(this);
+    }
+
+    emitError(data: Record<string, unknown>): void {
+      this.listeners.get(MockHls.Events.ERROR)?.(MockHls.Events.ERROR, data);
+    }
+  }
+
+  return { instances, isSupported, MockHls };
+});
+
+vi.mock("hls.js", () => ({ default: hlsMock.MockHls }));
+
 const createControllableAudioElement = () => {
   const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
   const audio = {
@@ -402,6 +438,107 @@ describe("Cacophony advanced features", () => {
       });
       expect(streamingAudio.audio.pause).toHaveBeenCalledOnce();
       expect(streamingAudio.audio.src).toBe("");
+    });
+
+    it("createStream uses native HLS when the media element supports it", async () => {
+      const url = "https://example.com/live.m3u8";
+      const streamingAudio = createControllableAudioElement();
+      const canPlayType = vi.fn().mockReturnValue("maybe");
+      Object.assign(streamingAudio.audio, { canPlayType });
+
+      vi.mocked(global.Audio).mockImplementationOnce(function MockStreamingAudio() {
+        return streamingAudio.audio as any;
+      });
+
+      const streamPromise = cacophony.createStream(url);
+
+      expect(canPlayType).toHaveBeenCalledWith("application/vnd.apple.mpegurl");
+      streamingAudio.dispatch("loadedmetadata");
+
+      const sound = await streamPromise;
+      expect(sound.soundType).toBe("streaming");
+      expect(streamingAudio.audio.src).toBe(url);
+    });
+
+    it("createStream attaches hls.js for HLS without native support and destroys it on cleanup", async () => {
+      const url = "https://example.com/live.m3u8";
+      const streamingAudio = createControllableAudioElement();
+      const canPlayType = vi.fn().mockReturnValue("");
+      Object.assign(streamingAudio.audio, { canPlayType });
+      hlsMock.instances.length = 0;
+      hlsMock.isSupported.mockReturnValue(true);
+
+      vi.mocked(global.Audio).mockImplementationOnce(function MockStreamingAudio() {
+        return streamingAudio.audio as any;
+      });
+
+      const streamPromise = cacophony.createStream(url);
+
+      await vi.waitFor(() => expect(hlsMock.instances).toHaveLength(1));
+      const hls = hlsMock.instances[0];
+      expect(hls.attachMedia).toHaveBeenCalledWith(streamingAudio.audio);
+      expect(hls.loadSource).toHaveBeenCalledWith(url);
+      expect(streamingAudio.audio.src).toBe("");
+
+      streamingAudio.dispatch("loadedmetadata");
+      const sound = await streamPromise;
+      sound.cleanup();
+
+      expect(hls.detachMedia).toHaveBeenCalledOnce();
+      expect(hls.destroy).toHaveBeenCalledOnce();
+    });
+
+    it("maps hls.js errors into the Sound event system", async () => {
+      const url = "https://example.com/live.m3u8";
+      const streamingAudio = createControllableAudioElement();
+      Object.assign(streamingAudio.audio, { canPlayType: vi.fn().mockReturnValue("") });
+      hlsMock.instances.length = 0;
+      hlsMock.isSupported.mockReturnValue(true);
+
+      vi.mocked(global.Audio).mockImplementationOnce(function MockStreamingAudio() {
+        return streamingAudio.audio as any;
+      });
+
+      const streamPromise = cacophony.createStream(url);
+      await vi.waitFor(() => expect(hlsMock.instances).toHaveLength(1));
+      streamingAudio.dispatch("loadedmetadata");
+      const sound = await streamPromise;
+      const soundError = vi.fn();
+      sound.on("soundError", soundError);
+
+      hlsMock.instances[0].emitError({
+        type: "networkError",
+        details: "manifestLoadError",
+        fatal: true,
+        error: new Error("manifest request failed"),
+      });
+
+      await vi.waitFor(() =>
+        expect(soundError).toHaveBeenCalledWith(
+          expect.objectContaining({
+            url,
+            errorType: "load",
+            recoverable: false,
+            error: expect.objectContaining({
+              message: expect.stringContaining("manifestLoadError"),
+            }),
+          }),
+        ),
+      );
+    });
+
+    it("createStream gives install guidance when neither native HLS nor hls.js can play HLS", async () => {
+      const streamingAudio = createControllableAudioElement();
+      Object.assign(streamingAudio.audio, { canPlayType: vi.fn().mockReturnValue("") });
+      hlsMock.isSupported.mockReturnValue(false);
+
+      vi.mocked(global.Audio).mockImplementationOnce(function MockStreamingAudio() {
+        return streamingAudio.audio as any;
+      });
+
+      await expect(cacophony.createStream("https://example.com/live.m3u8")).rejects.toThrow(
+        "install hls.js or use a direct stream URL",
+      );
     });
 
     it("createGroupFromUrls passes AbortSignal to all createSound calls", async () => {

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -42,6 +42,7 @@ import {
 import { TypedEventEmitter } from "./eventEmitter";
 import type { CacophonyEvents } from "./events";
 import { Group } from "./group";
+import { HlsAdapter } from "./hlsAdapter";
 import { type CacophonyLogger, consoleLogger, noopLogger } from "./logger";
 import { MediaStreamSound, type MediaStreamSoundOptions } from "./mediaStream";
 import { LoudnessMeter } from "./meters/loudness-meter";
@@ -792,14 +793,19 @@ export class Cacophony {
     soundType: "html" | "streaming",
     panType: PanType,
     signal?: AbortSignal,
+    preparedAudio?: HTMLAudioElement,
+    useHlsJs: boolean = false,
   ): Promise<Sound> {
     if (signal?.aborted) {
       return Promise.reject(this.createAbortError());
     }
 
     return new Promise<Sound>((resolve, reject) => {
-      const audio = new Audio();
+      const audio = preparedAudio ?? new Audio();
+      let hlsAdapter: HlsAdapter | undefined;
+      let sound: Sound | undefined;
       let settled = false;
+      const pendingHlsErrors: Array<{ error: Error; recoverable: boolean }> = [];
 
       const cleanup = () => {
         audio.removeEventListener("loadedmetadata", handleLoadedMetadata);
@@ -808,6 +814,7 @@ export class Cacophony {
       };
 
       const teardown = () => {
+        hlsAdapter?.destroy();
         audio.pause();
         audio.src = "";
         audio.load();
@@ -824,7 +831,17 @@ export class Cacophony {
 
       const handleLoadedMetadata = () => {
         settle(() => {
-          const sound = new Sound(url, undefined, this.context, this.globalGainNode, soundType, panType, this, audio);
+          sound = new Sound(
+            url,
+            undefined,
+            this.context,
+            this.globalGainNode,
+            soundType,
+            panType,
+            this,
+            audio,
+            hlsAdapter ? () => hlsAdapter?.destroy() : undefined,
+          );
           if (soundType === "streaming") {
             sound.streamCapabilities = {
               duration: Number.isFinite(audio.duration) ? audio.duration : Number.POSITIVE_INFINITY,
@@ -833,8 +850,24 @@ export class Cacophony {
               transport: "media-element",
             };
           }
+          for (const { error, recoverable } of pendingHlsErrors) {
+            sound.reportLoadError(error, recoverable);
+          }
           resolve(sound);
         });
+      };
+
+      const handleHlsError = (error: Error, recoverable: boolean) => {
+        if (sound) {
+          sound.reportLoadError(error, recoverable);
+        } else if (recoverable) {
+          pendingHlsErrors.push({ error, recoverable });
+        } else {
+          settle(() => {
+            teardown();
+            reject(error);
+          });
+        }
       };
 
       const handleError = () => {
@@ -858,9 +891,41 @@ export class Cacophony {
       audio.addEventListener("loadedmetadata", handleLoadedMetadata);
       audio.addEventListener("error", handleError);
       signal?.addEventListener("abort", handleAbort, { once: true });
-      audio.src = url;
-      audio.load();
+      if (useHlsJs) {
+        void HlsAdapter.create(handleHlsError).then(
+          (adapter) => {
+            hlsAdapter = adapter;
+            if (settled) {
+              adapter.destroy();
+              return;
+            }
+            try {
+              adapter.attach(audio, url);
+            } catch (error) {
+              settle(() => {
+                teardown();
+                reject(error);
+              });
+            }
+          },
+          (error: unknown) => {
+            settle(() => {
+              teardown();
+              reject(error);
+            });
+          },
+        );
+      } else {
+        audio.src = url;
+        audio.load();
+      }
     });
+  }
+
+  private createHlsSound(url: string, signal?: AbortSignal): Promise<Sound> {
+    const audio = new Audio();
+    const nativeHls = audio.canPlayType("application/vnd.apple.mpegurl") || audio.canPlayType("application/x-mpegURL");
+    return this.createMediaSound(url, "streaming", "HRTF", signal, audio, !nativeHls);
   }
 
   clearMemoryCache(): void {
@@ -1077,6 +1142,10 @@ export class Cacophony {
    * decoder for the track, fall back to the media-element streaming tier.
    */
   async createStream(url: string, signal?: AbortSignal): Promise<Sound | WebCodecsStreamSound> {
+    if (/\.m3u8(?:$|[?#])/i.test(url)) {
+      return this.createHlsSound(url, signal);
+    }
+
     if (typeof globalThis.AudioDecoder !== "function") {
       return this.createMediaSound(url, "streaming", "HRTF", signal);
     }

--- a/src/cli/package.test.ts
+++ b/src/cli/package.test.ts
@@ -6,9 +6,12 @@ const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf8")
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
 };
+const viteConfig = readFileSync(join(process.cwd(), "vite.config.ts"), "utf8");
 
-describe("CLI package metadata", () => {
+describe("Package metadata", () => {
   it("ships the Node Web Audio backend as an optional dependency", () => {
     // Loaded lazily via dynamic import in src/node.ts so browser-only consumers
     // never pull in the native package, and a failed native build degrades to
@@ -16,5 +19,16 @@ describe("CLI package metadata", () => {
     expect(pkg.optionalDependencies).toHaveProperty("node-web-audio-api");
     expect(pkg.dependencies).not.toHaveProperty("node-web-audio-api");
     expect(pkg.devDependencies).not.toHaveProperty("node-web-audio-api");
+  });
+
+  it("ships hls.js as an optional peer without changing the runtime dependency footprint", () => {
+    expect(pkg.peerDependencies).toHaveProperty("hls.js");
+    expect(pkg.peerDependenciesMeta?.["hls.js"]?.optional).toBe(true);
+    expect(pkg.dependencies).not.toHaveProperty("hls.js");
+    expect(pkg.optionalDependencies).not.toHaveProperty("hls.js");
+  });
+
+  it("externalizes peer dependencies from library bundles", () => {
+    expect(viteConfig).toMatch(/Object\.keys\(pkg\.peerDependencies/);
   });
 });

--- a/src/hls.test.ts
+++ b/src/hls.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("HlsAdapter optional peer loading", () => {
+  afterEach(() => {
+    vi.doUnmock("hls.js");
+    vi.resetModules();
+  });
+
+  it("gives install guidance when hls.js is not installed", async () => {
+    vi.doMock("hls.js", () => {
+      throw new Error("Cannot find package 'hls.js'");
+    });
+    const { HlsAdapter } = await import("./hlsAdapter");
+
+    await expect(HlsAdapter.create(vi.fn())).rejects.toThrow("install hls.js or use a direct stream URL");
+  });
+});

--- a/src/hlsAdapter.ts
+++ b/src/hlsAdapter.ts
@@ -1,0 +1,60 @@
+import type Hls from "hls.js";
+import type { ErrorData, Events } from "hls.js";
+
+const HLS_UNAVAILABLE_MESSAGE =
+  "HLS playback is unavailable in this browser; install hls.js or use a direct stream URL.";
+
+type HlsErrorListener = (error: Error, recoverable: boolean) => void;
+
+/**
+ * Owns one optional hls.js instance and its media-element attachment.
+ *
+ * The module is loaded only for `.m3u8` streams without native HLS support, so
+ * consumers that do not install the optional peer never load it.
+ */
+export class HlsAdapter {
+  private destroyed = false;
+
+  private readonly handleError = (_event: string, data: ErrorData): void => {
+    const message = `hls.js ${data.type}: ${data.details}`;
+    const error = new Error(message, data.error ? { cause: data.error } : undefined);
+    this.onError(error, !data.fatal);
+  };
+
+  private constructor(
+    private readonly hls: Hls,
+    private readonly errorEvent: Events.ERROR,
+    private readonly onError: HlsErrorListener,
+  ) {}
+
+  static async create(onError: HlsErrorListener): Promise<HlsAdapter> {
+    let HlsConstructor: typeof import("hls.js").default;
+    try {
+      ({ default: HlsConstructor } = await import("hls.js"));
+    } catch (cause) {
+      throw new Error(HLS_UNAVAILABLE_MESSAGE, { cause });
+    }
+
+    if (!HlsConstructor.isSupported()) {
+      throw new Error(HLS_UNAVAILABLE_MESSAGE);
+    }
+
+    return new HlsAdapter(new HlsConstructor(), HlsConstructor.Events.ERROR, onError);
+  }
+
+  attach(audio: HTMLAudioElement, url: string): void {
+    this.hls.on(this.errorEvent, this.handleError);
+    this.hls.loadSource(url);
+    this.hls.attachMedia(audio);
+  }
+
+  destroy(): void {
+    if (this.destroyed) {
+      return;
+    }
+    this.destroyed = true;
+    this.hls.off(this.errorEvent, this.handleError);
+    this.hls.detachMedia();
+    this.hls.destroy();
+  }
+}

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -83,6 +83,7 @@ export class Sound extends RoutableSource implements BaseSound {
     public panType: PanType = "HRTF",
     private _cacophony?: Cacophony,
     preparedMediaElement?: HTMLAudioElement,
+    private _preparedMediaElementCleanup?: () => void,
   ) {
     super();
     this.buffer = buffer;
@@ -120,6 +121,20 @@ export class Sound extends RoutableSource implements BaseSound {
 
   protected async emitAsync<K extends keyof SoundEvents>(event: K, data: SoundEvents[K]): Promise<void> {
     return this.eventEmitter.emitAsync(event, data);
+  }
+
+  /**
+   * Routes a media-loader failure through the Sound's existing typed event
+   * system. Used by optional media transports after the Sound has loaded.
+   */
+  reportLoadError(error: Error, recoverable: boolean): void {
+    void this.emitAsync("soundError", {
+      url: this.url,
+      error,
+      errorType: "load",
+      timestamp: Date.now(),
+      recoverable,
+    });
   }
 
   /**
@@ -525,6 +540,8 @@ export class Sound extends RoutableSource implements BaseSound {
 
   cleanup(): void {
     this._cacophony?.unregisterSoundCleanup(this._unregisterToken);
+    this._preparedMediaElementCleanup?.();
+    this._preparedMediaElementCleanup = undefined;
     if (this._preparedMediaElement) {
       this._preparedMediaElement.pause();
       this._preparedMediaElement.src = "";

--- a/src/stream-control.test.ts
+++ b/src/stream-control.test.ts
@@ -72,7 +72,10 @@ describe("Stream contract documentation", () => {
 
     expect(readme).toMatch(/media-element-backed/i);
     expect(readme).toMatch(/WebCodecs `AudioDecoder`/i);
-    expect(readme).toMatch(/native HLS[^.]*Safari/i);
+    expect(readme).toMatch(/native HLS[\s\S]{0,80}Safari/i);
+    expect(readme).toMatch(/npm install hls\.js/);
+    expect(readme).toMatch(/optional peer dependency/i);
+    expect(readme).not.toMatch(/hls\.js adapter issue/i);
     expect(cacophonySource).toMatch(/WebCodecsPullAdapter/);
     expect(cacophonySource).toMatch(/createMediaSound\(url, "streaming"/);
     expect(existsSync(join(process.cwd(), "src", "stream.ts"))).toBe(false);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -31,12 +31,12 @@ export default defineConfig({
       },
     },
     rollupOptions: {
-      // Never bundle runtime deps. node-web-audio-api is a native optional dep
-      // (loaded via dynamic import in src/node.ts) and lives under
-      // optionalDependencies, so externalize those keys too.
+      // Never bundle runtime deps. Optional dependencies and peers are loaded
+      // only by the feature paths that need them, so externalize those keys too.
       external: [
         ...Object.keys(pkg.dependencies),
         ...Object.keys(pkg.optionalDependencies ?? {}),
+        ...Object.keys(pkg.peerDependencies ?? {}),
         /^node:.*/,
       ],
     },


### PR DESCRIPTION
## Summary

- route `.m3u8` streams through native HLS when the media element supports it
- lazily attach the optional `hls.js` peer otherwise, with clear unavailable guidance
- map hls.js failures into `soundError` and detach/destroy the adapter during cleanup
- externalize peer dependencies so hls.js is not bundled into the default install
- document the shipped HLS behavior and optional install

## Root cause and impact

`createStream()` previously treated HLS like an ordinary WebCodecs/media URL. Non-Safari browsers without native HLS could silently wait on a media element, and there was no optional hls.js integration or cleanup/error bridge. Consumers can now play `.m3u8` streams cross-browser when they install hls.js, while the core package keeps the same hard runtime footprint.

## Validation

- `npm run lint`
- `npm run ci:test` — 72 files; 1,056 passed, 2 skipped; no type errors
- `npm run build` — completed with the repository's existing TS4094/TypeDoc warnings
- built ESM and CJS artifacts retain an external dynamic `hls.js` import

Closes #132