### PR TITLE
Track mute state independently from volume

### DIFF
--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -175,6 +175,27 @@ describe("Cacophony core", () => {
       expect(cacophony.globalGainNode.gain.value).toBe(0.75);
     });
 
+    it("treats zero volume as silent without muting", () => {
+      cacophony.volume = 0;
+
+      expect(cacophony.muted).toBe(false);
+
+      cacophony.volume = 0.5;
+
+      expect(cacophony.volume).toBe(0.5);
+      expect(cacophony.globalGainNode.gain.value).toBe(0.5);
+    });
+
+    it("applies volume changes made while muted when unmuting", () => {
+      cacophony.mute();
+      cacophony.volume = 0.7;
+      cacophony.unmute();
+
+      expect(cacophony.muted).toBe(false);
+      expect(cacophony.volume).toBe(0.7);
+      expect(cacophony.globalGainNode.gain.value).toBe(0.7);
+    });
+
     it("mutes and unmutes correctly", () => {
       cacophony.volume = 0.8;
       expect(cacophony.muted).toBe(false);

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -256,6 +256,7 @@ export class Cacophony {
   master: Bus;
   listener: AudioListener;
   private prevVolume: number = 1;
+  private isMuted: boolean = false;
   /**
    * Per-context cache of "module-name has been loaded on this BaseContext".
    * Keyed on the context itself because `AudioWorklet.addModule()` registers
@@ -1743,6 +1744,7 @@ export class Cacophony {
   mute() {
     if (!this.muted) {
       this.prevVolume = this.globalGainNode.gain.value;
+      this.isMuted = true;
       this.setGlobalVolume(0);
       this.emit("mute", undefined);
     }
@@ -1750,13 +1752,14 @@ export class Cacophony {
 
   unmute() {
     if (this.muted) {
+      this.isMuted = false;
       this.setGlobalVolume(this.prevVolume);
       this.emit("unmute", undefined);
     }
   }
 
   get muted(): boolean {
-    return this.globalGainNode.gain.value === 0;
+    return this.isMuted;
   }
 
   set muted(muted: boolean) {


### PR DESCRIPTION
## Summary

- track explicit master mute state independently from the gain value
- preserve volume changes made while explicitly muted for the next unmute
- cover zero-volume recovery and muted volume updates with regression tests

## Root cause

`Cacophony.muted` inferred mute state from `globalGainNode.gain.value === 0`. Setting `volume = 0` therefore looked like an explicit mute and caused later volume assignments to be stashed instead of applied.

## Impact

Setting the master volume to zero is now silent without being muted, so a later nonzero volume takes effect immediately. Explicit `mute()` / `unmute()` behavior continues to preserve volume updates made while muted.

## Validation

- `npm run test -- src/cacophony.test.ts` (73 passed)
- `npm run lint`
- `npm run ci:test` (1,058 passed, 2 skipped; no type errors)
- `npm run build` (completed with the repository's existing TS4094 and TypeDoc warnings)

Closes #103