### PR TITLE
Fix Node URL format fallback

### DIFF
--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -1095,6 +1095,9 @@ export class Cacophony {
   }
 
   private canPlaySource(url: string): boolean {
+    if (typeof Audio === "undefined") {
+      return true;
+    }
     const mime = mimeTypeForUrl(url);
     if (!mime) {
       return false;

--- a/src/node.test.ts
+++ b/src/node.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { nodeBackendAvailable } from "./backend-available";
@@ -79,5 +80,32 @@ describe.skipIf(!nodeBackendAvailable)("cacophony/node adapter", () => {
     const buffer = await decodeAudioFile(context, resolve(__dirname, "..", "test.ogg"));
     expect(buffer.numberOfChannels).toBeGreaterThanOrEqual(1);
     expect(buffer.duration).toBeGreaterThan(0);
+  });
+
+  it("falls back to the second URL when the first candidate cannot be decoded", async () => {
+    const { cacophony } = await createOfflineNodeCacophony({
+      length: Math.round(48000 * 0.1),
+      sampleRate: 48000,
+      quiet: true,
+    });
+    const urls = ["https://example.com/audio.mp3", "https://example.com/audio.ogg"];
+    const encodedOgg = await readFile(resolve(__dirname, "..", "test.ogg"));
+    const validAudio = encodedOgg.buffer.slice(
+      encodedOgg.byteOffset,
+      encodedOgg.byteOffset + encodedOgg.byteLength,
+    ) as ArrayBuffer;
+    const invalidAudio = new TextEncoder().encode("not audio").buffer;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      return new Response(String(input) === urls[0] ? invalidAudio : validAudio);
+    });
+
+    try {
+      const sound = await cacophony.createSound(urls);
+
+      expect(sound.url).toBe(urls[1]);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- bypass HTML audio capability probing only when the `Audio` global is unavailable
- let the real Node decoder select among URL-array format candidates
- cover invalid-first, valid-second fallback with the gated real Node backend and existing `test.ogg` fixture

## Root cause

The Node runtime has no `Audio` global, so every URL candidate was classified as unsupported before fetch or decode. The real `node-web-audio-api` decoder rejects invalid input with the existing `EncodingError` DOMException shape, so the established decode-only fallback gate remains correct.

## Impact

`createSound(urls[])` now works on the supported `cacophony/node` surface while browser `canPlayType` behavior remains unchanged.

## Validation

- `npm test -- src/node.test.ts`
- `npm test -- src/cacophony.test.ts`
- `npm run lint`
- `npm run ci:test`
- `npm run build`

Closes #144