### PR TITLE
Remove stale audio cleanup code

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -1,4 +1,4 @@
-import type { AudioNode, BiquadFilterNode } from "./context";
+import type { BiquadFilterNode } from "./context";
 
 export type FilterCloneOverrides = {
   filters?: BiquadFilterNode[];
@@ -35,24 +35,12 @@ export abstract class FilterManager {
     }
   }
 
-  applyFilters(connection: AudioNode): AudioNode {
-    return this._filters.reduce<AudioNode>((prevConnection, filter) => {
-      prevConnection.connect(filter);
-      return filter;
-    }, connection);
-  }
-
   get filters() {
     return this._filters;
   }
 
   addFilters(filters: BiquadFilterNode[]) {
-    // todo: be more efficient
     filters.forEach((filter) => this.addFilter(filter));
-  }
-
-  removeFilters(filters: BiquadFilterNode[]) {
-    filters.forEach((filter) => this.removeFilter(filter));
   }
 
   cleanup(): void {

--- a/src/sound.test.ts
+++ b/src/sound.test.ts
@@ -414,6 +414,11 @@ describe("Sound class", () => {
     expect(sound.filters.length).toBe(0);
   });
 
+  it("does not expose obsolete bulk filter helpers", () => {
+    expect("applyFilters" in sound).toBe(false);
+    expect("removeFilters" in sound).toBe(false);
+  });
+
   it("removeFilter uses object identity, not property comparison", () => {
     // This test catches the original bug where filters were compared by properties
     // Create two filters with identical properties but different object identities
@@ -1469,7 +1474,7 @@ describe("Sound preplay failure rollback", () => {
     vi.mocked(audioContextMock.createGain).mockImplementation(realCreateGain);
   });
 
-  it("unsubscribes Sound-side listeners when a playback ends naturally", async () => {
+  it("unsubscribes Sound-side listeners synchronously when a playback ends naturally", () => {
     const playback = sound.play()[0];
     // White-box read of the emitter's listener map — Sound-side wiring
     // attached two `playback.on(...)` listeners plus assigned the field
@@ -1481,13 +1486,10 @@ describe("Sound preplay failure rollback", () => {
     expect(errorBefore).toBeGreaterThan(0);
     expect(playback._loopEndCallback).toBeDefined();
 
-    // Natural end: loopEnded with no loops left fires "ended". Sound's
-    // "ended" listener schedules a microtask that tears down its own
-    // subscriptions via the captured unsubscribe functions (deferred so the
-    // emitter's post-iteration listener re-assignment doesn't overwrite the
-    // off()).
+    // Natural end: loopEnded with no loops left fires "ended". Sound tears
+    // down its subscriptions during the event because TypedEventEmitter
+    // preserves listener removals made inside a listener.
     playback.loopEnded();
-    await Promise.resolve();
 
     // One ended-listener and one error-listener removed (the ones Sound
     // registered); the loopEnd callback field was cleared.

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -267,12 +267,7 @@ export class Sound extends RoutableSource implements BaseSound {
         this.emit("ended", undefined);
         // Natural end: the playback has fired its terminal event; tear down
         // our subscriptions so it can be GC'd without waiting for cleanup().
-        // Deferred to a microtask because the emitter re-assigns its listener
-        // array AFTER the synchronous forEach iteration completes — calling
-        // off() inside the listener would have its removal overwritten by
-        // that re-assignment (see TypedEventEmitter.emit). The microtask
-        // defers the off() until after the emit cycle settles.
-        queueMicrotask(() => this._unsubscribeFromPlayback(playback));
+        this._unsubscribeFromPlayback(playback);
       });
       playback._loopEndCallback = () => {
         this.emit("loopEnd", undefined);

--- a/src/synth.test.ts
+++ b/src/synth.test.ts
@@ -1,5 +1,5 @@
 import { AudioContext } from "standardized-audio-context-mock";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { expectPath } from "./setupTests";
 import { Synth } from "./synth";
 import { SynthPlayback } from "./synthPlayback";
@@ -193,6 +193,21 @@ describe("Synth class", () => {
     const [playback] = synth.preplay();
 
     expectPath(playback.source!, [effect, playback.panner!, playback.outputNode, masterInput], destination);
+  });
+
+  it("lets the effect chain own source disconnection during cleanup", () => {
+    const effect = audioContextMock.createGain();
+    synth.addEffect({ build: () => effect });
+    const [playback] = synth.preplay();
+    const source = playback.source!;
+    const panner = playback.panner!;
+    const disconnectSpy = vi.spyOn(source, "disconnect");
+
+    expectPath(source, [effect, panner, playback.outputNode, masterInput], destination);
+    playback.cleanup();
+
+    expect(disconnectSpy).toHaveBeenCalledWith(effect);
+    expect(disconnectSpy).not.toHaveBeenCalledWith(panner);
   });
 
   it("prevents adding same filter instance twice", () => {

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -105,11 +105,6 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     }
     if (this.panner && this.gainNode) {
       try {
-        this.source.disconnect(this.panner);
-      } catch {
-        // Tolerate already-disconnected source.
-      }
-      try {
         this.panner.disconnect();
       } catch {}
     }


### PR DESCRIPTION
## Summary

- remove the obsolete microtask deferral from natural playback-end listener cleanup
- let `EffectChain` exclusively disconnect synth sources during cleanup
- delete the unused `FilterManager.applyFilters` and `removeFilters` methods and stale efficiency comment

## Root cause

These paths were leftovers from earlier emitter and audio-graph implementations. `TypedEventEmitter` now preserves removals made during dispatch, while `EffectChain` owns the source-side graph edges and teardown.

## TDD evidence

- Red: `npm test -- src/sound.test.ts src/synth.test.ts` failed three new assertions against `master` (3 failed, 97 passed)
- Green: `npm test -- src/sound.test.ts src/synth.test.ts` (100 passed)
- `npm run lint`
- `npm run ci:test`
- `npm run build` (completed with the repository's existing declaration-generation and TypeDoc warnings)

Closes #161
