### PR TITLE
Add per-source effect recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,40 @@ playback.filters[0].frequency.value = 500; // Only affects this playback
 
 See [TypeDoc](https://cacophony.js.org) for complete filter parameters and options.
 
+### Per-source effects
+
+Use `addEffect` for source character such as distortion, EQ, tremolo, or pitch
+processing. The source stores the `CacophonyEffect` as a recipe and builds a
+fresh effect instance for every playback, before that playback's panner. The
+returned playback handle can be automated without changing another playback.
+
+```typescript
+const guitar = await cacophony.createSound('guitar.mp3');
+const distortion = cacophony.createDistortion({ drive: 4 });
+guitar.addEffect(distortion);
+
+const [take] = guitar.play();
+const liveTremolo = await take.addEffect(cacophony.createTremolo({ rate: 5 }));
+take.rampEffectParam(liveTremolo, 'depth', 0.8, { duration: 250 });
+
+guitar.removeEffect(distortion); // future playbacks no longer build it
+```
+
+Keep shared space effects such as reverb on a bus and feed them with a wet
+send. This leaves the playback's dry character chain intact while every source
+sent to the bus shares one live reverb instance.
+
+```typescript
+const vocals = await cacophony.createSound('vocals.mp3');
+vocals.addEffect(cacophony.createDistortion({ drive: 1.5 })); // dry, per playback
+
+const chamber = cacophony.createBus('chamber');
+await chamber.addFilter(cacophony.createReverb({ wet: 1, dry: 0 }));
+vocals.routeTo(chamber, 0.25); // 25% wet send; primary output stays on master
+
+vocals.play();
+```
+
 ## Custom Audio Routing
 
 Cacophony exposes the underlying Web Audio graph through Playback instances, enabling manual routing through custom effects chains. This is the low-level foundation for building complex audio processing pipelines.

--- a/src/basePlayback.ts
+++ b/src/basePlayback.ts
@@ -1,8 +1,9 @@
 import type { Bus } from "./bus";
 import type { FadeType } from "./cacophony";
 import type { PlaybackContainer } from "./container";
-import type { AudioNode, BiquadFilterNode, GainNode } from "./context";
+import type { AudioNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
 import { EffectChain } from "./effectChain";
+import type { CacophonyEffect } from "./effects";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { PlaybackEvents } from "./events";
 import { FilterManager } from "./filters";
@@ -14,6 +15,7 @@ export type PlaybackState = "unplayed" | "playing" | "paused" | "stopped";
 export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager)) {
   public source?: AudioNode;
   protected _effectChain?: EffectChain;
+  private _effectContext?: BaseContext;
   /**
    * Per-playback send-gain allocations owned by the shared routing state
    * machine. Cleanup disconnects every allocation deterministically.
@@ -29,11 +31,83 @@ export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager
   }
 
   protected setEffectChainEndpoints(input: AudioNode, output: AudioNode): void {
+    this._effectContext =
+      (input.context as BaseContext | undefined) ??
+      (this.origin as PlaybackContainer & { context?: BaseContext }).context;
     if (this._effectChain) {
       this._effectChain.setEndpoints(input, output);
       return;
     }
     this._effectChain = new EffectChain(input, output, this.constructor.name);
+  }
+
+  /** Build and splice an effect into this live playback's pre-panner chain. */
+  addEffect(effect: CacophonyEffect): Promise<AudioNode> {
+    try {
+      return this.materializeEffect(effect);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  }
+
+  /** @internal Source preplay path that preserves synchronous native-build failures. */
+  _addSourceEffect(effect: CacophonyEffect): Promise<AudioNode> {
+    return this.materializeEffect(effect);
+  }
+
+  /** @internal Materialize a source-level biquad recipe and retain filter API compatibility. */
+  _addFilterEffect(effect: CacophonyEffect): Promise<AudioNode> {
+    return this.materializeEffect(effect, (handle) => {
+      this._filters.push(handle as BiquadFilterNode);
+    });
+  }
+
+  private materializeEffect(effect: CacophonyEffect, onBuilt?: (handle: AudioNode) => void): Promise<AudioNode> {
+    if (!this._effectChain || !this._effectContext) {
+      throw new Error("Cannot add an effect before the playback effect chain is initialized");
+    }
+    const chain = this._effectChain;
+    const reservation = chain.reserve();
+    let built;
+    try {
+      built = effect.build(this._effectContext);
+    } catch (error) {
+      chain.cancel(reservation);
+      throw error;
+    }
+    if (built instanceof Promise || (typeof built === "object" && built !== null && "then" in built)) {
+      return Promise.resolve(built).then(
+        (resolved) => {
+          const handle = chain.resolve(reservation, resolved);
+          onBuilt?.(handle);
+          return handle;
+        },
+        (error) => {
+          chain.cancel(reservation);
+          throw error;
+        },
+      );
+    }
+    try {
+      const handle = chain.resolve(reservation, built);
+      onBuilt?.(handle);
+      return Promise.resolve(handle);
+    } catch (error) {
+      chain.cancel(reservation);
+      throw error;
+    }
+  }
+
+  rampEffectParam(
+    handle: AudioNode,
+    paramName: string,
+    value: number,
+    options?: { duration?: number; type?: FadeType },
+  ): void {
+    if (!this._effectChain) {
+      throw new Error("Cannot automate an effect before the playback effect chain is initialized");
+    }
+    this._effectChain.rampParam(handle, paramName, value, options);
   }
 
   addFilter(filter: BiquadFilterNode): void {
@@ -174,6 +248,7 @@ export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager
     this._sendGains.clear();
     this._effectChain?.destroy();
     this._effectChain = undefined;
+    this._effectContext = undefined;
     this.eventEmitter.removeAllListeners();
     super.cleanup();
   }

--- a/src/effectChain.ts
+++ b/src/effectChain.ts
@@ -11,14 +11,21 @@ interface EffectChainEntry {
   dispose?: () => void;
 }
 
+interface EffectChainReservation {
+  readonly reservation: symbol;
+}
+
+type EffectChainSlot = EffectChainEntry | EffectChainReservation;
+
 /**
  * Incrementally reconciles a series of built effects between two caller-owned
  * endpoint nodes.
  */
 export class EffectChain {
-  private readonly entries: EffectChainEntry[] = [];
+  private readonly entries: EffectChainSlot[] = [];
   private readonly bypassed = new Set<AudioNode>();
   private readonly edges: Array<readonly [AudioNode, AudioNode]> = [];
+  private destroyed = false;
 
   constructor(
     private input: AudioNode,
@@ -29,11 +36,11 @@ export class EffectChain {
   }
 
   get nodes(): readonly AudioNode[] {
-    return this.entries.map((entry) => entry.handle);
+    return this.entries.filter(this.isEntry).map((entry) => entry.handle);
   }
 
   has(node: AudioNode): boolean {
-    return this.entries.some((entry) => entry.handle === node);
+    return this.entries.some((entry) => this.isEntry(entry) && entry.handle === node);
   }
 
   setEndpoints(input: AudioNode, output: AudioNode): void {
@@ -47,6 +54,9 @@ export class EffectChain {
   }
 
   add(built: BuiltEffect, index = this.entries.length): AudioNode {
+    if (this.destroyed) {
+      throw new Error("Cannot add an effect to a destroyed chain");
+    }
     const entry = this.normalize(built);
     if (this.has(entry.handle)) {
       throw new Error("Cannot add the same effect node to a chain twice");
@@ -56,28 +66,76 @@ export class EffectChain {
     return entry.handle;
   }
 
+  /** Reserve a declaration-order position for an asynchronously built effect. */
+  reserve(): symbol {
+    if (this.destroyed) {
+      throw new Error("Cannot reserve an effect on a destroyed chain");
+    }
+    const reservation = Symbol("effect-chain-reservation");
+    this.entries.push({ reservation });
+    return reservation;
+  }
+
+  /** Replace a reservation with its built effect while retaining its position. */
+  resolve(reservation: symbol, built: BuiltEffect): AudioNode {
+    const entry = this.normalize(built);
+    if (this.destroyed) {
+      entry.dispose?.();
+      return entry.handle;
+    }
+    const index = this.entries.findIndex(
+      (candidate) => !this.isEntry(candidate) && candidate.reservation === reservation,
+    );
+    if (index === -1) {
+      entry.dispose?.();
+      throw new Error("Cannot resolve an unknown effect-chain reservation");
+    }
+    if (this.has(entry.handle)) {
+      entry.dispose?.();
+      throw new Error("Cannot add the same effect node to a chain twice");
+    }
+    this.entries[index] = entry;
+    this.refresh();
+    return entry.handle;
+  }
+
+  cancel(reservation: symbol): void {
+    const index = this.entries.findIndex(
+      (candidate) => !this.isEntry(candidate) && candidate.reservation === reservation,
+    );
+    if (index !== -1) {
+      this.entries.splice(index, 1);
+    }
+  }
+
   remove(node: AudioNode): void {
-    const index = this.entries.findIndex((entry) => entry.handle === node);
+    const index = this.entries.findIndex((entry) => this.isEntry(entry) && entry.handle === node);
     if (index === -1) {
       throw new Error("Cannot remove an effect that was never added to this chain");
     }
     const [entry] = this.entries.splice(index, 1);
     this.bypassed.delete(node);
     this.refresh();
-    entry?.dispose?.();
+    if (entry && this.isEntry(entry)) {
+      entry.dispose?.();
+    }
   }
 
   setOrder(nodes: readonly AudioNode[]): void {
     const isPermutation =
-      nodes.length === this.entries.length &&
+      nodes.length === this.nodes.length &&
       new Set(nodes).size === nodes.length &&
       nodes.every((node) => this.has(node));
     if (!isPermutation) {
       throw new Error("Effect chain order must be a permutation of the current nodes");
     }
-    const ordered = nodes.map((node) => this.entries.find((entry) => entry.handle === node)!);
-    this.entries.length = 0;
-    this.entries.push(...ordered);
+    const ordered = nodes.map((node) => this.entries.find((entry) => this.isEntry(entry) && entry.handle === node)!);
+    let orderedIndex = 0;
+    for (let index = 0; index < this.entries.length; index += 1) {
+      if (this.isEntry(this.entries[index]!)) {
+        this.entries[index] = ordered[orderedIndex++]!;
+      }
+    }
     this.refresh();
   }
 
@@ -102,7 +160,7 @@ export class EffectChain {
   }
 
   rampParam(node: AudioNode, paramName: string, value: number, options?: { duration?: number; type?: FadeType }): void {
-    const entry = this.entries.find((candidate) => candidate.handle === node);
+    const entry = this.entries.filter(this.isEntry).find((candidate) => candidate.handle === node);
     if (!entry) {
       console.warn(
         `${this.diagnosticScope}.rampFilterParam: node is not a filter on this ${this.diagnosticScope.toLowerCase()}; ignoring automation of '${paramName}'.`,
@@ -135,11 +193,14 @@ export class EffectChain {
   }
 
   destroy(): void {
+    this.destroyed = true;
     this.disconnectEdges();
     for (const entry of this.entries) {
-      try {
-        entry.dispose?.();
-      } catch {}
+      if (this.isEntry(entry)) {
+        try {
+          entry.dispose?.();
+        } catch {}
+      }
     }
     this.entries.length = 0;
     this.bypassed.clear();
@@ -170,7 +231,7 @@ export class EffectChain {
   }
 
   private desiredEdges(): Array<readonly [AudioNode, AudioNode]> {
-    const active = this.entries.filter((entry) => !this.bypassed.has(entry.handle));
+    const active = this.entries.filter(this.isEntry).filter((entry) => !this.bypassed.has(entry.handle));
     if (active.length === 0) {
       return [[this.input, this.output]];
     }
@@ -199,6 +260,10 @@ export class EffectChain {
       input: built,
       output: built,
     };
+  }
+
+  private isEntry(slot: EffectChainSlot): slot is EffectChainEntry {
+    return "handle" in slot;
   }
 
   private resolveAudioParam(node: AudioNode, paramName: string): AudioParam | undefined {

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,11 +1,11 @@
 /**
  * Cacophony Effects: a thin abstraction over Web Audio nodes that lets a Bus
- * carry rich, possibly worklet-backed processing in its filter chain.
+ * carry shared processing or a playback build an independent source effect.
  *
  * A {@link CacophonyEffect} is responsible for producing a live AudioNode or
  * endpoint graph when its `build` method is invoked. Single-node effects return
  * the node directly. Multi-node effects return a {@link BuiltEffectGraph} with
- * distinct `input` and `output` endpoints so Bus chains can connect into and out
+ * distinct `input` and `output` endpoints so effect chains can connect into and out
  * of the graph without pretending the head node is also the tail.
  *
  * The `build` return is async-capable so worklet-backed effects (e.g.
@@ -72,11 +72,10 @@ export interface BuiltEffectGraph {
 export type BuiltEffect = AudioNode | BuiltEffectGraph;
 
 /**
- * Public surface every Cacophony effect implements. `build` is called by
- * `Bus.addFilter` to materialize the effect's live node graph against a
- * specific audio context. An effect may be built more than once (e.g. on
- * multiple buses or contexts), or it may bind to a single shared node — the
- * implementation is free to choose. Cacophony itself does not cache.
+ * Public surface every Cacophony effect implements. `build` materializes the
+ * effect's live node graph against a specific audio context. A Bus consumes an
+ * effect as shared live state; a source consumes it as a recipe and calls
+ * `build` once for every playback. Cacophony itself does not cache.
  */
 export interface CacophonyEffect {
   build(context: BaseContext): Promise<BuiltEffect> | BuiltEffect;
@@ -149,6 +148,25 @@ export class BiquadEffect implements CacophonyEffect {
 
   build(_context: BaseContext): AudioNode {
     return this.node;
+  }
+}
+
+/**
+ * Treats a BiquadFilterNode as a per-playback recipe. Unlike BiquadEffect,
+ * which intentionally shares its node, every build creates an independent
+ * node and copies the template's public filter state.
+ */
+export class BiquadRecipeEffect implements CacophonyEffect {
+  constructor(private readonly template: BiquadFilterNode) {}
+
+  build(context: BaseContext): BiquadFilterNode {
+    const node = context.createBiquadFilter();
+    node.type = this.template.type;
+    node.frequency.value = this.template.frequency.value;
+    node.detune.value = this.template.detune.value;
+    node.Q.value = this.template.Q.value;
+    node.gain.value = this.template.gain.value;
+    return node;
   }
 }
 

--- a/src/mediaStream.test.ts
+++ b/src/mediaStream.test.ts
@@ -77,6 +77,16 @@ describe("MediaStreamSound", () => {
     );
   });
 
+  it("builds source effects before the MediaStream playback panner", () => {
+    const sound = new MediaStreamSound(stream, context, globalGainNode);
+    const effect = context.createGain();
+    sound.addEffect({ build: () => effect });
+
+    const [playback] = sound.preplay();
+
+    expectPath(source, [effect, playback.panner!, playback.outputNode, globalGainNode], destination);
+  });
+
   it("applies volume and HRTF position to the live playback", () => {
     const sound = new MediaStreamSound(stream, context, globalGainNode);
     sound.volume = 0.25;

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -262,7 +262,7 @@ export class MediaStreamSound extends RoutableSource implements BaseSound {
       this.stopTracksOnStop,
       this.primeWithMediaElement,
     );
-    this._wireRouteSends(playback);
+    this._preparePlayback(playback);
     playback.volume = this.volume;
     if (this.panType === "HRTF") {
       playback.threeDOptions = this.threeDOptions;
@@ -270,7 +270,6 @@ export class MediaStreamSound extends RoutableSource implements BaseSound {
     } else {
       playback.stereoPan = this.stereoPan ?? 0;
     }
-    this._filters.forEach((filter) => playback.addFilter(filter));
     this.playbacks.push(playback);
     return [playback];
   }

--- a/src/pcmStream.test.ts
+++ b/src/pcmStream.test.ts
@@ -73,6 +73,16 @@ describe("PcmStreamSound", () => {
     expectNotReachable(playback.outputNode, cacophony.master.input);
   });
 
+  it("builds source effects before the PCM playback panner", async () => {
+    const sound = await cacophony.createPcmStreamSound({ latency: 0 });
+    const effect = audioContextMock.createGain();
+    sound.addEffect({ build: () => effect });
+
+    const [playback] = sound.preplay();
+
+    expectPath(playback.source!, [effect, playback.panner!, playback.outputNode], cacophony.master.input);
+  });
+
   it("accepts interleaved PCM, exposes buffered duration, and signals drain after backpressure", async () => {
     const capacityFrames = 4;
     const sound = await cacophony.createPcmStreamSound({

--- a/src/pcmStream.ts
+++ b/src/pcmStream.ts
@@ -353,7 +353,7 @@ export class PcmStreamSound extends RoutableSource implements BaseSound {
       this._resolveRouteTargetNode(),
       this.panType,
     );
-    this._wireRouteSends(playback);
+    this._preparePlayback(playback);
     playback.volume = this.volume;
     if (this.panType === "HRTF") {
       playback.threeDOptions = this.threeDOptions;
@@ -361,7 +361,6 @@ export class PcmStreamSound extends RoutableSource implements BaseSound {
     } else {
       playback.stereoPan = this.stereoPan;
     }
-    this._filters.forEach((filter) => playback.addFilter(filter));
     this.playbacks.push(playback);
     return [playback];
   }

--- a/src/routableSource.ts
+++ b/src/routableSource.ts
@@ -2,7 +2,9 @@ import type { BasePlayback } from "./basePlayback";
 import type { Bus, BusRoutedSource } from "./bus";
 import type { Cacophony } from "./cacophony";
 import { PlaybackContainer } from "./container";
-import type { BaseContext, GainNode } from "./context";
+import type { BaseContext, BiquadFilterNode, GainNode } from "./context";
+import type { CacophonyEffect } from "./effects";
+import { BiquadRecipeEffect } from "./effects";
 import { FilterManager } from "./filters";
 
 /**
@@ -22,6 +24,43 @@ export abstract class RoutableSource extends PlaybackContainer(FilterManager) im
   protected _routeTarget: Bus | null = null;
   /** Additional send target to gain-value mappings. */
   protected _sends: Map<Bus, number> = new Map();
+  /** Effect recipes materialized independently for each future playback. */
+  private readonly _effects: CacophonyEffect[] = [];
+  private readonly _filterEffects = new Map<BiquadFilterNode, CacophonyEffect>();
+  private readonly _filterEffectRecipes = new Set<CacophonyEffect>();
+
+  addEffect(effect: CacophonyEffect): void {
+    if (this._effects.includes(effect)) {
+      throw new Error("Cannot add the same effect recipe twice");
+    }
+    this._effects.push(effect);
+  }
+
+  removeEffect(effect: CacophonyEffect): void {
+    const index = this._effects.indexOf(effect);
+    if (index === -1) {
+      throw new Error("Cannot remove an effect recipe that was never added");
+    }
+    this._effects.splice(index, 1);
+  }
+
+  override addFilter(filter: BiquadFilterNode): void {
+    super.addFilter(filter);
+    const effect = new BiquadRecipeEffect(filter);
+    this._filterEffects.set(filter, effect);
+    this._filterEffectRecipes.add(effect);
+    this._effects.push(effect);
+  }
+
+  override removeFilter(filter: BiquadFilterNode): void {
+    super.removeFilter(filter);
+    const effect = this._filterEffects.get(filter);
+    if (effect) {
+      this._effects.splice(this._effects.indexOf(effect), 1);
+      this._filterEffects.delete(filter);
+      this._filterEffectRecipes.delete(effect);
+    }
+  }
 
   /**
    * Route this source to a bus, or add an independent send when `sendGain`
@@ -80,6 +119,19 @@ export abstract class RoutableSource extends PlaybackContainer(FilterManager) im
       sendGain.connect(bus.input);
       playback._sendGains.set(bus, sendGain);
     }
+  }
+
+  /** Materialize all declared recipes, then establish this playback's sends. */
+  protected _preparePlayback(playback: BasePlayback): void {
+    for (const effect of this._effects) {
+      const build = this._filterEffectRecipes.has(effect)
+        ? playback._addFilterEffect(effect)
+        : playback._addSourceEffect(effect);
+      void build.catch((error) => {
+        console.warn(`${this.constructor.name} could not build a per-playback effect; continuing without it.`, error);
+      });
+    }
+    this._wireRouteSends(playback);
   }
 
   private _setPrimary(bus: Bus): void {
@@ -176,6 +228,9 @@ export abstract class RoutableSource extends PlaybackContainer(FilterManager) im
     for (const bus of this._sends.keys()) {
       bus._unregisterRoutedSource(this);
     }
+    this._effects.length = 0;
+    this._filterEffects.clear();
+    this._filterEffectRecipes.clear();
     super.cleanup();
   }
 }

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -233,7 +233,7 @@ export class Sound extends RoutableSource implements BaseSound {
       const primaryTargetNode = this._resolveRouteTargetNode();
       gainNode.connect(primaryTargetNode);
       const playback = new Playback(this, source, gainNode);
-      this._wireRouteSends(playback);
+      this._preparePlayback(playback);
       this._holdings.sources.push(source);
       this._holdings.gainNodes.push(gainNode);
       if ("mediaElement" in source && source.mediaElement) {
@@ -251,15 +251,6 @@ export class Sound extends RoutableSource implements BaseSound {
           /* worklet unavailable on this context — playback proceeds unshifted */
         });
       }
-      // Clone filters from sound to playback (each playback gets independent filter instances)
-      this._filters.forEach((filter) => {
-        const clonedFilter = this.context.createBiquadFilter();
-        clonedFilter.type = filter.type;
-        clonedFilter.frequency.value = filter.frequency.value;
-        clonedFilter.Q.value = filter.Q.value;
-        clonedFilter.gain.value = filter.gain.value;
-        playback.addFilter(clonedFilter);
-      });
       if (this.panType === "HRTF") {
         playback.threeDOptions = this.threeDOptions;
         playback.position = this.position;

--- a/src/sourceEffects.test.ts
+++ b/src/sourceEffects.test.ts
@@ -1,0 +1,118 @@
+import { AudioBuffer } from "standardized-audio-context-mock";
+import { describe, expect, it, vi } from "vitest";
+import type { AudioNode, BaseContext, BiquadFilterNode } from "./context";
+import type { BuiltEffect, CacophonyEffect } from "./effects";
+import { audioContextMock, cacophony, expectPath } from "./setupTests";
+
+function recipe(build: (context: BaseContext) => BuiltEffect | Promise<BuiltEffect>): CacophonyEffect {
+  return { build };
+}
+
+async function createSound() {
+  return cacophony.createSound(new AudioBuffer({ length: 100, sampleRate: 44_100 }));
+}
+
+describe("per-source effects", () => {
+  it("builds independent instances for every Sound playback before its panner", async () => {
+    const sound = await createSound();
+    const built: BiquadFilterNode[] = [];
+    sound.addEffect(
+      recipe((context) => {
+        const node = context.createBiquadFilter();
+        built.push(node);
+        return node;
+      }),
+    );
+
+    const first = sound.preplay()[0];
+    const second = sound.preplay()[0];
+
+    expect(built).toHaveLength(2);
+    expect(built[0]).not.toBe(built[1]);
+    expectPath(first.source!, [built[0]!, first.panner!, first.outputNode], cacophony.master.input);
+    expectPath(second.source!, [built[1]!, second.panner!, second.outputNode], cacophony.master.input);
+
+    const firstSet = vi.spyOn(built[0]!.frequency, "setValueAtTime");
+    const secondSet = vi.spyOn(built[1]!.frequency, "setValueAtTime");
+    first.rampEffectParam(built[0]!, "frequency", 880);
+    expect(firstSet).toHaveBeenCalledWith(880, built[0]!.context.currentTime);
+    expect(secondSet).not.toHaveBeenCalled();
+  });
+
+  it("returns the live handle when an effect is added directly to a playback", async () => {
+    const sound = await createSound();
+    const playback = sound.preplay()[0];
+    const node = audioContextMock.createGain();
+
+    await expect(playback.addEffect(recipe(() => node))).resolves.toBe(node);
+    expectPath(playback.source!, [node, playback.panner!, playback.outputNode], cacophony.master.input);
+  });
+
+  it("preserves declaration order when async effect builds resolve out of order", async () => {
+    const sound = await createSound();
+    const first = audioContextMock.createGain();
+    const second = audioContextMock.createGain();
+    const third = audioContextMock.createGain();
+    let resolveFirst!: (node: AudioNode) => void;
+    let resolveSecond!: (node: AudioNode) => void;
+    sound.addEffect(recipe(() => new Promise<AudioNode>((resolve) => (resolveFirst = resolve))));
+    sound.addEffect(recipe(() => new Promise<AudioNode>((resolve) => (resolveSecond = resolve))));
+    sound.addEffect(recipe(() => third));
+
+    const playback = sound.preplay()[0];
+    expectPath(playback.source!, [third, playback.panner!, playback.outputNode], cacophony.master.input);
+
+    resolveSecond(second);
+    await Promise.resolve();
+    expectPath(playback.source!, [second, third, playback.panner!, playback.outputNode], cacophony.master.input);
+
+    resolveFirst(first);
+    await Promise.resolve();
+    expectPath(playback.source!, [first, second, third, playback.panner!, playback.outputNode], cacophony.master.input);
+  });
+
+  it("disposes a built effect graph during playback cleanup", async () => {
+    const sound = await createSound();
+    const dispose = vi.fn();
+    sound.addEffect(
+      recipe((context) => ({
+        input: context.createGain(),
+        output: context.createGain(),
+        dispose,
+      })),
+    );
+    const playback = sound.preplay()[0];
+
+    playback.cleanup();
+
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it("removes a source recipe before future playbacks are built", async () => {
+    const sound = await createSound();
+    const build = vi.fn((context: BaseContext) => context.createGain());
+    const effect = recipe(build);
+    sound.addEffect(effect);
+    sound.removeEffect(effect);
+
+    sound.preplay();
+
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it("supports a per-playback dry chain and a shared wet send end to end", async () => {
+    const sound = await createSound();
+    const dry = audioContextMock.createGain();
+    const wet = audioContextMock.createGain();
+    const reverbBus = cacophony.createBus("source-effects-wet-send");
+    sound.addEffect(recipe(() => dry));
+    await reverbBus.addFilter(recipe(() => wet));
+    sound.routeTo(reverbBus, 0.25);
+
+    const playback = sound.preplay()[0];
+    const sendGain = playback._sendGains.get(reverbBus);
+
+    expectPath(playback.source!, [dry, playback.panner!, playback.outputNode], cacophony.master.input);
+    expectPath(playback.outputNode, [sendGain!, reverbBus.input, wet, reverbBus.output], cacophony.master.input);
+  });
+});

--- a/src/synth.test.ts
+++ b/src/synth.test.ts
@@ -182,6 +182,15 @@ describe("Synth class", () => {
     );
   });
 
+  it("builds source effects before the synth playback panner", () => {
+    const effect = audioContextMock.createGain();
+    synth.addEffect({ build: () => effect });
+
+    const [playback] = synth.preplay();
+
+    expectPath(playback.source!, [effect, playback.panner!, playback.outputNode, masterInput], destination);
+  });
+
   it("prevents adding same filter instance twice", () => {
     const filter = audioContextMock.createBiquadFilter();
     synth.addFilter(filter);

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -116,17 +116,8 @@ export class Synth extends RoutableSource implements BaseSound {
     const primaryTargetNode = this._resolveRouteTargetNode();
     gainNode.connect(primaryTargetNode);
     const playback = new SynthPlayback(this, oscillator, gainNode);
-    this._wireRouteSends(playback);
+    this._preparePlayback(playback);
     playback.volume = this.volume;
-    // Clone filters from synth to playback (each playback gets independent filter instances)
-    this._filters.forEach((filter) => {
-      const clonedFilter = this.context.createBiquadFilter();
-      clonedFilter.type = filter.type;
-      clonedFilter.frequency.value = filter.frequency.value;
-      clonedFilter.Q.value = filter.Q.value;
-      clonedFilter.gain.value = filter.gain.value;
-      playback.addFilter(clonedFilter);
-    });
     if (this.panType === "HRTF") {
       playback.threeDOptions = this.threeDOptions;
       playback.position = this.position;


### PR DESCRIPTION
## Summary

- add source-level effect recipes shared by Sound, Synth, PCM streams, and MediaStreams
- materialize independent live effects in each playback's pre-panner EffectChain
- preserve declaration order across asynchronous effect builds and dispose owned graphs during cleanup
- retain `addFilter` compatibility through fresh per-playback biquad recipes
- document per-source dry effects with shared wet-send buses

## Root cause

Playback effect chains existed, but source containers only knew how to hand-copy biquads. They had no common recipe API, no live playback effect handle API, and no reservation mechanism for asynchronous effect builds.

## Validation

- `npm run lint`
- `npm run ci:test` (74 files; 1,078 passed, 1 skipped; no type errors)
- `npm run build` (completed with the repository's existing TS4094 and TypeDoc warnings)

Closes #113
