### PR TITLE
Extract EffectChain and move playback effects pre-panner

### DIFF
--- a/src/basePlayback.ts
+++ b/src/basePlayback.ts
@@ -1,7 +1,8 @@
 import type { Bus } from "./bus";
 import type { FadeType } from "./cacophony";
 import type { PlaybackContainer } from "./container";
-import type { AudioNode, GainNode } from "./context";
+import type { AudioNode, BiquadFilterNode, GainNode } from "./context";
+import { EffectChain } from "./effectChain";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { PlaybackEvents } from "./events";
 import { FilterManager } from "./filters";
@@ -12,6 +13,7 @@ export type PlaybackState = "unplayed" | "playing" | "paused" | "stopped";
 
 export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager)) {
   public source?: AudioNode;
+  protected _effectChain?: EffectChain;
   /**
    * Per-playback send-gain allocations owned by the shared routing state
    * machine. Cleanup disconnects every allocation deterministically.
@@ -24,6 +26,69 @@ export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager
   constructor(origin: PlaybackContainer) {
     super();
     this.origin = origin;
+  }
+
+  protected setEffectChainEndpoints(input: AudioNode, output: AudioNode): void {
+    if (this._effectChain) {
+      this._effectChain.setEndpoints(input, output);
+      return;
+    }
+    this._effectChain = new EffectChain(input, output, this.constructor.name);
+  }
+
+  addFilter(filter: BiquadFilterNode): void {
+    if (!this._effectChain) {
+      throw new Error("Cannot add a filter before the playback effect chain is initialized");
+    }
+    super.addFilter(filter);
+    this._effectChain.add(filter, this._filters.length - 1);
+  }
+
+  removeFilter(filter: BiquadFilterNode): void {
+    if (!this._effectChain) {
+      throw new Error("Cannot remove a filter before the playback effect chain is initialized");
+    }
+    super.removeFilter(filter);
+    this._effectChain.remove(filter);
+  }
+
+  setFilterOrder(filters: readonly BiquadFilterNode[]): void {
+    if (!this._effectChain) {
+      throw new Error("Cannot reorder filters before the playback effect chain is initialized");
+    }
+    const isPermutation =
+      filters.length === this._filters.length &&
+      new Set(filters).size === filters.length &&
+      filters.every((filter) => this._filters.includes(filter));
+    if (!isPermutation) {
+      throw new Error("setFilterOrder requires a permutation of the current filters");
+    }
+    const nonFilters = this._effectChain.nodes.filter((node) => !this._filters.includes(node as BiquadFilterNode));
+    this._effectChain.setOrder([...filters, ...nonFilters]);
+    this._filters = [...filters];
+  }
+
+  setFilterBypassed(filter: BiquadFilterNode, bypassed: boolean): void {
+    if (!this._effectChain) {
+      throw new Error("Cannot bypass a filter before the playback effect chain is initialized");
+    }
+    this._effectChain.setBypassed(filter, bypassed);
+  }
+
+  isFilterBypassed(filter: BiquadFilterNode): boolean {
+    return this._effectChain?.isBypassed(filter) ?? false;
+  }
+
+  rampFilterParam(
+    filter: BiquadFilterNode,
+    paramName: string,
+    value: number,
+    options?: { duration?: number; type?: FadeType },
+  ): void {
+    if (!this._effectChain) {
+      throw new Error("Cannot automate a filter before the playback effect chain is initialized");
+    }
+    this._effectChain.rampParam(filter, paramName, value, options);
   }
 
   abstract play(): [this];
@@ -107,6 +172,8 @@ export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager
       }
     }
     this._sendGains.clear();
+    this._effectChain?.destroy();
+    this._effectChain = undefined;
     this.eventEmitter.removeAllListeners();
     super.cleanup();
   }

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -20,7 +20,8 @@
  */
 
 import type { FadeType } from "./cacophony";
-import type { AudioNode, AudioParam, AudioWorkletNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
+import type { AudioNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
+import { EffectChain } from "./effectChain";
 import type { BuiltEffect, CacophonyEffect } from "./effects";
 import { isBuiltEffectGraph, isCacophonyBuiltBiquad, isCacophonyEffect } from "./effects";
 
@@ -30,14 +31,6 @@ import { isBuiltEffectGraph, isCacophonyBuiltBiquad, isCacophonyEffect } from ".
  * directly to it — escape hatch for advanced wiring).
  */
 export type BusConnectionTarget = Bus | AudioNode;
-
-interface BusFilterEntry {
-  handle: AudioNode;
-  input: AudioNode;
-  output: AudioNode;
-  params?: Readonly<Record<string, AudioParam>>;
-  dispose?: () => void;
-}
 
 /**
  * Structural contract a routed source (e.g. a {@link Sound}) implements so a
@@ -75,16 +68,7 @@ export class Bus {
   readonly output: GainNode;
 
   private readonly _context: BaseContext;
-  private readonly _filterEntries: BusFilterEntry[] = [];
-  /**
-   * Filter nodes currently bypassed (skipped in the audible chain). A bypassed
-   * node stays in {@link _filterEntries} — so {@link filters} order, identity, and
-   * its live AudioParams are preserved — but {@link _desiredFilterChainEdges}
-   * builds the series chain over the NON-bypassed filters only, wiring the
-   * signal around it. Membership is by node identity.
-   */
-  private readonly _bypassedFilters = new Set<AudioNode>();
-  private readonly _filterChainEdges: Array<readonly [AudioNode, AudioNode]> = [];
+  private readonly _effectChain: EffectChain;
   private readonly _sendGains: Map<BusConnectionTarget, GainNode> = new Map();
   private readonly _directConnections: Set<BusConnectionTarget> = new Set();
   /**
@@ -125,7 +109,7 @@ export class Bus {
     this.output = context.createGain();
     this._onDestroy = onDestroy;
     this._destroyable = destroyable;
-    this._connectFilterChainEdge(this.input, this.output);
+    this._effectChain = new EffectChain(this.input, this.output, "Bus");
   }
 
   /** True after {@link destroy} has been called. */
@@ -144,7 +128,7 @@ export class Bus {
 
   /** Live filter chain (read-only view). */
   get filters(): readonly AudioNode[] {
-    return this._filterEntries.map((entry) => entry.handle);
+    return this._effectChain.nodes;
   }
 
   /**
@@ -178,13 +162,11 @@ export class Bus {
         "Bus.addFilter rejects raw AudioNodes. Wrap with cacophony.shareEffect(node) or a CacophonyEffect to make the shared-state intent explicit.",
       );
     }
-    const entry = this._normalizeBuiltEffect(built);
-    if (this._filterEntries.some((existing) => existing.handle === entry.handle)) {
+    const handle = isBuiltEffectGraph(built) ? (built.handle ?? built.input) : built;
+    if (this._effectChain.has(handle)) {
       throw new Error("Cannot add the same filter node to a bus twice");
     }
-    this._filterEntries.push(entry);
-    this._refreshFilters();
-    return entry.handle;
+    return this._effectChain.add(built);
   }
 
   /**
@@ -195,22 +177,18 @@ export class Bus {
    */
   removeFilter(node: AudioNode): void {
     this._throwIfDestroyed();
-    const idx = this._filterEntries.findIndex((entry) => entry.handle === node);
-    if (idx === -1) {
+    if (!this._effectChain.has(node)) {
       throw new Error("Cannot remove filter that was never added to this bus");
     }
-    const [entry] = this._filterEntries.splice(idx, 1);
-    this._bypassedFilters.delete(node);
-    this._refreshFilters();
-    entry?.dispose?.();
+    this._effectChain.remove(node);
   }
 
   /**
    * Reorder the existing filter chain. `nodes` must be a PERMUTATION of the
    * current filters — the same set of node objects (matched by identity), the
-   * same length, with no duplicates — just in a new order. Because
-   * {@link _refreshFilters} is incremental, only the edges that actually move
-   * are reconnected; unchanged edges are left untouched.
+   * same length, with no duplicates — just in a new order. Because the owned
+   * {@link EffectChain} reconciles incrementally, only the edges that actually
+   * move are reconnected; unchanged edges are left untouched.
    *
    * @throws if the bus has been destroyed, or if `nodes` is not a permutation
    *   of the current filters.
@@ -218,16 +196,13 @@ export class Bus {
   setFilterOrder(nodes: readonly AudioNode[]): void {
     this._throwIfDestroyed();
     const isPermutation =
-      nodes.length === this._filterEntries.length &&
+      nodes.length === this._effectChain.nodes.length &&
       new Set(nodes).size === nodes.length &&
-      nodes.every((node) => this._filterEntries.some((entry) => entry.handle === node));
+      nodes.every((node) => this._effectChain.has(node));
     if (!isPermutation) {
       throw new Error("setFilterOrder requires a permutation of the current filters");
     }
-    const ordered = nodes.map((node) => this._filterEntries.find((entry) => entry.handle === node)!);
-    this._filterEntries.length = 0;
-    this._filterEntries.push(...ordered);
-    this._refreshFilters();
+    this._effectChain.setOrder(nodes);
   }
 
   /**
@@ -237,8 +212,8 @@ export class Bus {
    * it is skipped in the audible series chain: the signal is wired around it.
    * Un-bypassing wires it back in at its original position.
    *
-   * The reconnect goes through the incremental {@link _refreshFilters}, so only
-   * the seam around `node` is touched — the rest of the chain is left connected.
+   * The reconnect goes through the incremental {@link EffectChain}, so only the
+   * seam around `node` is touched — the rest of the chain is left connected.
    *
    * @param node A filter node currently on this bus (from {@link addFilter} or
    *   {@link filters}).
@@ -249,19 +224,10 @@ export class Bus {
    */
   setFilterBypassed(node: AudioNode, bypassed: boolean): void {
     this._throwIfDestroyed();
-    if (!this._filterEntries.some((entry) => entry.handle === node)) {
+    if (!this._effectChain.has(node)) {
       throw new Error("Cannot bypass a filter that was never added to this bus");
     }
-    const alreadyBypassed = this._bypassedFilters.has(node);
-    if (bypassed === alreadyBypassed) {
-      return;
-    }
-    if (bypassed) {
-      this._bypassedFilters.add(node);
-    } else {
-      this._bypassedFilters.delete(node);
-    }
-    this._refreshFilters();
+    this._effectChain.setBypassed(node, bypassed);
   }
 
   /**
@@ -269,7 +235,7 @@ export class Bus {
    * `false` for nodes that were never added to this bus.
    */
   isFilterBypassed(node: AudioNode): boolean {
-    return this._bypassedFilters.has(node);
+    return this._effectChain.isBypassed(node);
   }
 
   /**
@@ -313,72 +279,7 @@ export class Bus {
     options?: { duration?: number; type?: FadeType },
   ): void {
     this._throwIfDestroyed();
-    const entry = this._filterEntries.find((filterEntry) => filterEntry.handle === node);
-    if (!entry) {
-      console.warn(`Bus.rampFilterParam: node is not a filter on this bus; ignoring automation of '${paramName}'.`);
-      return;
-    }
-
-    const param = entry.params?.[paramName] ?? this._resolveAudioParam(node, paramName);
-    if (!param) {
-      console.warn(`Bus.rampFilterParam: could not resolve AudioParam '${paramName}' on the given node; ignoring.`);
-      return;
-    }
-
-    const now = node.context.currentTime;
-    const duration = options?.duration;
-    if (duration === undefined || duration <= 0) {
-      param.setValueAtTime(value, now);
-      return;
-    }
-
-    const endTime = now + duration / 1000;
-    param.setValueAtTime(param.value, now);
-    if (options?.type === "exponential") {
-      param.exponentialRampToValueAtTime(value === 0 ? 0.0001 : value, endTime);
-    } else {
-      param.linearRampToValueAtTime(value, endTime);
-    }
-  }
-
-  /**
-   * Resolve the named {@link AudioParam} on a node. Tries the worklet
-   * `parameters` map first, then a directly-exposed native param
-   * (`node[paramName]`). Returns `undefined` if neither yields an AudioParam.
-   *
-   * Detection is structural (duck-typed), never `instanceof` — the mocked test
-   * context may not provide the `AudioParam` global.
-   */
-  private _resolveAudioParam(node: AudioNode, paramName: string): AudioParam | undefined {
-    const parameters = (node as AudioWorkletNode).parameters;
-    if (parameters && typeof parameters.get === "function") {
-      const workletParam = parameters.get(paramName);
-      if (this._isAudioParam(workletParam)) {
-        return workletParam;
-      }
-    }
-
-    const nativeParam = (node as unknown as Record<string, unknown>)[paramName];
-    if (this._isAudioParam(nativeParam)) {
-      return nativeParam;
-    }
-
-    return undefined;
-  }
-
-  /**
-   * Structural AudioParam check: a value is treated as an AudioParam if it
-   * exposes the ramp scheduling methods. Avoids `instanceof AudioParam` so it
-   * works under the standardized-audio-context mock (which may lack the global).
-   */
-  private _isAudioParam(value: unknown): value is AudioParam {
-    return (
-      typeof value === "object" &&
-      value !== null &&
-      typeof (value as AudioParam).setValueAtTime === "function" &&
-      typeof (value as AudioParam).linearRampToValueAtTime === "function" &&
-      typeof (value as AudioParam).exponentialRampToValueAtTime === "function"
-    );
+    this._effectChain.rampParam(node, paramName, value, options);
   }
 
   /**
@@ -544,14 +445,7 @@ export class Bus {
     // Disconnect only this bus's internal chain edges. Filter nodes may be
     // shared with other buses, so broad node.disconnect() would steal their
     // routes.
-    this._disconnectFilterChainEdges();
-    for (const entry of this._filterEntries) {
-      try {
-        entry.dispose?.();
-      } catch {}
-    }
-    this._filterEntries.length = 0;
-    this._bypassedFilters.clear();
+    this._effectChain.destroy();
     try {
       this.input.disconnect();
     } catch {}
@@ -559,97 +453,6 @@ export class Bus {
       this.output.disconnect();
     } catch {}
     this._onDestroy?.();
-  }
-
-  /**
-   * Reconcile the live chain to `input → [filter1 → ... → filterN] → output`.
-   * Called after any add/remove/reorder of a filter. This is an INCREMENTAL
-   * diff, not a full rebuild: it disconnects only edges that are no longer part
-   * of the desired chain and connects only edges that are newly required,
-   * leaving edges present in both the old and new chain connected and
-   * untouched (no audible click on the unchanged portion of the chain).
-   *
-   * Edges are matched by OBJECT IDENTITY on both endpoints. Only this bus's own
-   * internal `input → ... → output` edges are touched — never a broad
-   * `node.disconnect()`, never the outbound send/direct edges.
-   */
-  private _refreshFilters(): void {
-    const desired = this._desiredFilterChainEdges();
-    // Disconnect every currently-recorded edge that is not in the desired set.
-    for (const [source, destination] of this._filterChainEdges) {
-      const stillPresent = desired.some(([s, d]) => s === source && d === destination);
-      if (!stillPresent) {
-        try {
-          source.disconnect(destination);
-        } catch {}
-      }
-    }
-    // Connect every desired edge that is not already recorded.
-    for (const [source, destination] of desired) {
-      const alreadyConnected = this._filterChainEdges.some(([s, d]) => s === source && d === destination);
-      if (!alreadyConnected) {
-        source.connect(destination);
-      }
-    }
-    // Record the new chain as exactly the desired edge list.
-    this._filterChainEdges.length = 0;
-    this._filterChainEdges.push(...desired);
-  }
-
-  /**
-   * Compute the desired ordered chain edge list from the current
-   * `_filterEntries`, skipping any node in {@link _bypassedFilters}: the series
-   * chain is built over the NON-bypassed filters only. With no active (non-
-   * bypassed) filters — whether the bus has no filters at all or every filter is
-   * bypassed — the desired list is `[[input, output]]` (the direct edge);
-   * otherwise `[[input, a1], [a1, a2], ..., [aN, output]]` over the active
-   * filters `a1..aN`. Bypassed nodes stay in {@link _filterEntries} (and thus in
-   * {@link filters}) but receive no inbound/outbound chain edge.
-   */
-  private _desiredFilterChainEdges(): Array<readonly [AudioNode, AudioNode]> {
-    const active = this._filterEntries.filter((entry) => !this._bypassedFilters.has(entry.handle));
-    if (active.length === 0) {
-      return [[this.input, this.output]];
-    }
-    const edges: Array<readonly [AudioNode, AudioNode]> = [];
-    let prev: AudioNode = this.input;
-    for (const entry of active) {
-      edges.push([prev, entry.input]);
-      prev = entry.output;
-    }
-    edges.push([prev, this.output]);
-    return edges;
-  }
-
-  private _normalizeBuiltEffect(built: BuiltEffect): BusFilterEntry {
-    if (isBuiltEffectGraph(built)) {
-      return {
-        handle: built.handle ?? built.input,
-        input: built.input,
-        output: built.output,
-        params: built.params,
-        dispose: built.dispose,
-      };
-    }
-    return {
-      handle: built,
-      input: built,
-      output: built,
-    };
-  }
-
-  private _connectFilterChainEdge(source: AudioNode, destination: AudioNode): void {
-    source.connect(destination);
-    this._filterChainEdges.push([source, destination]);
-  }
-
-  private _disconnectFilterChainEdges(): void {
-    for (const [source, destination] of this._filterChainEdges) {
-      try {
-        source.disconnect(destination);
-      } catch {}
-    }
-    this._filterChainEdges.length = 0;
   }
 
   private _throwIfDestroyed(): void {

--- a/src/effectChain.test.ts
+++ b/src/effectChain.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+import { EffectChain } from "./effectChain";
+import { cacophony, expectNotReachable, expectPath } from "./setupTests";
+
+describe("EffectChain", () => {
+  it("reconciles built effect endpoints between caller-owned nodes", () => {
+    const input = cacophony.context.createGain();
+    const output = cacophony.context.createGain();
+    const graphInput = cacophony.context.createGain();
+    const graphOutput = cacophony.context.createGain();
+    const handle = cacophony.context.createGain();
+    graphInput.connect(graphOutput);
+    const chain = new EffectChain(input, output);
+
+    expectPath(input, [], output);
+
+    expect(chain.add({ input: graphInput, output: graphOutput, handle })).toBe(handle);
+
+    expect(chain.nodes).toEqual([handle]);
+    expectPath(input, [graphInput, graphOutput], output);
+  });
+
+  it("reorders and bypasses entries through the incremental chain machine", () => {
+    const input = cacophony.context.createGain();
+    const output = cacophony.context.createGain();
+    const first = cacophony.context.createGain();
+    const second = cacophony.context.createGain();
+    const chain = new EffectChain(input, output);
+
+    chain.add(first);
+    chain.add(second);
+    chain.setOrder([second, first]);
+
+    expect(chain.nodes).toEqual([second, first]);
+    expectPath(input, [second, first], output);
+
+    chain.setBypassed(second, true);
+
+    expect(chain.isBypassed(second)).toBe(true);
+    expectPath(input, [first], output);
+    expectNotReachable(input, second);
+  });
+
+  it("removes the entry before disposing its owned graph", () => {
+    const input = cacophony.context.createGain();
+    const output = cacophony.context.createGain();
+    const graphInput = cacophony.context.createGain();
+    const graphOutput = cacophony.context.createGain();
+    const dispose = vi.fn();
+    const chain = new EffectChain(input, output);
+    const handle = chain.add({ input: graphInput, output: graphOutput, dispose });
+
+    chain.remove(handle);
+
+    expect(chain.nodes).toEqual([]);
+    expectPath(input, [], output);
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/src/effectChain.ts
+++ b/src/effectChain.ts
@@ -36,12 +36,22 @@ export class EffectChain {
     return this.entries.some((entry) => entry.handle === node);
   }
 
-  add(built: BuiltEffect): AudioNode {
+  setEndpoints(input: AudioNode, output: AudioNode): void {
+    if (input === this.input && output === this.output) {
+      return;
+    }
+    this.disconnectEdges();
+    this.input = input;
+    this.output = output;
+    this.refresh();
+  }
+
+  add(built: BuiltEffect, index = this.entries.length): AudioNode {
     const entry = this.normalize(built);
     if (this.has(entry.handle)) {
       throw new Error("Cannot add the same effect node to a chain twice");
     }
-    this.entries.push(entry);
+    this.entries.splice(index, 0, entry);
     this.refresh();
     return entry.handle;
   }

--- a/src/effectChain.ts
+++ b/src/effectChain.ts
@@ -1,0 +1,234 @@
+import type { FadeType } from "./cacophony";
+import type { AudioNode, AudioParam, AudioWorkletNode } from "./context";
+import type { BuiltEffect } from "./effects";
+import { isBuiltEffectGraph } from "./effects";
+
+interface EffectChainEntry {
+  handle: AudioNode;
+  input: AudioNode;
+  output: AudioNode;
+  params?: Readonly<Record<string, AudioParam>>;
+  dispose?: () => void;
+}
+
+/**
+ * Incrementally reconciles a series of built effects between two caller-owned
+ * endpoint nodes.
+ */
+export class EffectChain {
+  private readonly entries: EffectChainEntry[] = [];
+  private readonly bypassed = new Set<AudioNode>();
+  private readonly edges: Array<readonly [AudioNode, AudioNode]> = [];
+
+  constructor(
+    private input: AudioNode,
+    private output: AudioNode,
+    private readonly diagnosticScope = "EffectChain",
+  ) {
+    this.connectEdge(input, output);
+  }
+
+  get nodes(): readonly AudioNode[] {
+    return this.entries.map((entry) => entry.handle);
+  }
+
+  has(node: AudioNode): boolean {
+    return this.entries.some((entry) => entry.handle === node);
+  }
+
+  add(built: BuiltEffect): AudioNode {
+    const entry = this.normalize(built);
+    if (this.has(entry.handle)) {
+      throw new Error("Cannot add the same effect node to a chain twice");
+    }
+    this.entries.push(entry);
+    this.refresh();
+    return entry.handle;
+  }
+
+  remove(node: AudioNode): void {
+    const index = this.entries.findIndex((entry) => entry.handle === node);
+    if (index === -1) {
+      throw new Error("Cannot remove an effect that was never added to this chain");
+    }
+    const [entry] = this.entries.splice(index, 1);
+    this.bypassed.delete(node);
+    this.refresh();
+    entry?.dispose?.();
+  }
+
+  setOrder(nodes: readonly AudioNode[]): void {
+    const isPermutation =
+      nodes.length === this.entries.length &&
+      new Set(nodes).size === nodes.length &&
+      nodes.every((node) => this.has(node));
+    if (!isPermutation) {
+      throw new Error("Effect chain order must be a permutation of the current nodes");
+    }
+    const ordered = nodes.map((node) => this.entries.find((entry) => entry.handle === node)!);
+    this.entries.length = 0;
+    this.entries.push(...ordered);
+    this.refresh();
+  }
+
+  setBypassed(node: AudioNode, bypassed: boolean): void {
+    if (!this.has(node)) {
+      throw new Error("Cannot bypass an effect that was never added to this chain");
+    }
+    const alreadyBypassed = this.bypassed.has(node);
+    if (bypassed === alreadyBypassed) {
+      return;
+    }
+    if (bypassed) {
+      this.bypassed.add(node);
+    } else {
+      this.bypassed.delete(node);
+    }
+    this.refresh();
+  }
+
+  isBypassed(node: AudioNode): boolean {
+    return this.bypassed.has(node);
+  }
+
+  rampParam(node: AudioNode, paramName: string, value: number, options?: { duration?: number; type?: FadeType }): void {
+    const entry = this.entries.find((candidate) => candidate.handle === node);
+    if (!entry) {
+      console.warn(
+        `${this.diagnosticScope}.rampFilterParam: node is not a filter on this ${this.diagnosticScope.toLowerCase()}; ignoring automation of '${paramName}'.`,
+      );
+      return;
+    }
+
+    const param = entry.params?.[paramName] ?? this.resolveAudioParam(node, paramName);
+    if (!param) {
+      console.warn(
+        `${this.diagnosticScope}.rampFilterParam: could not resolve AudioParam '${paramName}' on the given node; ignoring.`,
+      );
+      return;
+    }
+
+    const now = node.context.currentTime;
+    const duration = options?.duration;
+    if (duration === undefined || duration <= 0) {
+      param.setValueAtTime(value, now);
+      return;
+    }
+
+    const endTime = now + duration / 1000;
+    param.setValueAtTime(param.value, now);
+    if (options?.type === "exponential") {
+      param.exponentialRampToValueAtTime(value === 0 ? 0.0001 : value, endTime);
+    } else {
+      param.linearRampToValueAtTime(value, endTime);
+    }
+  }
+
+  destroy(): void {
+    this.disconnectEdges();
+    for (const entry of this.entries) {
+      try {
+        entry.dispose?.();
+      } catch {}
+    }
+    this.entries.length = 0;
+    this.bypassed.clear();
+  }
+
+  private refresh(): void {
+    const desired = this.desiredEdges();
+    for (const [source, destination] of this.edges) {
+      const stillPresent = desired.some(([desiredSource, desiredDestination]) => {
+        return desiredSource === source && desiredDestination === destination;
+      });
+      if (!stillPresent) {
+        try {
+          source.disconnect(destination);
+        } catch {}
+      }
+    }
+    for (const [source, destination] of desired) {
+      const alreadyConnected = this.edges.some(([currentSource, currentDestination]) => {
+        return currentSource === source && currentDestination === destination;
+      });
+      if (!alreadyConnected) {
+        source.connect(destination);
+      }
+    }
+    this.edges.length = 0;
+    this.edges.push(...desired);
+  }
+
+  private desiredEdges(): Array<readonly [AudioNode, AudioNode]> {
+    const active = this.entries.filter((entry) => !this.bypassed.has(entry.handle));
+    if (active.length === 0) {
+      return [[this.input, this.output]];
+    }
+    const desired: Array<readonly [AudioNode, AudioNode]> = [];
+    let previous = this.input;
+    for (const entry of active) {
+      desired.push([previous, entry.input]);
+      previous = entry.output;
+    }
+    desired.push([previous, this.output]);
+    return desired;
+  }
+
+  private normalize(built: BuiltEffect): EffectChainEntry {
+    if (isBuiltEffectGraph(built)) {
+      return {
+        handle: built.handle ?? built.input,
+        input: built.input,
+        output: built.output,
+        params: built.params,
+        dispose: built.dispose,
+      };
+    }
+    return {
+      handle: built,
+      input: built,
+      output: built,
+    };
+  }
+
+  private resolveAudioParam(node: AudioNode, paramName: string): AudioParam | undefined {
+    const parameters = (node as AudioWorkletNode).parameters;
+    if (parameters && typeof parameters.get === "function") {
+      const workletParam = parameters.get(paramName);
+      if (this.isAudioParam(workletParam)) {
+        return workletParam;
+      }
+    }
+
+    const nativeParam = (node as unknown as Record<string, unknown>)[paramName];
+    if (this.isAudioParam(nativeParam)) {
+      return nativeParam;
+    }
+
+    return undefined;
+  }
+
+  private isAudioParam(value: unknown): value is AudioParam {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      typeof (value as AudioParam).setValueAtTime === "function" &&
+      typeof (value as AudioParam).linearRampToValueAtTime === "function" &&
+      typeof (value as AudioParam).exponentialRampToValueAtTime === "function"
+    );
+  }
+
+  private connectEdge(source: AudioNode, destination: AudioNode): void {
+    source.connect(destination);
+    this.edges.push([source, destination]);
+  }
+
+  private disconnectEdges(): void {
+    for (const [source, destination] of this.edges) {
+      try {
+        source.disconnect(destination);
+      } catch {}
+    }
+    this.edges.length = 0;
+  }
+}

--- a/src/mediaStream.test.ts
+++ b/src/mediaStream.test.ts
@@ -60,6 +60,7 @@ describe("MediaStreamSound", () => {
 
   it("creates one reusable playback for a live MediaStream", () => {
     const sound = new MediaStreamSound(stream, context, globalGainNode);
+    sound.addFilter(context.createBiquadFilter());
 
     const firstPlay = sound.play();
     const secondPlay = sound.play();
@@ -69,7 +70,11 @@ describe("MediaStreamSound", () => {
     expect(secondPlay[0]).toBe(firstPlay[0]);
     expect(context.createMediaStreamSource).toHaveBeenCalledTimes(1);
     expect(sound.isPlaying).toBe(true);
-    expectPath(source, [firstPlay[0].panner!, firstPlay[0].outputNode, globalGainNode], destination);
+    expectPath(
+      source,
+      [firstPlay[0].filters[0], firstPlay[0].panner!, firstPlay[0].outputNode, globalGainNode],
+      destination,
+    );
   });
 
   it("applies volume and HRTF position to the live playback", () => {

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -56,10 +56,9 @@ export class MediaStreamPlayback extends BasePlayback {
     this.source = source;
     this.setPanType(panType, context);
     this.setGainNode(gainNode);
-    this.source.connect(this.panner!);
+    this.setEffectChainEndpoints(this.source, this.panner!);
     this.panner!.connect(this.gainNode!);
     this.gainNode!.connect(outputNode);
-    this.refreshFilters();
     if (primeWithMediaElement) {
       this.createPrimeElement();
     }
@@ -170,7 +169,6 @@ export class MediaStreamPlayback extends BasePlayback {
       throw new Error("Cannot add a filter to a media stream that has been cleaned up");
     }
     super.addFilter(filter);
-    this.refreshFilters();
   }
 
   removeFilter(filter: BiquadFilterNode): void {
@@ -178,17 +176,6 @@ export class MediaStreamPlayback extends BasePlayback {
       throw new Error("Cannot remove a filter from a media stream that has been cleaned up");
     }
     super.removeFilter(filter);
-    this.refreshFilters();
-  }
-
-  private refreshFilters(): void {
-    if (!this.panner || !this.gainNode) {
-      throw new Error("Cannot update filters on a media stream that has been cleaned up");
-    }
-    let connection: AudioNode = this.panner;
-    connection.disconnect();
-    connection = this.applyFilters(connection);
-    connection.connect(this.gainNode);
   }
 
   get outputNode(): GainNode {

--- a/src/pcmStream.test.ts
+++ b/src/pcmStream.test.ts
@@ -68,7 +68,7 @@ describe("PcmStreamSound", () => {
     expect(playback.volume).toBe(0.25);
     expect(playback.stereoPan).toBe(-0.5);
     expect(playback.filters).toHaveLength(1);
-    expectPath(playback.source!, [playback.panner!, playback.filters[0], playback.outputNode], bus.input);
+    expectPath(playback.source!, [playback.filters[0], playback.panner!, playback.outputNode], bus.input);
     expectReachable(playback.source!, bus.output);
     expectNotReachable(playback.outputNode, cacophony.master.input);
   });

--- a/src/pcmStream.ts
+++ b/src/pcmStream.ts
@@ -58,10 +58,9 @@ export class PcmStreamPlayback extends BasePlayback {
     this.source = source;
     this.setPanType(panType, context);
     this.setGainNode(gainNode);
-    this.source.connect(this.panner!);
+    this.setEffectChainEndpoints(this.source, this.panner!);
     this.panner!.connect(this.gainNode!);
     this.gainNode!.connect(outputNode);
-    this.refreshFilters();
   }
 
   get duration(): number {
@@ -133,7 +132,6 @@ export class PcmStreamPlayback extends BasePlayback {
       throw new Error("Cannot add a filter to a PCM stream that has been cleaned up");
     }
     super.addFilter(filter);
-    this.refreshFilters();
   }
 
   removeFilter(filter: BiquadFilterNode): void {
@@ -141,17 +139,6 @@ export class PcmStreamPlayback extends BasePlayback {
       throw new Error("Cannot remove a filter from a PCM stream that has been cleaned up");
     }
     super.removeFilter(filter);
-    this.refreshFilters();
-  }
-
-  private refreshFilters(): void {
-    if (!this.panner || !this.gainNode) {
-      throw new Error("Cannot update filters on a PCM stream that has been cleaned up");
-    }
-    let connection: AudioNode = this.panner;
-    connection.disconnect();
-    connection = this.applyFilters(connection);
-    connection.connect(this.gainNode);
   }
 
   get outputNode(): GainNode {

--- a/src/pitch-shift-resurrection.test.ts
+++ b/src/pitch-shift-resurrection.test.ts
@@ -1,7 +1,7 @@
 import { AudioBuffer } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { audioContextMock, cacophony } from "./setupTests";
+import { audioContextMock, cacophony, expectPath } from "./setupTests";
 import type { Sound } from "./sound";
 import { WORKLETS } from "./worklets";
 
@@ -21,7 +21,7 @@ import { WORKLETS } from "./worklets";
 type PlaybackInternals = {
   context: unknown;
   panner: { connect: ReturnType<typeof vi.fn> };
-  _pitchShiftNode?: ReturnType<typeof makeFakePvNode>;
+  _effectChain: { nodes: readonly unknown[] };
 };
 
 const inspectPlayback = (playback: unknown): PlaybackInternals => playback as PlaybackInternals;
@@ -86,7 +86,7 @@ describe("phase-vocoder resurrection: pitch-shift wires the dead worklet into th
     expect(playback.pitchShift).toBe(2);
   });
 
-  it("splices the phase-vocoder node into the graph: filterTail/panner → pvNode → gainNode", async () => {
+  it("adds the phase-vocoder as a pre-panner chain entry", async () => {
     sound = await cacophony.createSound(buffer);
     const fakeNode = makeFakePvNode();
     vi.spyOn(cacophony, "buildWorkletEffect").mockResolvedValue(
@@ -94,16 +94,10 @@ describe("phase-vocoder resurrection: pitch-shift wires the dead worklet into th
     );
 
     const playback = sound.preplay()[0];
-    // With no filters, the panner is the chain tail feeding the pitch node.
-    const panner = inspectPlayback(playback).panner;
-    const pannerConnectSpy = vi.spyOn(panner, "connect");
-
     await playback.setPitchShift(1.5);
 
-    // panner now connects INTO the phase-vocoder node (not straight to gainNode).
-    expect(pannerConnectSpy).toHaveBeenCalledWith(fakeNode);
-    // and the phase-vocoder node connects OUT to the playback's gainNode.
-    expect(fakeNode.connect).toHaveBeenCalledWith(playback.outputNode);
+    expect(inspectPlayback(playback)._effectChain.nodes).toContain(fakeNode);
+    expectPath(playback.source!, [fakeNode, playback.panner!], playback.outputNode);
   });
 
   it("forwards the pitch factor to the node's pitchFactor AudioParam", async () => {
@@ -124,7 +118,7 @@ describe("phase-vocoder resurrection: pitch-shift wires the dead worklet into th
     expect(fakeNode._pitchParam.value).toBe(2);
   });
 
-  it("the pitch node survives a later refreshFilters rebuild (never bypassed)", async () => {
+  it("keeps the pitch node after a later filter insertion", async () => {
     sound = await cacophony.createSound(buffer);
     const fakeNode = makeFakePvNode();
     vi.spyOn(cacophony, "buildWorkletEffect").mockResolvedValue(
@@ -133,14 +127,14 @@ describe("phase-vocoder resurrection: pitch-shift wires the dead worklet into th
 
     const playback = sound.preplay()[0];
     await playback.setPitchShift(1.5);
-    fakeNode.connect.mockClear();
+    const pitchConnectCount = fakeNode.connect.mock.calls.length;
 
-    // Adding a filter triggers refreshFilters — the pitch node must be re-inserted.
     const filter = audioContextMock.createBiquadFilter();
     playback.addFilter(filter as unknown as Parameters<typeof playback.addFilter>[0]);
 
-    // pitch node still connects out to gainNode after the rebuild.
-    expect(fakeNode.connect).toHaveBeenCalledWith(playback.outputNode);
+    expect(inspectPlayback(playback)._effectChain.nodes).toContain(fakeNode);
+    expectPath(playback.source!, [filter, fakeNode, playback.panner!], playback.outputNode);
+    expect(fakeNode.connect).toHaveBeenCalledTimes(pitchConnectCount);
   });
 
   it("setPitchShift(1) tears the phase-vocoder node out and bypasses it (true passthrough)", async () => {
@@ -148,7 +142,7 @@ describe("phase-vocoder resurrection: pitch-shift wires the dead worklet into th
     // The peak/region pipeline does NOT guarantee identity for peakless/broadband
     // content, so factor 1 must remove the node from the graph, not just set the
     // param. We assert the node is disconnected, dropped, and the chain rebuilt
-    // so the panner feeds the gainNode directly (no pv node in between).
+    // so the source feeds the panner directly (no pv node in between).
     sound = await cacophony.createSound(buffer);
     const fakeNode = makeFakePvNode();
     vi.spyOn(cacophony, "buildWorkletEffect").mockResolvedValue(
@@ -157,21 +151,17 @@ describe("phase-vocoder resurrection: pitch-shift wires the dead worklet into th
 
     const playback = sound.preplay()[0];
     await playback.setPitchShift(1.5);
-    expect(inspectPlayback(playback)._pitchShiftNode).toBe(fakeNode); // node spliced in
+    expect(inspectPlayback(playback)._effectChain.nodes).toContain(fakeNode);
 
-    const panner = inspectPlayback(playback).panner;
-    const pannerConnectSpy = vi.spyOn(panner, "connect");
     fakeNode.disconnect.mockClear();
 
     await playback.setPitchShift(1);
 
     // node disconnected and dropped (genuine bypass, not param=1 with node live).
     expect(fakeNode.disconnect).toHaveBeenCalled();
-    expect(inspectPlayback(playback)._pitchShiftNode).toBeUndefined();
+    expect(inspectPlayback(playback)._effectChain.nodes).not.toContain(fakeNode);
     expect(playback.pitchShift).toBe(1);
-    // chain rebuilt so panner now feeds the gainNode directly, NOT the pv node.
-    expect(pannerConnectSpy).toHaveBeenCalledWith(playback.outputNode);
-    expect(pannerConnectSpy).not.toHaveBeenCalledWith(fakeNode);
+    expectPath(playback.source!, [playback.panner!], playback.outputNode);
   });
 
   it("Sound.setPitchShift rejects invalid factors (0/NaN/negative) WITHOUT storing them", async () => {
@@ -246,7 +236,7 @@ describe("phase-vocoder resurrection: pitch-shift wires the dead worklet into th
 
     expect(clone.pitchShift).toBe(original.pitchShift);
     expect(built).toHaveLength(2);
-    expect(inspectPlayback(clone)._pitchShiftNode).toBe(built[1]);
-    expect(inspectPlayback(clone)._pitchShiftNode).not.toBe(inspectPlayback(original)._pitchShiftNode);
+    expect(inspectPlayback(clone)._effectChain.nodes).toContain(built[1]);
+    expect(inspectPlayback(clone)._effectChain.nodes).not.toContain(built[0]);
   });
 });

--- a/src/playback.test.ts
+++ b/src/playback.test.ts
@@ -68,7 +68,7 @@ describe("Playback class", () => {
 
     playback.setPanType("stereo", audioContextMock);
 
-    expectPath(source, [playback.panner!, filter, gainNode], destination);
+    expectPath(source, [filter, playback.panner!, gainNode], destination);
     expectNotReachable(source, oldPanner);
     expect(graphSnapshot(oldPanner).edges).toEqual([]);
   });
@@ -324,7 +324,7 @@ describe("Playback cloning", () => {
   it("keeps a clone wired when overriding its pan type (#101)", () => {
     const clone = originalPlayback.clone({ panType: "stereo" });
 
-    expectPath(clone.source!, [clone.panner!, clone._filters[0]!, clone.gainNode!], gainNode);
+    expectPath(clone.source!, [clone._filters[0]!, clone.panner!, clone.gainNode!], gainNode);
     expectReachable(clone.source!, destination);
   });
 
@@ -443,6 +443,13 @@ describe("Playback cloning for media-element-backed playback", () => {
     expect((clone.source as any).mediaElement).toBe(clonedMediaElement);
     expect((originalPlayback.source as any).mediaElement).toBe(originalMediaElement);
   });
+
+  it("wires media-element playback filters before the panner", () => {
+    const filter = audioContextMock.createBiquadFilter();
+    originalPlayback.addFilter(filter);
+
+    expectPath(originalPlayback.source!, [filter, originalPlayback.panner!], gainNode);
+  });
 });
 
 describe("Playback cleanup functionality", () => {
@@ -550,20 +557,30 @@ describe("Playback filters chain", () => {
     const filter1 = audioContextMock.createBiquadFilter();
     const filter2 = audioContextMock.createBiquadFilter();
 
-    // Spy on refreshFilters method
-    const refreshSpy = vi.spyOn(playback as any, "refreshFilters");
-
     playback.addFilter(filter1);
     playback.addFilter(filter2);
 
-    // Verify refreshFilters was called for each filter addition
-    expect(refreshSpy).toHaveBeenCalledTimes(2);
-
-    // Verify filters are in the correct order in the array
     expect(playback._filters.length).toBe(2);
     expect(playback._filters[0].type).toBe(filter1.type);
     expect(playback._filters[1].type).toBe(filter2.type);
-    expectPath(source, [playback.panner!, filter1, filter2, gainNode], destination);
+    expectPath(source, [filter1, filter2, playback.panner!, gainNode], destination);
+  });
+
+  it("inherits reorder, bypass, and parameter automation from the effect chain", () => {
+    const filter1 = audioContextMock.createBiquadFilter();
+    const filter2 = audioContextMock.createBiquadFilter();
+    playback.addFilter(filter1);
+    playback.addFilter(filter2);
+
+    playback.setFilterOrder([filter2, filter1]);
+    playback.setFilterBypassed(filter2, true);
+    const setValueAtTime = vi.spyOn(filter1.frequency, "setValueAtTime");
+    playback.rampFilterParam(filter1, "frequency", 800);
+
+    expect(playback.filters).toEqual([filter2, filter1]);
+    expect(playback.isFilterBypassed(filter2)).toBe(true);
+    expectPath(source, [filter1, playback.panner!, gainNode], destination);
+    expect(setValueAtTime).toHaveBeenCalledWith(800, filter1.context.currentTime);
   });
 });
 

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -65,16 +65,6 @@ export class Playback extends BasePlayback implements BaseSound {
    */
   private _pitchFactor: number = 1;
   /**
-   * The phase-vocoder AudioWorkletNode (Laroche & Dolson 1999 peak-based
-   * pitch-shift with Identity Phase-Locking) spliced into this playback's chain
-   * between the filter tail and {@link gainNode}. `undefined` until
-   * {@link setPitchShift} is first called with a factor != 1; lazily built via
-   * `cacophony.createPhaseVocoderNode`. {@link refreshFilters} re-inserts it on
-   * every chain rebuild so it is never bypassed.
-   */
-  private _pitchShiftNode?: AudioWorkletNode;
-
-  /**
    * Creates an instance of the Playback class.
    * @throws {Error} Throws an error if an invalid pan type is provided.
    */
@@ -93,10 +83,9 @@ export class Playback extends BasePlayback implements BaseSound {
       this.buffer = source.buffer;
     }
     this.setupSourceNode(source);
-    this.source.connect(this.panner!);
     this.setGainNode(gainNode);
+    this.setEffectChainEndpoints(this.source, this.panner!);
     this.panner!.connect(this.gainNode!);
-    this.refreshFilters();
   }
 
   override setPanType(panType: PanType, audioContext: BaseContext): void {
@@ -107,9 +96,8 @@ export class Playback extends BasePlayback implements BaseSound {
       return;
     }
 
-    this.source.disconnect();
-    this.source.connect(this.panner);
-    this.refreshFilters();
+    this.setEffectChainEndpoints(this.source, this.panner);
+    this.panner.connect(this.gainNode);
   }
 
   private setupSourceNode(source: SourceNode) {
@@ -516,10 +504,9 @@ export class Playback extends BasePlayback implements BaseSound {
       }
       this.source = this.context.createBufferSource();
       this.source.buffer = this.buffer;
-      this.source.connect(this.panner);
+      this.setEffectChainEndpoints(this.source, this.panner);
       this.source.onended = this.loopEnded;
       this.playbackRate = this._playbackRate;
-      this.refreshFilters();
     } catch (error) {
       this.emitAsync("error", {
         error: error as Error,
@@ -570,15 +557,6 @@ export class Playback extends BasePlayback implements BaseSound {
     this.currentLoop = 0;
     this.source.disconnect();
     this.source = undefined;
-    // Tear down the phase-vocoder pitch-shift worklet node if one was spliced in.
-    if (this._pitchShiftNode) {
-      try {
-        this._pitchShiftNode.disconnect();
-      } catch {
-        // Best-effort — node may already have been disconnected externally.
-      }
-      this._pitchShiftNode = undefined;
-    }
     super.cleanup();
   }
 
@@ -591,13 +569,11 @@ export class Playback extends BasePlayback implements BaseSound {
   addFilter(filter: BiquadFilterNode): void {
     this.assertNotCleanedUp();
     super.addFilter(filter);
-    this.refreshFilters();
   }
 
   removeFilter(filter: BiquadFilterNode): void {
     this.assertNotCleanedUp();
     super.removeFilter(filter);
-    this.refreshFilters();
   }
 
   /**
@@ -631,42 +607,16 @@ export class Playback extends BasePlayback implements BaseSound {
   }
 
   /**
-   * Refreshes the audio filters by re-applying them to the audio signal chain.
-   * This method is called internally whenever filters are added or removed.
-   * @throws {Error} Throws an error if the sound has been cleaned up.
-   */
-
-  private refreshFilters(): void {
-    if (!this.panner || !this.gainNode) {
-      throw new Error("Cannot update filters on a sound that has been cleaned up");
-    }
-    let connection: AudioNode = this.panner;
-    connection.disconnect();
-    connection = this.applyFilters(connection);
-    // Splice the phase-vocoder pitch-shift worklet (if active) AFTER the filter
-    // chain and BEFORE the gainNode, so the rebuilt chain is
-    // panner → [filters] → pitchShiftNode → gainNode. Re-inserted on every
-    // rebuild so it is never bypassed when filters change. (Laroche & Dolson
-    // 1999 peak-based pitch shift — see Playback.setPitchShift.)
-    if (this._pitchShiftNode) {
-      this._pitchShiftNode.disconnect();
-      connection.connect(this._pitchShiftNode);
-      connection = this._pitchShiftNode;
-    }
-    connection.connect(this.gainNode);
-  }
-
-  /**
    * Sets the pitch-shift factor for this playback, resurrecting the dormant
    * phase-vocoder worklet (Jean Laroche & Mark Dolson, "New Phase-Vocoder
    * Techniques for Pitch-Shifting, Harmonizing and Other Exotic Effects",
    * 1999 IEEE WASPAA — peak-based pitch shift with Identity Phase-Locking).
    *
-   * On first use (factor !== 1) the phase-vocoder AudioWorkletNode is built via
-   * `cacophony.createPhaseVocoderNode` and spliced into this playback's graph at
-   * the {@link refreshFilters} seam (panner → [filters] → pitchShiftNode →
-   * gainNode). The factor is forwarded to the node's `pitchFactor` AudioParam
-   * (1 = no shift, 2 = +1 octave, 0.5 = -1 octave).
+   * On first use (factor !== 1) the phase-vocoder AudioWorkletNode is built and
+   * added as an ordinary entry at the tail of the pre-panner effect chain:
+   * source → [filters] → phase vocoder → panner → gainNode. The factor is
+   * forwarded to the node's `pitchFactor` AudioParam (1 = no shift, 2 = +1
+   * octave, 0.5 = -1 octave).
    *
    * @param factor Pitch multiplier (> 0).
    * @throws {Error} if the playback has been cleaned up or factor <= 0.
@@ -677,38 +627,39 @@ export class Playback extends BasePlayback implements BaseSound {
       throw new Error("Pitch-shift factor must be greater than 0");
     }
     this._pitchFactor = factor;
+    const effectChain = this._effectChain;
+    if (!effectChain) {
+      throw new Error("Cannot pitch-shift a playback before its effect chain is initialized");
+    }
+    let pitchShiftNode = effectChain.nodes.find((node) => {
+      const parameters = (node as AudioWorkletNode).parameters;
+      return parameters && typeof parameters.get === "function" && parameters.get("pitchFactor") !== undefined;
+    }) as AudioWorkletNode | undefined;
 
     // factor === 1 is the documented "no shift" contract and MUST be a genuine
     // passthrough. The peak/region phase-vocoder pipeline does NOT guarantee
     // identity for peakless / edge-bin / broadband content (it zero-fills and
     // only repopulates detected peak regions), so we cannot leave the node in
-    // the chain at factor 1. Tear it down and rebuild the chain so the signal
-    // bypasses the worklet entirely (panner → [filters] → gainNode). A later
+    // the chain at factor 1. Remove its ordinary chain entry so the signal
+    // bypasses the worklet entirely (source → [filters] → panner). A later
     // non-unity factor rebuilds a fresh node.
     if (factor === 1) {
-      if (this._pitchShiftNode) {
-        try {
-          this._pitchShiftNode.disconnect();
-        } catch {
-          // Best-effort — node may already have been disconnected.
-        }
-        this._pitchShiftNode = undefined;
-        this.refreshFilters();
+      if (pitchShiftNode) {
+        effectChain.remove(pitchShiftNode);
       }
       return;
     }
 
-    if (!this._pitchShiftNode) {
+    if (!pitchShiftNode) {
       const cacophony = this.origin.cacophony;
       if (!cacophony) {
         throw new Error("Cannot pitch-shift a playback whose Sound has no Cacophony instance");
       }
-      this._pitchShiftNode = await cacophony.buildWorkletEffect(WORKLETS.phaseVocoder, {}, this.context);
-      // Insert the freshly built node into the live chain.
-      this.refreshFilters();
+      pitchShiftNode = await cacophony.buildWorkletEffect(WORKLETS.phaseVocoder, {}, this.context);
+      effectChain.add(pitchShiftNode);
     }
 
-    const pitchParam = this._pitchShiftNode.parameters?.get("pitchFactor");
+    const pitchParam = pitchShiftNode.parameters?.get("pitchFactor");
     if (pitchParam) {
       pitchParam.value = factor;
     }

--- a/src/synth.test.ts
+++ b/src/synth.test.ts
@@ -170,14 +170,14 @@ describe("Synth class", () => {
     expect(playbacks[0].filters[0].frequency.value).toBe(filter.frequency.value);
   });
 
-  it.skip("wires cloned filters into the synth playback path (#41)", () => {
+  it("wires cloned filters before the synth playback panner", () => {
     const filter = audioContextMock.createBiquadFilter();
     synth.addFilter(filter);
     const [playback] = synth.preplay();
 
     expectPath(
       playback.source!,
-      [playback.panner!, playback.filters[0], playback.outputNode, masterInput],
+      [playback.filters[0], playback.panner!, playback.outputNode, masterInput],
       destination,
     );
   });

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -26,10 +26,9 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     if (!panner) {
       throw new Error("setPanType did not produce a panner node");
     }
-    source.connect(panner);
     this.setGainNode(gainNode);
+    this.setEffectChainEndpoints(source, panner);
     panner.connect(gainNode);
-    this.refreshFilters();
     this.oscillatorOptions = {
       detune: source.detune.value,
       frequency: source.frequency.value,
@@ -78,22 +77,6 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     }
 
     this.markStopped();
-  }
-
-  /**
-   * Refreshes the audio filters by re-applying them to the audio signal chain.
-   * This method is called internally whenever filters are added or removed.
-   * @throws {Error} Throws an error if the synth has been cleaned up.
-   */
-
-  private refreshFilters(): void {
-    if (!this.panner || !this.gainNode) {
-      throw new Error("Cannot update filters on a sound that has been cleaned up");
-    }
-    let connection: AudioNode = this.panner;
-    connection.disconnect();
-    connection = this.applyFilters(connection);
-    connection.connect(this.gainNode);
   }
 
   cleanup(): void {
@@ -166,6 +149,6 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
 
     this.source.disconnect();
     this.source = this.context.createOscillator();
-    this.source.connect(this.panner);
+    this.setEffectChainEndpoints(this.source, this.panner);
   }
 }


### PR DESCRIPTION
## Summary

- extract the incremental `EffectChain` machine from `Bus` while preserving Bus behavior
- give every `BasePlayback` an owned effect chain wired `source → effects → panner → gain`
- delete the four playback-specific `refreshFilters` implementations
- make the phase-vocoder an ordinary chain entry and expose chain reorder, bypass, and parameter automation to playbacks
- update graph assertions for buffer, media-element, synth, PCM-stream, and media-stream playback

## Why

Playback filters were applied after spatial panning, so nonlinear and time-variant effects could process HRTF output per ear and damage binaural cues. The duplicated playback chain rebuilds also lacked Bus's incremental reconciliation and effect controls.

## Impact

Playback filters and pitch shifting now run before panning. Bus behavior remains unchanged. No compatibility path for the old post-panner placement is retained.

## Validation

- TDD red run: 12 focused failures against the old topology and missing shared controls
- focused graph and pitch suites: 110 passing tests
- `npm run lint`
- `npm run ci:test` — 1069 passed, 1 skipped, no type errors
- `npm run build` — exit 0 (repository's existing TS4094 and TypeDoc warnings remain)

Closes #140