### PR TITLE
Dispose duplicate effect graphs on rejection

### DIFF
--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -94,6 +94,32 @@ describe("Bus: addFilter discrimination", () => {
     await expect(bus.addFilter(effect)).rejects.toThrow(/same filter/);
   });
 
+  it("disposes a built graph rejected for a duplicate handle", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const handle = cacophony.context.createGain();
+    const firstGraph = {
+      input: cacophony.context.createGain(),
+      output: cacophony.context.createGain(),
+      handle,
+    };
+    const disposeDuplicate = vi.fn();
+    const duplicateGraph = {
+      input: cacophony.context.createGain(),
+      output: cacophony.context.createGain(),
+      handle,
+      dispose: disposeDuplicate,
+    };
+    const effect = {
+      build: vi.fn().mockReturnValueOnce(firstGraph).mockReturnValueOnce(duplicateGraph),
+    };
+
+    await bus.addFilter(effect);
+
+    await expect(bus.addFilter(effect)).rejects.toThrow(/same filter/);
+    expect(disposeDuplicate).toHaveBeenCalledOnce();
+    expect(bus.filters).toEqual([handle]);
+  });
+
   it("rejects a raw AudioNode (e.g. context.createGain())", async () => {
     const bus = new Bus(cacophony.context, null);
     const raw = cacophony.context.createGain();

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -164,6 +164,9 @@ export class Bus {
     }
     const handle = isBuiltEffectGraph(built) ? (built.handle ?? built.input) : built;
     if (this._effectChain.has(handle)) {
+      if (isBuiltEffectGraph(built)) {
+        built.dispose?.();
+      }
       throw new Error("Cannot add the same filter node to a bus twice");
     }
     return this._effectChain.add(built);

--- a/src/effectChain.test.ts
+++ b/src/effectChain.test.ts
@@ -56,4 +56,24 @@ describe("EffectChain", () => {
     expectPath(input, [], output);
     expect(dispose).toHaveBeenCalledOnce();
   });
+
+  it("disposes a built graph rejected for a duplicate handle", () => {
+    const input = cacophony.context.createGain();
+    const output = cacophony.context.createGain();
+    const handle = cacophony.context.createGain();
+    const firstInput = cacophony.context.createGain();
+    const firstOutput = cacophony.context.createGain();
+    const duplicateInput = cacophony.context.createGain();
+    const duplicateOutput = cacophony.context.createGain();
+    const disposeDuplicate = vi.fn();
+    const chain = new EffectChain(input, output);
+
+    chain.add({ input: firstInput, output: firstOutput, handle });
+
+    expect(() =>
+      chain.add({ input: duplicateInput, output: duplicateOutput, handle, dispose: disposeDuplicate }),
+    ).toThrow(/same effect/);
+    expect(disposeDuplicate).toHaveBeenCalledOnce();
+    expect(chain.nodes).toEqual([handle]);
+  });
 });

--- a/src/effectChain.ts
+++ b/src/effectChain.ts
@@ -59,6 +59,7 @@ export class EffectChain {
     }
     const entry = this.normalize(built);
     if (this.has(entry.handle)) {
+      entry.dispose?.();
       throw new Error("Cannot add the same effect node to a chain twice");
     }
     this.entries.splice(index, 0, entry);


### PR DESCRIPTION
## Summary

- dispose built effect graphs when EffectChain rejects a duplicate handle
- dispose duplicate graphs rejected by Bus after an effect build completes
- preserve the accepted chain entry and add regression coverage for both paths

## Root cause

Ownership transfers when an effect graph finishes building, but both duplicate guards threw before releasing the newly built graph. The existing EffectChain.resolve path already applied the correct disposal policy.

## Validation

- npx vitest run src/effectChain.test.ts src/bus.test.ts --no-color
- npm run lint
- npm run ci:test
- npm run build

Closes #157