### PR TITLE
Protect the master bus from destruction

### DIFF
--- a/src/bus-integration.test.ts
+++ b/src/bus-integration.test.ts
@@ -2,7 +2,7 @@ import { AudioContext } from "standardized-audio-context-mock";
 import { describe, expect, it, vi } from "vitest";
 import { Bus } from "./bus";
 import { Cacophony } from "./cacophony";
-import { cacophony } from "./setupTests";
+import { cacophony, expectReachable } from "./setupTests";
 
 describe("Cacophony.master", () => {
   it("exists as a Bus instance after construction", () => {
@@ -15,6 +15,15 @@ describe("Cacophony.master", () => {
 
   it("master.name === 'master'", () => {
     expect(cacophony.master.name).toBe("master");
+  });
+
+  it("refuses destruction without breaking the audible graph", () => {
+    expectReachable(cacophony.master.input, cacophony.master.output);
+
+    expect(() => cacophony.master.destroy()).toThrow("The master bus cannot be destroyed");
+
+    expect(cacophony.master.destroyed).toBe(false);
+    expectReachable(cacophony.master.input, cacophony.master.output);
   });
 
   it("cacophony.volume = 0.5 reflects on master.input.gain.value", () => {

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -100,6 +100,7 @@ export class Bus {
    * the named-bus registry on destroy. Anonymous buses leave this undefined.
    */
   private readonly _onDestroy?: () => void;
+  private readonly _destroyable: boolean;
   private _destroyed = false;
 
   /**
@@ -109,13 +110,21 @@ export class Bus {
    *   the `master` bus to alias `cacophony.globalGainNode`. If omitted, a
    *   fresh GainNode is allocated.
    * @param onDestroy Optional registry-cleanup hook fired by destroy().
+   * @param destroyable Whether destroy() may tear down this bus.
    */
-  constructor(context: BaseContext, name: string | null = null, input?: GainNode, onDestroy?: () => void) {
+  constructor(
+    context: BaseContext,
+    name: string | null = null,
+    input?: GainNode,
+    onDestroy?: () => void,
+    destroyable = true,
+  ) {
     this._context = context;
     this.name = name;
     this.input = input ?? context.createGain();
     this.output = context.createGain();
     this._onDestroy = onDestroy;
+    this._destroyable = destroyable;
     this._connectFilterChainEdge(this.input, this.output);
   }
 
@@ -514,6 +523,9 @@ export class Bus {
    * playback (the routeTo machinery checks `destroyed` at preplay).
    */
   destroy(options?: { drainTo?: Bus }): void {
+    if (!this._destroyable) {
+      throw new Error("The master bus cannot be destroyed");
+    }
     if (this._destroyed) {
       return;
     }

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -334,7 +334,7 @@ export class Cacophony {
     // globalGainNode directly. If globalGainNode were pre-connected to
     // destination, adding a master filter would call _refreshFilters() which
     // disconnects master.input's outgoing edges, severing the audible path.
-    this.master = new Bus(this.context, "master", this.globalGainNode);
+    this.master = new Bus(this.context, "master", this.globalGainNode, undefined, false);
     this.master.output.connect(this.context.destination);
     this.cache = cache ?? new AudioCache();
     this.createAudioWorkletNode =


### PR DESCRIPTION
## Summary

- add a constructor-level destroyability guard to `Bus`
- mark only `cacophony.master` as non-destroyable
- verify a rejected destroy leaves the master graph and state intact

## Root cause and impact

The master bus was constructed as an ordinary `Bus`, so its public `destroy()` method disconnected the only route to the audio destination and permanently silenced the `Cacophony` instance. The master bus now rejects destruction with a clear error while ordinary named and anonymous buses remain destroyable.

## Validation

- `npm test -- src/bus-integration.test.ts` (red before implementation, 18 tests green after)
- `npm run lint`
- `npm run ci:test` (1,060 passed, 2 skipped; no type errors)
- `npm run build` (completed with existing TS4094 and TypeDoc warnings)

Closes #142