### PR TITLE
Respect mute in global volume changes

### DIFF
--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -196,6 +196,27 @@ describe("Cacophony core", () => {
       expect(cacophony.globalGainNode.gain.value).toBe(0.7);
     });
 
+    it("defers setGlobalVolume changes made while muted until unmuting", () => {
+      cacophony.volume = 0.8;
+      cacophony.mute();
+      const listener = vi.fn();
+      const cleanup = cacophony.on("volumeChange", listener);
+
+      cacophony.setGlobalVolume(0.5);
+
+      expect(cacophony.muted).toBe(true);
+      expect(cacophony.globalGainNode.gain.value).toBe(0);
+      expect(listener).not.toHaveBeenCalled();
+
+      cacophony.unmute();
+
+      expect(cacophony.muted).toBe(false);
+      expect(cacophony.volume).toBe(0.5);
+      expect(listener).toHaveBeenCalledOnce();
+      expect(listener).toHaveBeenCalledWith(0.5);
+      cleanup();
+    });
+
     it("mutes and unmutes correctly", () => {
       cacophony.volume = 0.8;
       expect(cacophony.muted).toBe(false);

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -1725,6 +1725,10 @@ export class Cacophony {
   }
 
   setGlobalVolume(volume: number) {
+    if (this.muted) {
+      this.prevVolume = volume;
+      return;
+    }
     if (this.globalGainNode.gain.value === volume) {
       return;
     }
@@ -1748,7 +1752,10 @@ export class Cacophony {
     if (!this.muted) {
       this.prevVolume = this.globalGainNode.gain.value;
       this.isMuted = true;
-      this.setGlobalVolume(0);
+      if (this.globalGainNode.gain.value !== 0) {
+        this.globalGainNode.gain.value = 0;
+        this.emit("volumeChange", 0);
+      }
       this.emit("mute", undefined);
     }
   }


### PR DESCRIPTION
## Summary

- defer `setGlobalVolume()` updates while Cacophony is muted
- apply the deferred global volume when unmuting
- preserve the existing mute gain and event behavior
- add regression coverage for gain, mute state, event emission, and unmute restoration

## Root cause

`setGlobalVolume()` wrote directly to the global gain node and emitted `volumeChange` without checking the explicit mute state, unlike the `volume` setter.

## Validation

- `npm test -- src/cacophony.test.ts`
- `npm run lint`
- `npm run ci:test`
- `npm run build`

Closes #141