### PR TITLE
Fix issue 145 paper cuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,9 +829,14 @@ resampled to the active audio context and written into the same AudioWorklet
 ring buffer used by `createPcmStreamSound()`. The returned stream is therefore
 sample-accurately scheduled, pannable, filterable, bus-routable, and meterable.
 
+The current streaming resampler uses linear interpolation without an
+anti-aliasing filter. When downsampling, source frequencies above the target
+Nyquist frequency can alias into the audible band; this is an accepted v1
+quality trade-off pending a future band-limited resampler.
+
 ```typescript
 const controller = new AbortController();
-const stream = await cacophony.createStream('/music.ogg', controller.signal);
+const stream = await cacophony.createStream('/music.ogg', controller.signal, 'stereo');
 
 console.log(stream.streamCapabilities);
 // {

--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -263,6 +263,12 @@ describe("Cacophony advanced features", () => {
     expect(streamSound.soundType).toBe("streaming");
   });
 
+  it("threads stereo panning through the media-element stream tier", async () => {
+    const streamSound = await cacophony.createStream("https://example.com/audio.mp3", undefined, "stereo");
+    expect(streamSound).toBeInstanceOf(Sound);
+    expect(streamSound).toMatchObject({ panType: "stereo" });
+  });
+
   it("createGroupFromUrls creates a Group with Sound instances", async () => {
     const urls = ["url1", "url2", "url3"];
     const mockBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
@@ -492,13 +498,14 @@ describe("Cacophony advanced features", () => {
         return streamingAudio.audio as any;
       });
 
-      const streamPromise = cacophony.createStream(url);
+      const streamPromise = cacophony.createStream(url, undefined, "stereo");
 
       expect(canPlayType).toHaveBeenCalledWith("application/vnd.apple.mpegurl");
       streamingAudio.dispatch("loadedmetadata");
 
       const sound = await streamPromise;
       expect(sound.soundType).toBe("streaming");
+      expect(sound).toMatchObject({ panType: "stereo" });
       expect(streamingAudio.audio.src).toBe(url);
     });
 

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -923,10 +923,10 @@ export class Cacophony {
     });
   }
 
-  private createHlsSound(url: string, signal?: AbortSignal): Promise<Sound> {
+  private createHlsSound(url: string, panType: PanType, signal?: AbortSignal): Promise<Sound> {
     const audio = new Audio();
     const nativeHls = audio.canPlayType("application/vnd.apple.mpegurl") || audio.canPlayType("application/x-mpegURL");
-    return this.createMediaSound(url, "streaming", "HRTF", signal, audio, !nativeHls);
+    return this.createMediaSound(url, "streaming", panType, signal, audio, !nativeHls);
   }
 
   clearMemoryCache(): void {
@@ -1144,24 +1144,32 @@ export class Cacophony {
    * PCM is fed into the same routable AudioWorklet source returned by
    * {@link createPcmStreamSound}. Browsers without WebCodecs, or without a
    * decoder for the track, fall back to the media-element streaming tier.
+   * @param url - Encoded audio stream URL.
+   * @param signal - Optional cancellation signal retained as the second
+   * parameter for backwards compatibility.
+   * @param panType - Type of panning (HRTF or stereo).
    */
-  async createStream(url: string, signal?: AbortSignal): Promise<Sound | WebCodecsStreamSound> {
+  async createStream(
+    url: string,
+    signal?: AbortSignal,
+    panType: PanType = "HRTF",
+  ): Promise<Sound | WebCodecsStreamSound> {
     if (/\.m3u8(?:$|[?#])/i.test(url)) {
-      return this.createHlsSound(url, signal);
+      return this.createHlsSound(url, panType, signal);
     }
 
     if (typeof globalThis.AudioDecoder !== "function") {
-      return this.createMediaSound(url, "streaming", "HRTF", signal);
+      return this.createMediaSound(url, "streaming", panType, signal);
     }
 
     const adapter = await WebCodecsPullAdapter.open(url, this.context.sampleRate, signal);
     if (!adapter) {
-      return this.createMediaSound(url, "streaming", "HRTF", signal);
+      return this.createMediaSound(url, "streaming", panType, signal);
     }
     try {
       const sound = await this.createPcmStreamSound({
         channelCount: adapter.channelCount,
-        panType: "HRTF",
+        panType,
         signal,
       });
       return adapter.attach(sound);

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ export {
 export type { LoudnessReading } from "./meters/loudness-meter";
 export { LoudnessMeter } from "./meters/loudness-meter";
 export { TruePeakDetector, truePeakDb } from "./meters/truepeak-core";
-export { MicrophonePlayback } from "./microphone";
+export { MicrophonePlayback, MicrophoneStream } from "./microphone";
 export type { HrtfPannerOptions, PanCloneOverrides, ThreeDOptions } from "./pannerMixin";
 export type {
   PcmStreamBufferEvent,

--- a/src/microphone.test.ts
+++ b/src/microphone.test.ts
@@ -1,6 +1,7 @@
 import { AudioContext } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Cacophony } from "./cacophony";
+import { MicrophoneStream as PublicMicrophoneStream } from "./index";
 import { MicrophonePlayback, MicrophoneStream } from "./microphone";
 import { expectPath } from "./setupTests";
 
@@ -28,6 +29,10 @@ function createMockMediaStreamSource(stream: MediaStream) {
     numberOfOutputs: 1,
   };
 }
+
+it("exports MicrophoneStream from the public package entrypoint", () => {
+  expect(PublicMicrophoneStream).toBe(MicrophoneStream);
+});
 
 describe("MicrophonePlayback", () => {
   let context: AudioContext;

--- a/src/routableSource.ts
+++ b/src/routableSource.ts
@@ -190,6 +190,11 @@ export abstract class RoutableSource extends PlaybackContainer(FilterManager) im
       try {
         playback.outputNode.connect(sendGain);
       } catch {
+        try {
+          sendGain.disconnect();
+        } catch {
+          // The failed connection may leave the fresh node already detached.
+        }
         continue;
       }
       sendGain.connect(bus.input);

--- a/src/routeTo.test.ts
+++ b/src/routeTo.test.ts
@@ -124,6 +124,25 @@ describe("Sound.routeTo: additive send", () => {
     bus.destroy();
   });
 
+  it("disconnects a newly allocated send gain when the playback connection fails", async () => {
+    const sound = await buildSound();
+    const [playback] = sound.play();
+    const bus = cacophony.createBus("failed-send");
+    const realCreateGain = cacophony.context.createGain.bind(cacophony.context);
+    const sendGain = realCreateGain();
+    const disconnectSpy = vi.spyOn(sendGain, "disconnect");
+
+    vi.spyOn(cacophony.context, "createGain").mockReturnValueOnce(sendGain);
+    vi.spyOn(playback.outputNode, "connect").mockImplementationOnce(() => {
+      throw new Error("connection rejected");
+    });
+
+    expect(() => sound.routeTo(bus, 0.5)).not.toThrow();
+    expect(disconnectSpy).toHaveBeenCalledOnce();
+    expect(playback._sendGains.has(bus)).toBe(false);
+    bus.destroy();
+  });
+
   it("throws when adding a send to a destroyed bus", async () => {
     const sound = await buildSound();
     const bus = cacophony.createBus("dead-send");

--- a/src/synth.test.ts
+++ b/src/synth.test.ts
@@ -125,6 +125,10 @@ describe("Synth class", () => {
     expect(synth.detune).toBe(100);
   });
 
+  it("defaults detune to zero when it has not been set", () => {
+    expect(synth.detune).toBe(0);
+  });
+
   it("can set and get oscillator type", () => {
     synth.type = "square";
     expect(synth.type).toBe("square");

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -131,26 +131,22 @@ export class Synth extends RoutableSource implements BaseSound {
   play(): ReturnType<this["preplay"]> {
     const playbacks = super.play() as ReturnType<this["preplay"]>;
     this.emit("play", playbacks[0]);
-    this.cacophony?.emit("globalPlay", { source: this, timestamp: Date.now() });
     return playbacks;
   }
 
   stop(): void {
     super.stop();
     this.emit("stop", undefined);
-    this.cacophony?.emit("globalStop", { source: this, timestamp: Date.now() });
   }
 
   pause(): void {
     super.pause();
     this.emit("pause", undefined);
-    this.cacophony?.emit("globalPause", { source: this, timestamp: Date.now() });
   }
 
   resume(): void {
     this.playbacks.filter((playback) => playback.isPaused).forEach((playback) => playback.play());
     this.emit("resume", undefined);
-    this.cacophony?.emit("globalPlay", { source: this, timestamp: Date.now() });
   }
 
   get volume(): number {
@@ -188,7 +184,7 @@ export class Synth extends RoutableSource implements BaseSound {
   }
 
   get detune(): number {
-    return this.oscillatorOptions.detune as number;
+    return this.oscillatorOptions.detune ?? 0;
   }
 
   set detune(detune: number) {

--- a/src/synthPlayback-output.test.ts
+++ b/src/synthPlayback-output.test.ts
@@ -2,6 +2,38 @@ import { describe, expect, it, vi } from "vitest";
 import { cacophony, expectPath } from "./setupTests";
 
 describe("SynthPlayback: outputNode / connect / disconnect parity with Playback", () => {
+  it("emits playback and global events across play, pause, resume, and stop", () => {
+    const synth = cacophony.createOscillator({});
+    const [playback] = synth.preplay();
+    const playbackEvents: string[] = [];
+    const globalEvents: string[] = [];
+
+    playback.on("play", () => playbackEvents.push("play"));
+    playback.on("pause", () => playbackEvents.push("pause"));
+    playback.on("resume", () => playbackEvents.push("resume"));
+    playback.on("stop", () => playbackEvents.push("stop"));
+    cacophony.on("globalPlay", ({ source }) => {
+      expect(source).toBe(synth);
+      globalEvents.push("play");
+    });
+    cacophony.on("globalPause", ({ source }) => {
+      expect(source).toBe(synth);
+      globalEvents.push("pause");
+    });
+    cacophony.on("globalStop", ({ source }) => {
+      expect(source).toBe(synth);
+      globalEvents.push("stop");
+    });
+
+    playback.play();
+    playback.pause();
+    playback.play();
+    playback.stop();
+
+    expect(playbackEvents).toEqual(["play", "pause", "play", "resume", "stop"]);
+    expect(globalEvents).toEqual(["play", "pause", "play", "stop"]);
+  });
+
   it("exposes outputNode (a GainNode) on a live synth playback", () => {
     const synth = cacophony.createOscillator({});
     const [playback] = synth.play();

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -45,7 +45,8 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
       return [this];
     }
 
-    if (this._state === "paused" || this._state === "stopped") {
+    const isResume = this._state === "paused";
+    if (isResume || this._state === "stopped") {
       this.recreateSource();
     }
 
@@ -55,6 +56,14 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
 
     this.source.start();
     this.markPlaying();
+    this.emit("play", this);
+    if (isResume) {
+      this.emit("resume", undefined);
+    }
+    this.origin.cacophony?.emit("globalPlay", {
+      source: this.origin,
+      timestamp: Date.now(),
+    });
     return [this];
   }
 
@@ -65,6 +74,11 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
 
     this.source.stop();
     this.markPaused();
+    this.emit("pause", undefined);
+    this.origin.cacophony?.emit("globalPause", {
+      source: this.origin,
+      timestamp: Date.now(),
+    });
   }
 
   stop(): void {
@@ -77,6 +91,11 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     }
 
     this.markStopped();
+    this.emit("stop", undefined);
+    this.origin.cacophony?.emit("globalStop", {
+      source: this.origin,
+      timestamp: Date.now(),
+    });
   }
 
   cleanup(): void {

--- a/src/webCodecsStream.test.ts
+++ b/src/webCodecsStream.test.ts
@@ -172,6 +172,15 @@ describe("WebCodecs URL streaming", () => {
     expect(media.sourceUrl).toBe("https://example.com/music.ogg");
   });
 
+  it("threads stereo panning through the WebCodecs stream tier", async () => {
+    const stream = await cacophony.createStream("https://example.com/music.ogg", undefined, "stereo");
+    expect(stream).toBeInstanceOf(PcmStreamSound);
+
+    const [playback] = stream.play();
+
+    expect(playback.panType).toBe("stereo");
+  });
+
   it("seeks by reopening the range-backed decoder at the requested timestamp", async () => {
     const stream = await cacophony.createStream("https://example.com/music.mp3");
 

--- a/src/webCodecsStream.ts
+++ b/src/webCodecsStream.ts
@@ -305,6 +305,13 @@ function waitForDrain(sound: PcmStreamSound, signal: AbortSignal): Promise<void>
   });
 }
 
+/**
+ * Stateful linear-interpolation resampler for decoded stream chunks.
+ *
+ * This v1 implementation has no anti-aliasing filter. Downsampling can fold
+ * source frequencies above the target Nyquist frequency into the audible band;
+ * use a band-limited resampler if that quality trade-off is unacceptable.
+ */
 class StreamingPcmResampler {
   private inputFrames = 0;
   private nextSourcePosition = 0;


### PR DESCRIPTION
## Summary

- dispose failed send-gain allocations and default unset synth detune to zero
- emit playback/global lifecycle events from `SynthPlayback` without duplicating `Synth` container notifications
- thread configurable panning through every `createStream` transport tier and export `MicrophoneStream`
- document the streaming resampler's anti-aliasing limitation

## TDD evidence

- Red: the focused regression run produced six behavioral failures, and the public-entrypoint test failed on the missing export
- Green: focused suite passed 159 tests with 1 environment-gated skip
- `npm run lint`
- `npm run ci:test` (1,084 passed, 1 skipped, no type errors)
- `npm run build` (successful; existing TS4094 and TypeDoc warnings remain)

Closes #145