### PR TITLE
Dedupe AudioCache fetch/decode pipeline

### DIFF
--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -185,6 +185,61 @@ describe("AudioCache", () => {
     consoleErrorSpy.mockRestore();
   });
 
+  it("routes every network-backed branch through one fetch/decode/cache helper", async () => {
+    const urls = [
+      "https://example.com/no-cache-api.mp3",
+      "https://example.com/cache-miss.mp3",
+      "https://example.com/inconsistent-cache.mp3",
+    ];
+    const encodedAudio = new ArrayBuffer(8);
+    const decodedAudio = urls.map((_, index) => audioBufferShape(index + 1));
+    const fetchDecodeAndCacheSpy = vi.spyOn(
+      cache as unknown as AudioCache & {
+        fetchDecodeAndCache: (...args: unknown[]) => Promise<AudioBuffer>;
+      },
+      "fetchDecodeAndCache",
+    );
+
+    mockFetch.mockImplementation(() => Promise.resolve(new Response(encodedAudio, { status: 200 })));
+    vi.spyOn(audioContextMock, "decodeAudioData")
+      .mockResolvedValueOnce(decodedAudio[0])
+      .mockResolvedValueOnce(decodedAudio[1])
+      .mockResolvedValueOnce(decodedAudio[2]);
+
+    global.caches = undefined as unknown as CacheStorage;
+    await expect(cache.getAudioBuffer(audioContextMock, urls[0])).resolves.toBe(decodedAudio[0]);
+
+    const cacheMiss = {
+      match: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
+    };
+    const inconsistentCache = {
+      match: vi.fn().mockImplementation((key: string) =>
+        Promise.resolve(
+          key.endsWith(":meta")
+            ? new Response(
+                JSON.stringify({
+                  url: urls[2],
+                  cacheControl: "max-age=3600",
+                  timestamp: Date.now(),
+                }),
+              )
+            : null,
+        ),
+      ),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(true),
+    };
+    mockCaches.open = vi.fn().mockResolvedValueOnce(cacheMiss).mockResolvedValueOnce(inconsistentCache);
+    global.caches = mockCaches;
+
+    await expect(cache.getAudioBuffer(audioContextMock, urls[1])).resolves.toBe(decodedAudio[1]);
+    await expect(cache.getAudioBuffer(audioContextMock, urls[2])).resolves.toBe(decodedAudio[2]);
+
+    expect(fetchDecodeAndCacheSpy).toHaveBeenCalledTimes(3);
+  });
+
   it("handles 304 Not Modified responses correctly when cache expires", async () => {
     const url = "https://example.com/audio.mp3";
     const mockAudioBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -675,6 +675,62 @@ export class AudioCache implements ICache {
     return await fetchResponse.arrayBuffer();
   }
 
+  /**
+   * Run the shared network-result pipeline: fetch bytes, decode them, emit
+   * loading callbacks, and retain the decoded buffer in the in-memory LRU.
+   * The caller supplies the fetch strategy so persistent-cache and degraded
+   * runtimes share this plumbing without changing their network behavior.
+   */
+  private async fetchDecodeAndCache(
+    context: BaseContext,
+    url: string,
+    decodedBuffers: ByteBoundedLRUCache<string, AudioBuffer>,
+    fetchBuffer: () => Promise<ArrayBuffer>,
+    callbacks?: Pick<CacheCallbacks, "onLoadingComplete" | "onLoadingError" | "onCacheError">,
+    reportCacheError = false,
+  ): Promise<AudioBuffer> {
+    try {
+      const arrayBuffer = await fetchBuffer();
+      let audioBuffer: AudioBuffer;
+      try {
+        audioBuffer = await AudioCache.decodeAudioData(context, arrayBuffer);
+      } catch (error) {
+        callbacks?.onLoadingError?.({
+          url,
+          error: toError(error),
+          errorType: "decode",
+          timestamp: Date.now(),
+        });
+        throw error;
+      }
+
+      callbacks?.onLoadingComplete?.({
+        url,
+        duration: audioBuffer.duration,
+        size: arrayBuffer.byteLength,
+        timestamp: Date.now(),
+      });
+      decodedBuffers.set(url, audioBuffer);
+      return audioBuffer;
+    } catch (error) {
+      callbacks?.onLoadingError?.({
+        url,
+        error: toError(error),
+        errorType: getNetworkErrorType(error),
+        timestamp: Date.now(),
+      });
+      if (reportCacheError) {
+        callbacks?.onCacheError?.({
+          url,
+          error: toError(error),
+          operation: "get",
+          timestamp: Date.now(),
+        });
+      }
+      throw error;
+    }
+  }
+
   private static async decodeAudioData(context: BaseContext, arrayBuffer: ArrayBuffer): Promise<AudioBuffer> {
     try {
       return await context.decodeAudioData(arrayBuffer);
@@ -790,43 +846,13 @@ export class AudioCache implements ICache {
             });
           }
 
-          try {
-            const arrayBuffer = await this.fetchAndDecodeWithoutCache(context, url, signal);
-            let audioBuffer: AudioBuffer;
-            try {
-              audioBuffer = await AudioCache.decodeAudioData(context, arrayBuffer);
-            } catch (error) {
-              if (callbacks?.onLoadingError) {
-                callbacks.onLoadingError({
-                  url,
-                  error: toError(error),
-                  errorType: "decode",
-                  timestamp: Date.now(),
-                });
-              }
-              throw error;
-            }
-            if (callbacks?.onLoadingComplete) {
-              callbacks.onLoadingComplete({
-                url,
-                duration: audioBuffer.duration,
-                size: arrayBuffer.byteLength,
-                timestamp: Date.now(),
-              });
-            }
-            decodedBuffers.set(url, audioBuffer);
-            return audioBuffer;
-          } catch (error) {
-            if (callbacks?.onLoadingError) {
-              callbacks.onLoadingError({
-                url,
-                error: toError(error),
-                errorType: getNetworkErrorType(error),
-                timestamp: Date.now(),
-              });
-            }
-            throw error;
-          }
+          return await this.fetchDecodeAndCache(
+            context,
+            url,
+            decodedBuffers,
+            () => this.fetchAndDecodeWithoutCache(context, url, signal),
+            callbacks,
+          );
         },
         signal,
         { onLoadingProgress: callbacks?.onLoadingProgress },
@@ -885,58 +911,22 @@ export class AudioCache implements ICache {
             });
           }
 
-          try {
-            const arrayBuffer = await this.fetchAndCacheBuffer(
-              context,
-              url,
-              cache,
-              { etag: metadata?.etag, lastModified: metadata?.lastModified },
-              signal,
-              { onCacheHit: callbacks?.onCacheHit },
-            );
-            let audioBuffer: AudioBuffer;
-            try {
-              audioBuffer = await AudioCache.decodeAudioData(context, arrayBuffer);
-            } catch (error) {
-              if (callbacks?.onLoadingError) {
-                callbacks.onLoadingError({
-                  url,
-                  error: toError(error),
-                  errorType: "decode",
-                  timestamp: Date.now(),
-                });
-              }
-              throw error;
-            }
-            if (callbacks?.onLoadingComplete) {
-              callbacks.onLoadingComplete({
+          return await this.fetchDecodeAndCache(
+            context,
+            url,
+            decodedBuffers,
+            () =>
+              this.fetchAndCacheBuffer(
+                context,
                 url,
-                duration: audioBuffer.duration,
-                size: arrayBuffer.byteLength,
-                timestamp: Date.now(),
-              });
-            }
-            decodedBuffers.set(url, audioBuffer);
-            return audioBuffer;
-          } catch (error) {
-            if (callbacks?.onLoadingError) {
-              callbacks.onLoadingError({
-                url,
-                error: toError(error),
-                errorType: getNetworkErrorType(error),
-                timestamp: Date.now(),
-              });
-            }
-            if (callbacks?.onCacheError) {
-              callbacks.onCacheError({
-                url,
-                error: toError(error),
-                operation: "get",
-                timestamp: Date.now(),
-              });
-            }
-            throw error;
-          }
+                cache,
+                { etag: metadata?.etag, lastModified: metadata?.lastModified },
+                signal,
+                { onCacheHit: callbacks?.onCacheHit },
+              ),
+            callbacks,
+            true,
+          );
         } else {
           // Content should be fresh in cache
           const cachedBuffer = await AudioCache.getBufferFromCache(url, cache);
@@ -965,50 +955,21 @@ export class AudioCache implements ICache {
             }
 
             // Fallback to network if body missing but metadata is fresh
-            try {
-              const arrayBuffer = await this.fetchAndCacheBuffer(
-                context,
-                url,
-                cache,
-                { etag: metadata?.etag, lastModified: metadata?.lastModified },
-                signal,
-                { onCacheHit: callbacks?.onCacheHit },
-              );
-              let audioBuffer: AudioBuffer;
-              try {
-                audioBuffer = await AudioCache.decodeAudioData(context, arrayBuffer);
-              } catch (error) {
-                if (callbacks?.onLoadingError) {
-                  callbacks.onLoadingError({
-                    url,
-                    error: toError(error),
-                    errorType: "decode",
-                    timestamp: Date.now(),
-                  });
-                }
-                throw error;
-              }
-              if (callbacks?.onLoadingComplete) {
-                callbacks.onLoadingComplete({
+            return await this.fetchDecodeAndCache(
+              context,
+              url,
+              decodedBuffers,
+              () =>
+                this.fetchAndCacheBuffer(
+                  context,
                   url,
-                  duration: audioBuffer.duration,
-                  size: arrayBuffer.byteLength,
-                  timestamp: Date.now(),
-                });
-              }
-              decodedBuffers.set(url, audioBuffer);
-              return audioBuffer;
-            } catch (error) {
-              if (callbacks?.onLoadingError) {
-                callbacks.onLoadingError({
-                  url,
-                  error: toError(error),
-                  errorType: getNetworkErrorType(error),
-                  timestamp: Date.now(),
-                });
-              }
-              throw error;
-            }
+                  cache,
+                  { etag: metadata?.etag, lastModified: metadata?.lastModified },
+                  signal,
+                  { onCacheHit: callbacks?.onCacheHit },
+                ),
+              callbacks,
+            );
           }
         }
       },


### PR DESCRIPTION
## Summary
- extract one internal fetchDecodeAndCache pipeline for network-backed audio loads
- keep the existing persistent-cache and degraded fetch strategies while centralizing decode, memory caching, and callback emission
- cover all three callers with a focused delegation regression test

## TDD proof
- Red: focused cache suite failed because fetchDecodeAndCache did not exist; 44 existing tests passed
- Green: focused cache suite passes 45 tests

## Validation
- npm run lint
- npm run ci:test (82 files, 1,106 tests, no type errors)
- npm run build (successful with existing declaration and TypeDoc warnings)

Closes #171