### PR TITLE
Preserve playback clone fade and pitch state

### DIFF
--- a/src/pitch-shift-resurrection.test.ts
+++ b/src/pitch-shift-resurrection.test.ts
@@ -227,4 +227,26 @@ describe("phase-vocoder resurrection: pitch-shift wires the dead worklet into th
     expect(future.pitchShift).toBe(2);
     expect(built.length).toBe(2);
   });
+
+  it("Playback.clone preserves pitch shift with its own worklet node", async () => {
+    sound = await cacophony.createSound(buffer);
+    const built: ReturnType<typeof makeFakePvNode>[] = [];
+    vi.spyOn(cacophony, "buildWorkletEffect").mockImplementation(async () => {
+      const node = makeFakePvNode();
+      built.push(node);
+      return node as unknown as Awaited<ReturnType<typeof cacophony.buildWorkletEffect>>;
+    });
+
+    const original = sound.preplay()[0];
+    await original.setPitchShift(2);
+
+    const clone = original.clone();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(clone.pitchShift).toBe(original.pitchShift);
+    expect(built).toHaveLength(2);
+    expect(inspectPlayback(clone)._pitchShiftNode).toBe(built[1]);
+    expect(inspectPlayback(clone)._pitchShiftNode).not.toBe(inspectPlayback(original)._pitchShiftNode);
+  });
 });

--- a/src/playback.test.ts
+++ b/src/playback.test.ts
@@ -252,6 +252,18 @@ describe("Playback cloning", () => {
     expect(clone.panType).toBe(originalPlayback.panType);
   });
 
+  it("copies fade configuration without sharing references", () => {
+    void originalPlayback.fadeIn(500, "exponential", { perLoop: true });
+    originalPlayback.configureFadeOut(750, "linear");
+
+    const clone = originalPlayback.clone();
+
+    expect(clone._fadeInConfig).toEqual(originalPlayback._fadeInConfig);
+    expect(clone._fadeInConfig).not.toBe(originalPlayback._fadeInConfig);
+    expect(clone._fadeOutConfig).toEqual(originalPlayback._fadeOutConfig);
+    expect(clone._fadeOutConfig).not.toBe(originalPlayback._fadeOutConfig);
+  });
+
   it("keeps a clone reachable from the destination (#100)", () => {
     const clone = originalPlayback.clone();
 

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -825,6 +825,12 @@ export class Playback extends BasePlayback implements BaseSound {
     clone.volume = this.volume;
     clone.playbackRate = this._playbackRate;
     clone._offset = this._offset;
+    if (this._fadeInConfig) {
+      clone._fadeInConfig = { ...this._fadeInConfig };
+    }
+    if (this._fadeOutConfig) {
+      clone._fadeOutConfig = { ...this._fadeOutConfig };
+    }
     if (this._state === "paused") {
       clone.markPaused();
     } else if (this._state === "stopped") {
@@ -840,6 +846,12 @@ export class Playback extends BasePlayback implements BaseSound {
       clonedFilter.gain.value = filter.gain.value;
       clone.addFilter(clonedFilter as unknown as BiquadFilterNode);
     });
+
+    if (this._pitchFactor !== 1) {
+      void clone.setPitchShift(this._pitchFactor).catch(() => {
+        /* worklet unavailable on this context — clone proceeds unshifted */
+      });
+    }
 
     // If the original is playing, start the clone
     if (this._state === "playing") {


### PR DESCRIPTION
## Summary

- copy fade-in and fade-out configuration into playback clones without sharing object references
- carry non-unity pitch shift onto clones through `setPitchShift`, creating a distinct worklet node
- add regression coverage for fade configuration and pitch worklet ownership

## Root cause

`Playback.clone()` copied ordinary playback properties and filters but omitted the fade configuration objects and pitch factor. Pitch state cannot be restored by sharing the original worklet node because each playback needs its own audio graph node.

## Impact

Cloned playbacks now retain the original playback's fade behavior and pitch shift while keeping their mutable configuration and worklet nodes independent.

## Validation

- `npm test -- src/playback.test.ts src/pitch-shift-resurrection.test.ts` (red before fix; green after fix: 68 tests)
- `npm run lint`
- type checking completed with no errors
- local full-suite/build execution was interrupted by host-wide V8 worker/process exhaustion; GitHub CI is the full-matrix merge gate

Closes #143