### PR TITLE
Make autoplay unlock resilient to later suspension

### DIFF
--- a/src/autoplayUnlock.test.ts
+++ b/src/autoplayUnlock.test.ts
@@ -23,11 +23,11 @@ function createOfflineContextMock(): BaseContext & { startRendering(): Promise<C
 /**
  * Tests for autoplay unlock on first user gesture.
  *
- * The Cacophony constructor installs one-time touchend/click/keydown listeners
- * on document.body when the audio context starts in 'suspended' state. The
- * first fired gesture resumes the context, plays a silent primer buffer
- * (required for iOS Safari to truly unlock), removes the listeners, and emits
- * an `unlock` event.
+ * The Cacophony constructor watches the audio context and installs
+ * touchend/click/keydown listeners on document.body whenever it is suspended.
+ * A gesture resumes the context, plays a silent primer buffer (required for
+ * iOS Safari to truly unlock), removes the listeners, and emits an `unlock`
+ * event. Failed resume attempts re-arm the gesture listeners.
  *
  * Vitest runs in node environment by default — `document` is undefined — so
  * each test that exercises the listener-install path mocks a minimal document
@@ -137,15 +137,39 @@ describe("Autoplay unlock", () => {
       expect(doc.addEventListenerSpy).toHaveBeenCalled();
     });
 
-    it("does NOT install listeners when context.state is 'running'", async () => {
+    it("arms gesture listeners if a context that starts running later suspends", async () => {
       const doc = installMockDocument();
       const ctx = new AudioContext();
       await ctx.resume(); // state -> 'running'
       expect(ctx.state).toBe("running");
 
+      let state: string = "running";
+      Object.defineProperty(ctx, "state", { configurable: true, get: () => state });
+
       new Cacophony(ctx as any, mockCache);
 
       expect(doc.addEventListenerSpy).not.toHaveBeenCalled();
+
+      state = "suspended";
+      ctx.dispatchEvent(new Event("statechange"));
+
+      expect(doc.listenersFor("touchend")).toHaveLength(1);
+      expect(doc.listenersFor("click")).toHaveLength(1);
+      expect(doc.listenersFor("keydown")).toHaveLength(1);
+    });
+
+    it("uses capture and passive gesture listeners", () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+
+      new Cacophony(ctx as any, mockCache);
+
+      for (const eventName of UNLOCK_EVENTS) {
+        expect(doc.addEventListenerSpy).toHaveBeenCalledWith(eventName, expect.any(Function), {
+          capture: true,
+          passive: true,
+        });
+      }
     });
 
     it("does NOT install listeners when autoUnlock is false", () => {
@@ -301,6 +325,31 @@ describe("Autoplay unlock", () => {
       warnSpy.mockRestore();
     });
 
+    it("re-arms listeners after context.resume() rejects so a later gesture can retry", async () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const resumeSpy = vi.spyOn(ctx, "resume").mockRejectedValueOnce(new Error("transient failure"));
+      const onUnlock = vi.fn();
+
+      installAutoplayUnlock({ context: ctx as any, onUnlock });
+
+      doc.fire("click");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onUnlock).not.toHaveBeenCalled();
+      expect(doc.listenersFor("click")).toHaveLength(1);
+
+      doc.fire("click");
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(resumeSpy).toHaveBeenCalledTimes(2);
+      expect(onUnlock).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
     it("emits unlock asynchronously, only after resume() fulfills", async () => {
       const doc = installMockDocument();
       const ctx = new AudioContext();
@@ -352,6 +401,32 @@ describe("Autoplay unlock", () => {
       expect(stopSpy).toHaveBeenCalledWith(0);
       // start must precede stop
       expect(startSpy.mock.invocationCallOrder[0]).toBeLessThan(stopSpy.mock.invocationCallOrder[0]);
+    });
+
+    it("cleanup suppresses an in-flight unlock callback and removes the state watcher", async () => {
+      const doc = installMockDocument();
+      const ctx = new AudioContext();
+      const removeContextListenerSpy = vi.spyOn(ctx, "removeEventListener");
+      let resolveResume!: () => void;
+      vi.spyOn(ctx, "resume").mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveResume = resolve;
+        }),
+      );
+      const onUnlock = vi.fn();
+      const cleanup = installAutoplayUnlock({ context: ctx as any, onUnlock });
+
+      doc.fire("click");
+      cleanup();
+      resolveResume();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onUnlock).not.toHaveBeenCalled();
+      expect(removeContextListenerSpy).toHaveBeenCalledWith("statechange", expect.any(Function));
+      for (const eventName of UNLOCK_EVENTS) {
+        expect(doc.listenersFor(eventName)).toHaveLength(0);
+      }
     });
   });
 

--- a/src/autoplayUnlock.ts
+++ b/src/autoplayUnlock.ts
@@ -13,15 +13,17 @@ import type { BaseContext } from "./context";
  *      gesture's call stack (the iOS "primer").
  *
  * Many callers do (1) but not (2), and hear silence with no obvious cause.
- * This module installs one-time `touchend` / `click` / `keydown` listeners
- * on `document.body` (or `document` as fallback). The first one to fire
- * resumes the context, plays a 1-sample silent primer inside the gesture
- * call stack, removes all three listeners, and calls the `onUnlock` callback.
+ * This module watches the context for suspension and arms `touchend` / `click`
+ * / `keydown` listeners on `document.body` (or `document` as fallback). A
+ * gesture resumes the context, plays a 1-sample silent primer inside the
+ * gesture call stack, removes all three listeners, and calls the `onUnlock`
+ * callback. If the context suspends again, the listeners are re-armed.
  *
  * Design adapted (not copied) from Howler.js `_unlockAudio` — MIT licensed.
  */
 
 const UNLOCK_EVENT_TYPES: ReadonlyArray<"touchend" | "click" | "keydown"> = ["touchend", "click", "keydown"];
+const GESTURE_LISTENER_OPTIONS = { capture: true, passive: true } as const;
 
 /**
  * A `Document`-like type with the methods we need. Avoids a hard dependency
@@ -57,12 +59,12 @@ export interface AutoplayUnlockOptions {
 }
 
 /**
- * Install one-time unlock listeners. Returns a cleanup function that removes
- * the listeners if they have not already fired (e.g. when a `Cacophony`
- * instance is torn down before the user interacts).
+ * Watch for context suspension and install unlock listeners while needed.
+ * Returns a cleanup function that removes both the context watcher and any
+ * armed gesture listeners (e.g. when a `Cacophony` instance is torn down).
  *
- * If the environment is non-browser (`document` is undefined) or the context
- * is not in `suspended` state, this is a no-op and returns a no-op cleanup.
+ * If the environment is non-browser (`document` is undefined), this is a
+ * no-op and returns a no-op cleanup.
  *
  * @internal
  */
@@ -71,12 +73,6 @@ export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
 
   // Server-side / non-browser: nothing to do.
   if (typeof document === "undefined") {
-    return () => {};
-  }
-
-  // Already running: nothing to unlock.
-  const state = (context as unknown as { state?: string }).state;
-  if (state !== "suspended") {
     return () => {};
   }
 
@@ -93,18 +89,27 @@ export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
 
   const doc = document as unknown as DocumentLike;
   const target: EventTargetLike = (doc.body as EventTargetLike | null | undefined) ?? doc;
+  const observableContext = context as unknown as {
+    state?: string;
+    addEventListener?: (type: string, listener: () => void) => void;
+    removeEventListener?: (type: string, listener: () => void) => void;
+  };
 
-  let fired = false;
+  let armed = false;
+  let resumeInFlight = false;
+  let disposed = false;
 
   const removeAll = () => {
+    if (!armed) return;
     for (const type of UNLOCK_EVENT_TYPES) {
-      target.removeEventListener(type, handler);
+      target.removeEventListener(type, handler, GESTURE_LISTENER_OPTIONS);
     }
+    armed = false;
   };
 
   const handler = () => {
-    if (fired) return;
-    fired = true;
+    if (disposed || resumeInFlight) return;
+    resumeInFlight = true;
 
     // Remove listeners FIRST so a re-entrant gesture cannot re-trigger us
     // while resume() is in flight.
@@ -147,6 +152,8 @@ export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
     // be a function here (guarded at install time above).
     resume.call(context).then(
       () => {
+        resumeInFlight = false;
+        if (disposed) return;
         try {
           onUnlock();
         } catch (err) {
@@ -154,14 +161,41 @@ export function installAutoplayUnlock(opts: AutoplayUnlockOptions): () => void {
         }
       },
       (err: unknown) => {
+        resumeInFlight = false;
+        if (disposed) return;
         console.warn("[cacophony/autoplayUnlock] resume failed:", err);
+        syncGestureListeners();
       },
     );
   };
 
-  for (const type of UNLOCK_EVENT_TYPES) {
-    target.addEventListener(type, handler);
+  const armAll = () => {
+    if (disposed || armed || resumeInFlight) return;
+    for (const type of UNLOCK_EVENT_TYPES) {
+      target.addEventListener(type, handler, GESTURE_LISTENER_OPTIONS);
+    }
+    armed = true;
+  };
+
+  function syncGestureListeners(): void {
+    if (observableContext.state === "suspended") {
+      armAll();
+    } else {
+      removeAll();
+    }
   }
 
-  return removeAll;
+  const handleStateChange = () => {
+    if (!disposed) syncGestureListeners();
+  };
+
+  observableContext.addEventListener?.("statechange", handleStateChange);
+  syncGestureListeners();
+
+  return () => {
+    if (disposed) return;
+    disposed = true;
+    removeAll();
+    observableContext.removeEventListener?.("statechange", handleStateChange);
+  };
 }

--- a/src/cacophony.ts
+++ b/src/cacophony.ts
@@ -307,9 +307,8 @@ export class Cacophony {
   // duplicate wrapper-driven suspend calls, but resume() still delegates because
   // the underlying AudioContext can be suspended externally.
   private suspendState: "unknown" | "running" | "suspended" = "unknown";
-  // Cleanup function for the autoplay-unlock listeners. No-op when listeners
-  // were not installed (autoUnlock disabled, offline context, non-browser,
-  // or context not in 'suspended' state at construction time).
+  // Cleanup function for the autoplay-unlock state watcher and gesture
+  // listeners. No-op when autoUnlock is disabled or unsupported.
   private autoplayUnlockCleanup: () => void = () => {};
 
   /**
@@ -367,10 +366,10 @@ export class Cacophony {
       }
     });
 
-    // Install autoplay unlock — guarded against offline contexts, non-browser
-    // environments, and non-suspended contexts inside installAutoplayUnlock
-    // itself. Offline contexts are filtered out here because they cannot
-    // suspend in the same way and an unlock makes no sense for them.
+    // Install autoplay unlock — guarded against offline contexts here and
+    // unsupported/non-browser environments inside installAutoplayUnlock.
+    // Offline contexts cannot suspend in the same way, so unlock makes no
+    // sense for them.
     const autoUnlock = runtimeOptions.autoUnlock !== false;
     if (autoUnlock && !this.isOffline) {
       this.autoplayUnlockCleanup = installAutoplayUnlock({


### PR DESCRIPTION
## Summary
- watch `AudioContext` state changes and arm gesture unlock listeners whenever it becomes suspended
- re-arm after transient `resume()` failures while preventing concurrent attempts
- register capture/passive gesture listeners and suppress in-flight callbacks after cleanup

## TDD
- red: 4 focused regressions failed for later suspension, listener options, retry, and in-flight cleanup
- green: 23 autoplay unlock tests passed

## Validation
- `npm run lint`
- `npm run ci:test` (82 files, 1,115 tests, no type errors)
- `npm run build`
- focused Cacophony/autoplay suites (98 tests)

Closes #158