### PR TITLE
Fix independent Synth cloning

### DIFF
--- a/src/synth.test.ts
+++ b/src/synth.test.ts
@@ -151,6 +151,31 @@ describe("Synth class", () => {
     expect(clone.type).toBe("triangle");
   });
 
+  it("clones oscillator options independently", () => {
+    synth.oscillatorOptions = { frequency: 440, detune: 12, type: "triangle" };
+
+    const clone = synth.clone();
+    clone.frequency = 880;
+    synth.detune = 24;
+
+    expect(synth.frequency).toBe(440);
+    expect(clone.detune).toBe(12);
+    expect(clone.oscillatorOptions).not.toBe(synth.oscillatorOptions);
+  });
+
+  it("honors empty filter and independent position overrides", () => {
+    synth.position = [1, 2, 3];
+    synth.addFilter(audioContextMock.createBiquadFilter());
+    const position: [number, number, number] = [4, 5, 6];
+
+    const clone = synth.clone({ filters: [], position });
+    position[0] = 99;
+
+    expect(clone.filters).toEqual([]);
+    expect(clone.position).toEqual([4, 5, 6]);
+    expect(synth.position).toEqual([1, 2, 3]);
+  });
+
   it("can add and remove filters", () => {
     const filter = audioContextMock.createBiquadFilter();
     synth.addFilter(filter);

--- a/src/synth.ts
+++ b/src/synth.ts
@@ -1,4 +1,4 @@
-import type { BaseSound, Cacophony, PanType, SoundType } from "./cacophony";
+import type { BaseSound, Cacophony, PanType, Position, SoundType } from "./cacophony";
 import type { BaseContext, GainNode, OscillatorNode } from "./context";
 import { TypedEventEmitter } from "./eventEmitter";
 import type { SynthEvents } from "./events";
@@ -70,9 +70,9 @@ export class Synth extends RoutableSource implements BaseSound {
     const panType = overrides.panType ?? this.panType;
     const stereoPan = overrides.stereoPan !== undefined ? overrides.stereoPan : this.stereoPan;
     const volume = overrides.volume !== undefined ? overrides.volume : this.volume;
-    const position = overrides.position?.length ? overrides.position : this.position;
-    const filters = overrides.filters?.length ? overrides.filters : this._filters;
-    const oscillatorOptions = overrides.oscillatorOptions ?? this._oscillatorOptions;
+    const position = overrides.position !== undefined ? overrides.position : this.position;
+    const filters = overrides.filters !== undefined ? overrides.filters : this._filters;
+    const oscillatorOptions = { ...(overrides.oscillatorOptions ?? this._oscillatorOptions) };
 
     const clone = new Synth(
       this.context,
@@ -83,7 +83,7 @@ export class Synth extends RoutableSource implements BaseSound {
       this._cacophony,
     );
     clone._volume = volume;
-    clone._position = position;
+    clone._position = [...position] as Position;
     clone._stereoPan = stereoPan;
     // Apply HRTF override (if provided) through the canonical setter so the
     // discriminated `_threeDOptions` invariant is preserved. Without an override
@@ -92,6 +92,9 @@ export class Synth extends RoutableSource implements BaseSound {
       clone.threeDOptions = overrides.threeDOptions;
     } else if (this.panType === "HRTF") {
       clone.threeDOptions = this.threeDOptions;
+    }
+    if (panType === "HRTF") {
+      clone.position = [...position] as Position;
     }
     clone.addFilters(filters);
     return clone;


### PR DESCRIPTION
## Summary

- clone oscillator options into independent mutable state
- copy and apply HRTF position overrides without retaining caller arrays
- honor explicit empty filter overrides
- add focused regressions for clone independence and empty overrides

## Root cause

`Synth.clone()` reused the original oscillator options object and selected array overrides by length, so clone mutations leaked across instances and empty overrides fell back to the original state.

## Validation

- `npx vitest run src/synth.test.ts --no-color` (red before the fix, 2 failures; green after, 27 tests)
- `npm run lint`
- `npm run ci:test` (82 files, 1,110 tests, no type errors)
- `npm run build`

Closes #156
