### PR TITLE
Define media-element streaming contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,40 @@ decoded by WebCodecs, `createStream()` returns the compatibility
 media-element tier. Its `streamCapabilities.transport` is `'media-element'`;
 the browser owns buffering, seeking, and live-stream behavior in that tier.
 
+### Media-element streaming contract
+
+`createSound(url, 'streaming')` selects the media-element tier directly.
+`createStream(url)` returns the same tier when WebCodecs is unavailable or
+cannot decode the primary track, and always uses it for HLS. After metadata
+loads, `streamCapabilities` reports the browser's duration and whether it
+currently exposes a seekable range. A live source has `live: true` and
+`duration: Infinity`; an ordinary finite resource reports its real duration.
+The `Sound` itself has `duration === NaN` while unplayed because it has no
+playback yet. After `preplay()` or `play()`, `sound.duration` and
+`playback.duration` read the loaded media element and return the finite value
+or `Infinity` for a live source.
+
+Media playback moves from unplayed to playing only after the element's
+`play()` promise resolves. `pause()` moves it to paused, `resume()` calls
+`play()` again and returns it to playing, and `stop()` moves it to stopped and
+resets it. Playback events follow those accepted transitions: `play`, `pause`,
+then both `play` and `resume` on a resume, followed by `stop`. The owning
+`Sound` emits `play` after the initial accepted play, plus its collective
+`pause`, `resume`, and `stop` events.
+
+`seek(time)` writes the media element's `currentTime` only when the browser
+exposes a seekable range. A live or finite media source without such a range
+throws a descriptive error and remains at its current position. Infinite
+looping uses the media element's native `loop`; finite loop counts are managed
+by Cacophony and emit `loopEnd` between iterations before the final `ended`.
+
+Every `preplay()` creates an independent media element, so a media-backed
+`Sound` supports concurrent playback instances. `cleanup()` pauses each
+element, clears its `src`, calls `load()` to release the resource, disconnects
+its Web Audio nodes, and removes the playback. Offline `timeStretch()` requires
+a decoded `AudioBuffer`, so calling `timeStretch()` on this tier throws a
+predictable buffer-required error.
+
 For audio that arrives as decoded samples instead of a URL, use the
 AudioWorklet-backed push source:
 

--- a/src/media-element-rejection.test.ts
+++ b/src/media-element-rejection.test.ts
@@ -239,6 +239,8 @@ describe("Media element play() rejection", () => {
 
   it("cleanup() tears down active HTML playback", async () => {
     const mediaElement = {
+      src: "https://example.com/html-audio.mp3",
+      load: vi.fn(),
       play: vi.fn().mockResolvedValue(undefined),
       pause: vi.fn(),
       currentTime: 0,
@@ -266,6 +268,8 @@ describe("Media element play() rejection", () => {
     htmlSound.cleanup();
 
     expect(mediaElement.pause).toHaveBeenCalledTimes(1);
+    expect(mediaElement.src).toBe("");
+    expect(mediaElement.load).toHaveBeenCalledOnce();
     expect(mediaElement.currentTime).toBe(0);
     expect(mediaElement.loop).toBe(false);
     expect(mediaElement.onended).toBeNull();

--- a/src/media-streaming-contract.test.ts
+++ b/src/media-streaming-contract.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cacophony } from "./setupTests";
+
+type MockMediaElement = HTMLAudioElement & {
+  load: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  play: ReturnType<typeof vi.fn>;
+};
+
+function createMediaElement(options: { duration?: number; seekable?: boolean } = {}): MockMediaElement {
+  const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+  const duration = options.duration ?? 60;
+  const seekable = options.seekable ?? true;
+  const audio = {
+    src: "",
+    crossOrigin: null,
+    preload: "auto",
+    error: null,
+    currentTime: 0,
+    duration,
+    loop: false,
+    playbackRate: 1,
+    onended: null as (() => void) | null,
+    seekable: {
+      length: seekable ? 1 : 0,
+      start: () => 0,
+      end: () => (Number.isFinite(duration) ? duration : 0),
+    },
+    load: vi.fn(() => {
+      if (!audio.src) {
+        return;
+      }
+      queueMicrotask(() => {
+        const event = new Event("loadedmetadata");
+        for (const listener of listeners.get("loadedmetadata") ?? []) {
+          if (typeof listener === "function") {
+            listener.call(audio, event);
+          } else {
+            listener.handleEvent(event);
+          }
+        }
+      });
+    }),
+    play: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      listeners.set(type, listeners.get(type) ?? new Set());
+      listeners.get(type)?.add(listener);
+    }),
+    removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      listeners.get(type)?.delete(listener);
+    }),
+  };
+  return audio as unknown as MockMediaElement;
+}
+
+function useMediaElements(...elements: MockMediaElement[]): void {
+  for (const element of elements) {
+    vi.mocked(global.Audio).mockImplementationOnce(function MockStreamingAudio() {
+      return element;
+    });
+  }
+}
+
+async function createStreamingSound(entrypoint: "createSound" | "createStream", element: MockMediaElement) {
+  useMediaElements(element);
+  if (entrypoint === "createStream") {
+    return cacophony.createStream("https://example.com/radio.mp3");
+  }
+  return cacophony.createSound("https://example.com/radio.mp3", "streaming");
+}
+
+describe("media-element streaming public contract", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    "createSound",
+    "createStream",
+  ] as const)("%s exposes the media tier's metadata-backed capabilities", async (entrypoint) => {
+    const element = createMediaElement({ duration: 42, seekable: true });
+    const sound = await createStreamingSound(entrypoint, element);
+
+    expect(sound.streamCapabilities).toEqual({
+      duration: 42,
+      live: false,
+      seekable: true,
+      transport: "media-element",
+    });
+    expect(Number.isNaN(sound.duration)).toBe(true);
+
+    const [playback] = sound.preplay();
+    expect(playback.duration).toBe(42);
+    expect(sound.duration).toBe(42);
+    expect(() => sound.timeStretch(2)).toThrow(
+      "Sound.timeStretch requires a buffer-based sound (a loaded AudioBuffer).",
+    );
+    sound.cleanup();
+  });
+
+  it("moves through play, pause, resume, and stop states with the documented events", async () => {
+    const element = createMediaElement();
+    const sound = await createStreamingSound("createSound", element);
+    const soundEvents: string[] = [];
+    const playbackEvents: string[] = [];
+    sound.on("play", () => soundEvents.push("play"));
+    sound.on("pause", () => soundEvents.push("pause"));
+    sound.on("resume", () => soundEvents.push("resume"));
+    sound.on("stop", () => soundEvents.push("stop"));
+
+    const [playback] = sound.play();
+    playback.on("play", () => playbackEvents.push("play"));
+    playback.on("pause", () => playbackEvents.push("pause"));
+    playback.on("resume", () => playbackEvents.push("resume"));
+    playback.on("stop", () => playbackEvents.push("stop"));
+
+    expect(playback.isPlaying).toBe(false);
+    await vi.waitFor(() => expect(playback.isPlaying).toBe(true));
+    expect(soundEvents).toEqual(["play"]);
+    expect(playbackEvents).toEqual(["play"]);
+
+    sound.pause();
+    expect(playback.isPaused).toBe(true);
+    expect(soundEvents).toEqual(["play", "pause"]);
+    expect(playbackEvents).toEqual(["play", "pause"]);
+
+    sound.resume();
+    await vi.waitFor(() => expect(playback.isPlaying).toBe(true));
+    expect(soundEvents).toEqual(["play", "pause", "resume"]);
+    expect(playbackEvents).toEqual(["play", "pause", "play", "resume"]);
+
+    sound.stop();
+    expect(playback.isPlaying).toBe(false);
+    expect(playback.source).toBeUndefined();
+    expect(sound.playbacks).toEqual([]);
+    expect(soundEvents).toEqual(["play", "pause", "resume", "stop"]);
+    expect(playbackEvents).toEqual(["play", "pause", "play", "resume", "stop"]);
+  });
+
+  it("seeks media only when the browser exposes a seekable range", async () => {
+    const finiteElement = createMediaElement({ duration: 90, seekable: true });
+    const finiteSound = await createStreamingSound("createSound", finiteElement);
+    finiteSound.preplay();
+
+    finiteSound.seek(12.5);
+    expect(finiteElement.currentTime).toBe(12.5);
+    finiteSound.cleanup();
+
+    const liveElement = createMediaElement({ duration: Number.POSITIVE_INFINITY, seekable: false });
+    const liveSound = await createStreamingSound("createSound", liveElement);
+    liveSound.preplay();
+
+    expect(liveSound.streamCapabilities).toEqual({
+      duration: Number.POSITIVE_INFINITY,
+      live: true,
+      seekable: false,
+      transport: "media-element",
+    });
+    expect(liveSound.duration).toBe(Number.POSITIVE_INFINITY);
+    expect(() => liveSound.seek(5)).toThrow("Live media-element streams do not expose a seekable range");
+    expect(liveElement.currentTime).toBe(0);
+    liveSound.cleanup();
+  });
+
+  it("applies infinite looping to every newly prepared media element", async () => {
+    const firstElement = createMediaElement();
+    const secondElement = createMediaElement();
+    useMediaElements(firstElement, secondElement);
+    const sound = await cacophony.createSound("https://example.com/loop.mp3", "streaming");
+
+    sound.loop("infinite");
+    sound.preplay();
+    sound.preplay();
+
+    expect(firstElement.loop).toBe(true);
+    expect(secondElement.loop).toBe(true);
+    sound.cleanup();
+  });
+
+  it("manages finite media loops and reports each repeated iteration", async () => {
+    const element = createMediaElement();
+    const sound = await createStreamingSound("createSound", element);
+    const loopEnd = vi.fn();
+    const ended = vi.fn();
+    sound.on("loopEnd", loopEnd);
+    sound.on("ended", ended);
+    sound.loop(2);
+
+    const [playback] = sound.play();
+    await vi.waitFor(() => expect(playback.isPlaying).toBe(true));
+    expect(element.loop).toBe(false);
+
+    element.onended?.(new Event("ended"));
+    await vi.waitFor(() => expect(loopEnd).toHaveBeenCalledTimes(1));
+    element.onended?.(new Event("ended"));
+    await vi.waitFor(() => expect(loopEnd).toHaveBeenCalledTimes(2));
+    element.onended?.(new Event("ended"));
+
+    await vi.waitFor(() => expect(ended).toHaveBeenCalledOnce());
+    expect(playback.isPlaying).toBe(false);
+    expect(sound.playbacks).toEqual([]);
+  });
+
+  it("creates an independent media element for every preplay call", async () => {
+    const firstElement = createMediaElement();
+    const secondElement = createMediaElement();
+    useMediaElements(firstElement, secondElement);
+    const sound = await cacophony.createSound("https://example.com/concurrent.mp3", "streaming");
+
+    const [firstPlayback] = sound.preplay();
+    const [secondPlayback] = sound.preplay();
+
+    expect(firstPlayback).not.toBe(secondPlayback);
+    expect(firstPlayback.source).not.toBe(secondPlayback.source);
+    expect((firstPlayback.source as { mediaElement: HTMLMediaElement }).mediaElement).toBe(firstElement);
+    expect((secondPlayback.source as { mediaElement: HTMLMediaElement }).mediaElement).toBe(secondElement);
+    sound.cleanup();
+  });
+
+  it("pauses, clears, and reloads every media element during cleanup", async () => {
+    const element = createMediaElement();
+    const sound = await createStreamingSound("createSound", element);
+    sound.preplay();
+
+    sound.cleanup();
+
+    expect(element.pause).toHaveBeenCalled();
+    expect(element.src).toBe("");
+    expect(element.load).toHaveBeenCalledTimes(2);
+    expect(sound.playbacks).toEqual([]);
+  });
+});

--- a/src/playback.test.ts
+++ b/src/playback.test.ts
@@ -353,6 +353,7 @@ describe("Playback cloning for media-element-backed playback", () => {
   let originalPlayback: Playback;
   let originalMediaElement: {
     cloneNode: ReturnType<typeof vi.fn>;
+    load: ReturnType<typeof vi.fn>;
     play: ReturnType<typeof vi.fn>;
     pause: ReturnType<typeof vi.fn>;
     onended: null | (() => void);
@@ -360,8 +361,10 @@ describe("Playback cloning for media-element-backed playback", () => {
     currentTime: number;
     duration: number;
     playbackRate: number;
+    src: string;
   };
   let clonedMediaElement: {
+    load: ReturnType<typeof vi.fn>;
     play: ReturnType<typeof vi.fn>;
     pause: ReturnType<typeof vi.fn>;
     onended: null | (() => void);
@@ -369,6 +372,7 @@ describe("Playback cloning for media-element-backed playback", () => {
     currentTime: number;
     duration: number;
     playbackRate: number;
+    src: string;
   };
   let gainNode: GainNode;
   let sound: Sound;
@@ -376,6 +380,7 @@ describe("Playback cloning for media-element-backed playback", () => {
 
   beforeEach(() => {
     clonedMediaElement = {
+      load: vi.fn(),
       play: vi.fn(() => Promise.resolve()),
       pause: vi.fn(),
       onended: null,
@@ -383,9 +388,11 @@ describe("Playback cloning for media-element-backed playback", () => {
       currentTime: 0,
       duration: 10,
       playbackRate: 1,
+      src: "test-url",
     };
     originalMediaElement = {
       cloneNode: vi.fn(() => clonedMediaElement),
+      load: vi.fn(),
       play: vi.fn(() => Promise.resolve()),
       pause: vi.fn(),
       onended: null,
@@ -393,6 +400,7 @@ describe("Playback cloning for media-element-backed playback", () => {
       currentTime: 0,
       duration: 10,
       playbackRate: 1,
+      src: "test-url",
     };
 
     // Mock createMediaElementSource to return a source wrapping whichever

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -455,6 +455,17 @@ export class Playback extends BasePlayback implements BaseSound {
       throw new Error("Invalid time value for seek");
     }
 
+    if (
+      this.origin.soundType === "streaming" &&
+      "mediaElement" in this.source &&
+      (this.source.mediaElement.seekable?.length ?? 0) === 0
+    ) {
+      if (this.source.mediaElement.duration === Number.POSITIVE_INFINITY) {
+        throw new Error("Live media-element streams do not expose a seekable range");
+      }
+      throw new Error("Media-element stream does not currently expose a seekable range");
+    }
+
     const wasPlaying = this._state === "playing";
     if (wasPlaying) {
       this.pause();
@@ -544,10 +555,17 @@ export class Playback extends BasePlayback implements BaseSound {
       return; // Already cleaned up
     }
     if ("mediaElement" in this.source && this.source.mediaElement) {
-      this.source.mediaElement.pause();
-      this.source.mediaElement.currentTime = 0;
-      this.source.mediaElement.loop = false;
-      this.source.mediaElement.onended = null;
+      const mediaElement = this.source.mediaElement;
+      mediaElement.pause();
+      try {
+        mediaElement.currentTime = 0;
+      } catch {
+        // Live media without a seekable range can reject currentTime writes.
+      }
+      mediaElement.loop = false;
+      mediaElement.onended = null;
+      mediaElement.src = "";
+      mediaElement.load();
     } else if ("onended" in this.source) {
       this.source.onended = null;
     }

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -242,6 +242,7 @@ export class Sound extends RoutableSource implements BaseSound {
       playback.setGainNode(gainNode);
       playback.volume = this.volume;
       playback.playbackRate = this.playbackRate;
+      playback.loop(this.loopCount);
       // Carry the Sound's pitch-shift factor onto the new playback. Building the
       // phase-vocoder worklet node is async; preplay is sync, so this is a
       // fire-and-forget that splices the node in once the worklet resolves


### PR DESCRIPTION
## Summary

- define the media-element streaming lifecycle, duration, seeking, looping, concurrency, cleanup, and unsupported-operation contract through the public API
- reject seeks when a streaming media element exposes no seekable range
- apply configured loops to newly prepared media playbacks and fully release media resources during cleanup
- document the media tier separately from the WebCodecs streaming tier

## Root cause

The media tier relied on generic playback behavior without one public contract suite. That left three accidental gaps: unseekable live media accepted `currentTime` writes, loop settings made before playback were not applied to new elements, and active cleanup did not clear and reload the media source.

## Validation

- TDD red: 3 failed, 4 passed
- focused green: 8 passed
- related media/playback slice: 237 passed
- `npm run ci:test`: 75 files, 1,082 tests passed; no type errors
- `npm run lint`
- `npm run build` (completed with the existing TS4094 declaration diagnostics)

Closes #59
