### PR TITLE
Modernize microphone playback and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,8 +800,13 @@ Capture, process, and manipulate live audio input:
 const cacophony = new Cacophony();
 
 try {
-  const micStream = await cacophony.getMicrophoneStream();
-  micStream.play();
+  const micStream = await cacophony.getMicrophoneStream({
+    panType: 'stereo',
+    stereoPan: 0,
+    constraints: {
+      audio: { echoCancellation: true }
+    }
+  });
 
   // Apply filters to microphone input
   const lowPassFilter = cacophony.createBiquadFilter({ type: 'lowpass', frequency: 1000 });
@@ -809,6 +814,7 @@ try {
 
   // Control microphone volume
   micStream.volume = 0.8;
+  micStream.play();
 
   // Pause and resume
   setTimeout(() => {
@@ -817,9 +823,15 @@ try {
   }, 5000);
 
 } catch (error) {
+  // Permission and device failures reject getMicrophoneStream().
   console.error("Error accessing microphone:", error);
 }
 ```
+
+Microphone monitoring is routed through the master bus, so global volume,
+mute, master effects, and metering apply. Each playback exposes the standard
+play, pause, stop, and error event surface and is fully disconnected when the
+microphone is stopped.
 
 ## Audio Streaming
 

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -46,7 +46,7 @@ import { HlsAdapter } from "./hlsAdapter";
 import { type CacophonyLogger, consoleLogger, noopLogger } from "./logger";
 import { MediaStreamSound, type MediaStreamSoundOptions } from "./mediaStream";
 import { LoudnessMeter } from "./meters/loudness-meter";
-import { MicrophoneStream } from "./microphone";
+import { MicrophoneStream, type MicrophoneStreamOptions } from "./microphone";
 import type { ThreeDOptions } from "./pannerMixin";
 import { PcmStreamSound, type PcmStreamSoundOptions } from "./pcmStream";
 import { GATE_DEFAULT_RATIO } from "./processors/dynamics-core";
@@ -1790,9 +1790,8 @@ export class Cacophony {
     }
   }
 
-  async getMicrophoneStream(): Promise<MicrophoneStream> {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    return new MicrophoneStream(this.context, stream);
+  async getMicrophoneStream(options: MicrophoneStreamOptions = {}): Promise<MicrophoneStream> {
+    return MicrophoneStream.request(this.context, this.globalGainNode, options, this);
   }
 
   get listenerOrientation(): Orientation {

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,6 +114,7 @@ export {
 export type { LoudnessReading } from "./meters/loudness-meter";
 export { LoudnessMeter } from "./meters/loudness-meter";
 export { TruePeakDetector, truePeakDb } from "./meters/truepeak-core";
+export type { MicrophoneStreamOptions } from "./microphone";
 export { MicrophonePlayback, MicrophoneStream } from "./microphone";
 export type { HrtfPannerOptions, PanCloneOverrides, ThreeDOptions } from "./pannerMixin";
 export type {

--- a/src/microphone.test.ts
+++ b/src/microphone.test.ts
@@ -1,14 +1,15 @@
 import { AudioContext } from "standardized-audio-context-mock";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Cacophony } from "./cacophony";
-import { MicrophoneStream as PublicMicrophoneStream } from "./index";
+import { MicrophonePlayback as PublicMicrophonePlayback, MicrophoneStream as PublicMicrophoneStream } from "./index";
 import { MicrophonePlayback, MicrophoneStream } from "./microphone";
-import { expectPath } from "./setupTests";
+import { expectNotReachable, expectPath, expectReachable } from "./setupTests";
 
 function createMockTrack(): MediaStreamTrack {
   return {
     stop: vi.fn(),
     enabled: true,
+    readyState: "live",
   } as unknown as MediaStreamTrack;
 }
 
@@ -20,9 +21,7 @@ function createMockStream(tracks: MediaStreamTrack[]): MediaStream {
 
 function createMockMediaStreamSource(stream: MediaStream) {
   return {
-    connect: vi.fn().mockReturnValue({
-      connect: vi.fn(),
-    }),
+    connect: vi.fn((destination) => destination),
     disconnect: vi.fn(),
     mediaStream: stream,
     numberOfInputs: 1,
@@ -30,76 +29,9 @@ function createMockMediaStreamSource(stream: MediaStream) {
   };
 }
 
-it("exports MicrophoneStream from the public package entrypoint", () => {
+it("exports the microphone classes from the public package entrypoint", () => {
   expect(PublicMicrophoneStream).toBe(MicrophoneStream);
-});
-
-describe("MicrophonePlayback", () => {
-  let context: AudioContext;
-  let mockTrack: MediaStreamTrack;
-  let mockStream: MediaStream;
-  let mockSource: ReturnType<typeof createMockMediaStreamSource>;
-  let mockGainNode: any;
-  let playback: MicrophonePlayback;
-
-  beforeEach(() => {
-    context = new AudioContext();
-    mockTrack = createMockTrack();
-    mockStream = createMockStream([mockTrack]);
-    mockSource = createMockMediaStreamSource(mockStream);
-    mockGainNode = context.createGain();
-    playback = new MicrophonePlayback(mockSource as any, mockGainNode, context);
-  });
-
-  afterEach(() => {
-    context.close();
-  });
-
-  it("play returns array containing itself", () => {
-    const result = playback.play();
-    expect(result).toEqual([playback]);
-  });
-
-  it("isPlaying is true when source exists", () => {
-    expect(playback.isPlaying).toBe(true);
-  });
-
-  it("stop calls track.stop() on all stream tracks", () => {
-    playback.stop();
-    expect(mockTrack.stop).toHaveBeenCalled();
-  });
-
-  it("pause disables all stream tracks", () => {
-    playback.pause();
-    expect(mockTrack.enabled).toBe(false);
-  });
-
-  it("resume enables all stream tracks", () => {
-    playback.pause();
-    expect(mockTrack.enabled).toBe(false);
-    playback.resume();
-    expect(mockTrack.enabled).toBe(true);
-  });
-
-  it("volume getter/setter works", () => {
-    playback.volume = 0.5;
-    expect(playback.volume).toBe(0.5);
-  });
-
-  it("position getter/setter works", () => {
-    playback.position = [1, 2, 3];
-    expect(playback.position).toEqual([1, 2, 3]);
-  });
-
-  it("playbackRate is always 1 (not applicable for mic)", () => {
-    expect(playback.playbackRate).toBe(1);
-    playback.playbackRate = 2;
-    expect(playback.playbackRate).toBe(1);
-  });
-
-  it("duration is always 0", () => {
-    expect(playback.duration).toBe(0);
-  });
+  expect(PublicMicrophonePlayback).toBe(MicrophonePlayback);
 });
 
 describe("MicrophoneStream", () => {
@@ -112,7 +44,6 @@ describe("MicrophoneStream", () => {
     mockTrack = createMockTrack();
     mockStream = createMockStream([mockTrack]);
 
-    // Mock navigator.mediaDevices.getUserMedia
     Object.defineProperty(global, "navigator", {
       value: {
         mediaDevices: {
@@ -123,8 +54,9 @@ describe("MicrophoneStream", () => {
       configurable: true,
     });
 
-    // Mock createMediaStreamSource on the context
-    vi.spyOn(context as any, "createMediaStreamSource").mockReturnValue(createMockMediaStreamSource(mockStream));
+    vi.spyOn(context as any, "createMediaStreamSource").mockImplementation((stream: MediaStream) =>
+      createMockMediaStreamSource(stream),
+    );
   });
 
   afterEach(() => {
@@ -132,142 +64,152 @@ describe("MicrophoneStream", () => {
     context.close();
   });
 
-  it("play() returns playback immediately when constructed with a stream", () => {
-    const mic = new MicrophoneStream(context, mockStream);
-    const result = mic.play();
-    expect(result).toHaveLength(1);
-    expect(result[0]).toBeInstanceOf(MicrophonePlayback);
-  });
-
-  it("play() returns empty array and calls getUserMedia when constructed without a stream", () => {
+  it("acquires audio with the default constraints", async () => {
     (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
-    const mic = new MicrophoneStream(context);
-    const result = mic.play();
-    expect(result).toEqual([]);
+
+    const microphone = await MicrophoneStream.request(context);
+
+    expect(microphone).toBeInstanceOf(MicrophoneStream);
     expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith({ audio: true });
   });
 
-  it("play() sets up streamPlayback after getUserMedia resolves (no-stream path)", async () => {
+  it("forwards custom media constraints", async () => {
     (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
-    const mic = new MicrophoneStream(context);
-    mic.play();
+    const constraints: MediaStreamConstraints = {
+      audio: { autoGainControl: false, echoCancellation: false },
+    };
 
-    // Wait for async setup
-    await vi.waitFor(() => {
-      expect(mic.isPlaying).toBe(true);
-    });
+    await MicrophoneStream.request(context, undefined, { constraints });
 
-    // Second call should return the playback
-    const result = mic.play();
-    expect(result).toHaveLength(1);
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledWith(constraints);
   });
 
-  it("handles getUserMedia permission denial", async () => {
+  it("rejects microphone acquisition failures through the async factory", async () => {
     const permissionError = new DOMException("Permission denied", "NotAllowedError");
     (navigator.mediaDevices.getUserMedia as any).mockRejectedValue(permissionError);
-    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cacophony = new Cacophony(context as any);
 
-    const mic = new MicrophoneStream(context);
-    mic.play();
-
-    await vi.waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith("Error initializing microphone stream:", permissionError);
-    });
-
-    expect(mic.isPlaying).toBe(false);
-    consoleSpy.mockRestore();
+    await expect(cacophony.getMicrophoneStream()).rejects.toBe(permissionError);
   });
 
-  it("does not call getUserMedia when constructed with a stream", () => {
-    const mic = new MicrophoneStream(context, mockStream);
-    mic.play();
-    mic.play();
+  it("does not reacquire a provided stream", () => {
+    const microphone = new MicrophoneStream(context, mockStream);
+
+    microphone.play();
+
     expect(navigator.mediaDevices.getUserMedia).not.toHaveBeenCalled();
   });
 
-  it("stop() delegates to streamPlayback and clears it", () => {
-    const mic = new MicrophoneStream(context, mockStream);
-    mic.play();
-    expect(mic.isPlaying).toBe(true);
+  it("uses the BasePlayback state machine and lifecycle events", () => {
+    const microphone = new MicrophoneStream(context, mockStream);
+    const [playback] = microphone.preplay();
+    const onPlay = vi.fn();
+    const onPause = vi.fn();
+    const onStop = vi.fn();
+    playback.on("play", onPlay);
+    playback.on("pause", onPause);
+    playback.on("stop", onStop);
 
-    mic.stop();
-    expect(mic.isPlaying).toBe(false);
-    expect(mockTrack.stop).toHaveBeenCalled();
-  });
-
-  it("pause() delegates to streamPlayback", () => {
-    const mic = new MicrophoneStream(context, mockStream);
-    mic.play();
-
-    mic.pause();
+    expect(playback.isPlaying).toBe(false);
+    expect(playback.play()).toEqual([playback]);
+    expect(playback).toBeInstanceOf(MicrophonePlayback);
+    expect(playback.isPlaying).toBe(true);
+    playback.pause();
+    expect(playback.isPaused).toBe(true);
     expect(mockTrack.enabled).toBe(false);
-  });
-
-  it("resume() delegates to streamPlayback", () => {
-    const mic = new MicrophoneStream(context, mockStream);
-    mic.play();
-
-    mic.pause();
-    mic.resume();
+    playback.resume();
+    expect(playback.isPlaying).toBe(true);
     expect(mockTrack.enabled).toBe(true);
+    playback.stop();
+    expect(playback.isPlaying).toBe(false);
+
+    expect(onPlay).toHaveBeenCalledTimes(2);
+    expect(onPause).toHaveBeenCalledOnce();
+    expect(onStop).toHaveBeenCalledOnce();
   });
 
-  it("stop/pause/resume are no-ops when no stream acquired", () => {
-    const mic = new MicrophoneStream(context);
-    // None of these should throw
-    mic.stop();
-    mic.pause();
-    mic.resume();
-    expect(mic.isPlaying).toBe(false);
+  it("keeps one playback for the live microphone stream", () => {
+    const microphone = new MicrophoneStream(context, mockStream);
+
+    const first = microphone.play();
+    const second = microphone.play();
+
+    expect(second[0]).toBe(first[0]);
+    expect(microphone.playbacks).toHaveLength(1);
   });
 
-  it("duration is always 0", () => {
-    const mic = new MicrophoneStream(context);
-    expect(mic.duration).toBe(0);
+  it("supports HRTF options", () => {
+    const microphone = new MicrophoneStream(context, mockStream, undefined, {
+      panType: "HRTF",
+      threeDOptions: { positionX: 4, positionY: 2, positionZ: -1 },
+    });
+
+    expect(microphone.position).toEqual([4, 2, -1]);
+    const [playback] = microphone.play();
+
+    expect(playback.panType).toBe("HRTF");
+    expect(playback.position).toEqual([4, 2, -1]);
   });
 
-  it("loop always returns 0", () => {
-    const mic = new MicrophoneStream(context);
-    expect(mic.loop()).toBe(0);
-    expect(mic.loop(5)).toBe(0);
+  it("supports configurable stereo panning", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const cacophony = new Cacophony(context as any);
+
+    const microphone = await cacophony.getMicrophoneStream({
+      panType: "stereo",
+      stereoPan: -0.25,
+    });
+    const [playback] = microphone.play();
+
+    expect(playback.panType).toBe("stereo");
+    expect(playback.stereoPan).toBe(-0.25);
   });
 
-  it("playbackRate is always 1", () => {
-    const mic = new MicrophoneStream(context);
-    expect(mic.playbackRate).toBe(1);
-    mic.playbackRate = 2;
-    expect(mic.playbackRate).toBe(1);
-  });
-
-  it("connects the internal microphoneGainNode to the provided outputNode", () => {
-    // Regression test for routing bug: MicrophoneStream previously created
-    // a microphoneGainNode that was never connected to anything downstream,
-    // so volume/mute on the chain were inaudible. The fix wires the gain
-    // node through an optional outputNode in the constructor.
-    // See notes/scout-routing-graph.md ("MicrophonePlayback" / dangling
-    // gain node observation).
-    const outputNode = context.createGain();
-    const microphone = new MicrophoneStream(context, mockStream, outputNode);
-    const microphoneGainNode = (
-      microphone as unknown as {
-        microphoneGainNode: GainNode;
-      }
-    ).microphoneGainNode;
-
-    expectPath(microphoneGainNode, [], outputNode);
-  });
-
-  it.skip("routes Cacophony microphone monitoring through the master bus (#102)", async () => {
+  it("routes Cacophony microphone monitoring through the master bus (#102)", async () => {
     (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
     const cacophony = new Cacophony(context as any);
 
     const microphone = await cacophony.getMicrophoneStream();
-    const microphoneGainNode = (
-      microphone as unknown as {
-        microphoneGainNode: GainNode;
-      }
-    ).microphoneGainNode;
+    const [playback] = microphone.play();
 
-    expectPath(microphoneGainNode, [], cacophony.master.input);
+    expectPath(playback.outputNode, [], cacophony.master.input);
+    expectReachable(playback.source!, cacophony.master.input);
+    cacophony.mute();
+    expect(cacophony.master.input.gain.value).toBe(0);
+  });
+
+  it("routes a directly constructed microphone to its provided output", () => {
+    const outputNode = context.createGain();
+    const microphone = new MicrophoneStream(context, mockStream, outputNode);
+
+    const [playback] = microphone.play();
+
+    expectPath(playback.outputNode, [], outputNode);
+  });
+
+  it("stop tears down the graph, tracks, and playback state", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const cacophony = new Cacophony(context as any);
+    const microphone = await cacophony.getMicrophoneStream();
+    const [playback] = microphone.play();
+    const source = playback.source!;
+
+    expectReachable(source, cacophony.master.input);
+    microphone.stop();
+
+    expectNotReachable(source, cacophony.master.input);
+    expect(microphone.playbacks).toEqual([]);
+    expect(mockTrack.stop).toHaveBeenCalledOnce();
+  });
+
+  it("retains live-stream duration, loop, and playback-rate contracts", () => {
+    const microphone = new MicrophoneStream(context, mockStream);
+    const [playback] = microphone.play();
+
+    expect(playback.duration).toBe(0);
+    expect(microphone.loop(4)).toBe(0);
+    expect(microphone.playbackRate).toBe(1);
+    microphone.playbackRate = 2;
+    expect(microphone.playbackRate).toBe(1);
   });
 });

--- a/src/microphone.ts
+++ b/src/microphone.ts
@@ -1,259 +1,66 @@
-import type { BaseSound, LoopCount, Position } from "./cacophony";
-import type {
-  AudioNode,
-  BaseContext,
-  BiquadFilterNode,
-  GainNode,
-  MediaStreamAudioSourceNode,
-  PannerNode,
-} from "./context";
-import { FilterManager } from "./filters";
+import type { Cacophony, PanType } from "./cacophony";
+import type { AudioNode, BaseContext, GainNode } from "./context";
+import { MediaStreamPlayback, MediaStreamSound, type MediaStreamSoundOptions } from "./mediaStream";
+import type { HrtfPannerOptions } from "./pannerMixin";
 
-export class MicrophonePlayback extends FilterManager {
-  private context: BaseContext;
-  private source?: MediaStreamAudioSourceNode;
-  private gainNode?: GainNode;
-  private panner?: PannerNode;
-
-  constructor(source: MediaStreamAudioSourceNode, gainNode: GainNode, context: BaseContext, loopCount: LoopCount = 0) {
-    super();
-    this.source = source;
-    this.gainNode = gainNode;
-    this.context = context;
-    this.panner = context.createPanner();
-    source.connect(this.panner).connect(this.gainNode);
-    this.refreshFilters();
-  }
-
-  get duration() {
-    return 0;
-  }
-
-  play() {
-    if (!this.source) {
-      throw new Error("Cannot play a sound that has been cleaned up");
-    }
-    return [this];
-  }
-
-  /**
-   * Indicates whether the audio is currently playing.
-   */
-
-  get isPlaying() {
-    return Boolean(this.source);
-  }
-
-  get volume(): number {
-    if (!this.gainNode) {
-      throw new Error("Cannot get volume of a sound that has been cleaned up");
-    }
-    return this.gainNode.gain.value;
-  }
-
-  set volume(v: number) {
-    if (!this.gainNode) {
-      throw new Error("Cannot set volume of a sound that has been cleaned up");
-    }
-    this.gainNode.gain.value = v;
-  }
-
-  stop(): void {
-    if (!this.source) {
-      throw new Error("Cannot stop a sound that has been cleaned up");
-    }
-    this.source.mediaStream.getTracks().forEach((track) => track.stop());
-  }
-
-  pause(): void {
-    if (!this.source) {
-      throw new Error("Cannot pause a sound that has been cleaned up");
-    }
-    this.source.mediaStream.getTracks().forEach((track) => (track.enabled = false));
-  }
-
-  resume(): void {
-    if (!this.source) {
-      throw new Error("Cannot resume a sound that has been cleaned up");
-    }
-    this.source.mediaStream.getTracks().forEach((track) => (track.enabled = true));
-  }
-
-  addFilter(filter: BiquadFilterNode): void {
-    super.addFilter(filter);
-    this.refreshFilters();
-  }
-
-  removeFilter(filter: BiquadFilterNode): void {
-    super.removeFilter(filter);
-    this.refreshFilters();
-  }
-
-  set position(position: Position) {
-    if (!this.panner) {
-      throw new Error("Cannot move a sound that has been cleaned up");
-    }
-    const [x, y, z] = position;
-    this.panner.positionX.value = x;
-    this.panner.positionY.value = y;
-    this.panner.positionZ.value = z;
-  }
-
-  get position(): Position {
-    if (!this.panner) {
-      throw new Error("Cannot get position of a sound that has been cleaned up");
-    }
-    return [this.panner.positionX.value, this.panner.positionY.value, this.panner.positionZ.value];
-  }
-
-  private refreshFilters(): void {
-    if (!this.panner || !this.gainNode) {
-      throw new Error("Cannot update filters on a sound that has been cleaned up");
-    }
-    let connection: AudioNode = this.panner;
-    connection.disconnect();
-    connection = this.applyFilters(connection);
-    connection.connect(this.gainNode);
-  }
-
-  get playbackRate(): number {
-    // Playback rate is not applicable for live microphone stream
-    return 1;
-  }
-
-  set playbackRate(rate: number) {}
+/** Options for acquiring and monitoring a microphone stream. */
+export interface MicrophoneStreamOptions extends Omit<MediaStreamSoundOptions, "stopTracksOnStop"> {
+  /** Constraints forwarded to `navigator.mediaDevices.getUserMedia`. */
+  constraints?: MediaStreamConstraints;
+  /** Initial left/right pan when `panType` is `"stereo"`. */
+  stereoPan?: number;
+  /** Initial spatial options when `panType` is `"HRTF"` (the default). */
+  threeDOptions?: Partial<HrtfPannerOptions>;
 }
 
-export class MicrophoneStream extends FilterManager implements BaseSound {
-  context: BaseContext;
-  private _position: Position = [0, 0, 0];
-  loopCount: LoopCount = 0;
-  private prevVolume: number = 1;
-  private microphoneGainNode: GainNode;
-  private streamPlayback?: MicrophonePlayback;
-  private stream: MediaStream | undefined;
-  private streamSource?: MediaStreamAudioSourceNode;
+/**
+ * A microphone playback uses the same BasePlayback lifecycle, event, panning,
+ * effect, routing, and cleanup implementation as every other MediaStream.
+ */
+export { MediaStreamPlayback as MicrophonePlayback };
 
-  constructor(context: BaseContext, stream?: MediaStream, outputNode?: AudioNode) {
-    super();
-    this.context = context;
-    this.microphoneGainNode = this.context.createGain();
-    // Wire the microphone gain node into the audio graph. Without this
-    // connection the gain node is dangling and volume/mute on the chain
-    // have no audible effect. Callers should pass the shared
-    // `globalGainNode` so global volume applies; otherwise we fall back
-    // to `context.destination` so the chain is at least reachable.
-    this.microphoneGainNode.connect(outputNode ?? this.context.destination);
-    if (stream) {
-      this.stream = stream;
-      this.streamSource = this.createStreamSource(stream);
+/**
+ * A live microphone source backed by the current MediaStreamSound architecture.
+ * Use {@link MicrophoneStream.request} (or `Cacophony.getMicrophoneStream`) when
+ * the stream still needs to be acquired so permission failures remain observable.
+ */
+export class MicrophoneStream extends MediaStreamSound {
+  static async request(
+    context: BaseContext,
+    outputNode?: AudioNode,
+    options: MicrophoneStreamOptions = {},
+    cacophony?: Cacophony,
+  ): Promise<MicrophoneStream> {
+    const stream = await navigator.mediaDevices.getUserMedia(options.constraints ?? { audio: true });
+    return new MicrophoneStream(context, stream, outputNode, options, cacophony);
+  }
+
+  constructor(
+    context: BaseContext,
+    stream: MediaStream,
+    outputNode?: AudioNode,
+    options: MicrophoneStreamOptions = {},
+    cacophony?: Cacophony,
+  ) {
+    const { constraints: _constraints, stereoPan, threeDOptions, ...mediaStreamOptions } = options;
+    const panType: PanType = mediaStreamOptions.panType ?? "HRTF";
+    super(
+      stream,
+      context,
+      (outputNode ?? context.destination) as GainNode,
+      {
+        ...mediaStreamOptions,
+        panType,
+        primeWithMediaElement: mediaStreamOptions.primeWithMediaElement ?? false,
+        stopTracksOnStop: true,
+      },
+      cacophony,
+    );
+
+    if (panType === "stereo") {
+      this.stereoPan = stereoPan ?? 0;
+    } else if (threeDOptions) {
+      this.threeDOptions = threeDOptions;
     }
   }
-
-  private createStreamSource(stream: MediaStream): MediaStreamAudioSourceNode {
-    if (!this.context.createMediaStreamSource) {
-      throw new Error("Media stream sources are not supported on this audio context (e.g. OfflineAudioContext).");
-    }
-    return this.context.createMediaStreamSource(stream);
-  }
-
-  play(): MicrophonePlayback[] {
-    if (!this.stream) {
-      navigator.mediaDevices
-        .getUserMedia({ audio: true })
-        .then((stream) => {
-          this.stream = stream;
-          this.streamSource = this.createStreamSource(this.stream);
-          this.streamPlayback = new MicrophonePlayback(this.streamSource, this.microphoneGainNode, this.context);
-          this.streamPlayback.play();
-        })
-        .catch((err) => {
-          console.error("Error initializing microphone stream:", err);
-        });
-      return [];
-    }
-    if (!this.streamPlayback) {
-      this.streamSource = this.streamSource ?? this.createStreamSource(this.stream);
-      this.streamPlayback = new MicrophonePlayback(this.streamSource, this.microphoneGainNode, this.context);
-    }
-    return [this.streamPlayback];
-  }
-
-  get duration() {
-    return 0;
-  }
-
-  seek(time: number) {
-    // Seeking is not applicable for live microphone stream
-  }
-
-  /**
-   * A boolean indicating whether the sound is currently playing.
-   */
-
-  get isPlaying(): boolean {
-    return Boolean(this.streamPlayback);
-  }
-
-  stop() {
-    if (this.streamPlayback) {
-      this.streamPlayback.stop();
-      this.streamPlayback = undefined;
-    }
-  }
-
-  pause() {
-    if (this.streamPlayback) {
-      this.streamPlayback.pause();
-    }
-  }
-
-  resume() {
-    if (this.streamPlayback) {
-      this.streamPlayback.resume();
-    }
-  }
-
-  addFilter(filter: BiquadFilterNode): void {
-    if (this.streamPlayback) {
-      this.streamPlayback.addFilter(filter);
-    }
-  }
-
-  removeFilter(filter: BiquadFilterNode): void {
-    if (this.streamPlayback) {
-      this.streamPlayback.removeFilter(filter);
-    }
-  }
-
-  get volume(): number {
-    return this.streamPlayback ? this.streamPlayback.volume : 0;
-  }
-
-  set volume(volume: number) {
-    if (this.streamPlayback) {
-      this.streamPlayback.volume = volume;
-    }
-  }
-
-  get position(): Position {
-    // Position is not applicable for live microphone stream
-    return [0, 0, 0];
-  }
-
-  set position(position: Position) {
-    // Position is not applicable for live microphone stream
-  }
-
-  loop(loopCount?: LoopCount): LoopCount {
-    // Looping is not applicable for live microphone stream
-    return 0;
-  }
-
-  get playbackRate(): number {
-    // Playback rate is not applicable for live microphone stream
-    return 1;
-  }
-
-  set playbackRate(rate: number) {}
 }


### PR DESCRIPTION
## Summary

- rebuild microphone monitoring on the shared MediaStreamSound/BasePlayback architecture
- route Cacophony microphone output through the master bus
- expose observable async acquisition failures and configurable constraints/panning
- verify lifecycle events and deterministic graph teardown

## TDD evidence

- Red: five focused acceptance tests failed on the legacy implementation (async factory, master routing, stereo panning, lifecycle events, and cleanup reachability)
- Green: focused microphone/media-stream suite passed 26 tests
- `npm run lint`
- `npm run ci:test` (1,074 passed, no type errors)
- `npm run build` (successful; existing TS4094 and TypeDoc warnings remain)

Closes #102
Closes #110