### PR TITLE
Fix shared audio cache cancellation

### DIFF
--- a/src/cache.test.ts
+++ b/src/cache.test.ts
@@ -585,6 +585,102 @@ describe("AudioCache", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1); // Should only fetch once
   });
 
+  it("keeps a shared pending request when one caller aborts", async () => {
+    const url = "https://example.com/audio.mp3";
+    const mockArrayBuffer = new ArrayBuffer(8);
+    const mockAudioBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const mockCache = {
+      match: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    let resolveFetch!: (response: Response) => void;
+    const fetchResponse = new Promise<Response>((resolve) => {
+      resolveFetch = resolve;
+    });
+
+    mockCaches.open.mockResolvedValue(mockCache);
+    mockFetch.mockReturnValue(fetchResponse);
+    vi.spyOn(audioContextMock, "decodeAudioData").mockResolvedValue(mockAudioBuffer);
+
+    const firstRequest = cache.getAudioBuffer(audioContextMock, url, firstController.signal);
+    const firstOutcome = firstRequest.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    const secondRequest = cache.getAudioBuffer(audioContextMock, url, secondController.signal);
+
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    firstController.abort();
+
+    const thirdRequest = cache.getAudioBuffer(audioContextMock, url);
+    await vi.waitFor(() => expect(mockCache.match).toHaveBeenCalledTimes(3));
+    await Promise.resolve();
+
+    const sharedSignal = mockFetch.mock.calls[0]?.[1]?.signal;
+    expect(sharedSignal).not.toBe(firstController.signal);
+    expect(sharedSignal?.aborted).toBe(false);
+
+    resolveFetch(
+      new Response(mockArrayBuffer, {
+        status: 200,
+        headers: { "content-type": "audio/mpeg" },
+      }),
+    );
+
+    await expect(firstOutcome).resolves.toMatchObject({ name: "AbortError" });
+    await expect(secondRequest).resolves.toBe(mockAudioBuffer);
+    await expect(thirdRequest).resolves.toBe(mockAudioBuffer);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts and replaces a shared request after every caller aborts", async () => {
+    const url = "https://example.com/audio.mp3";
+    const mockArrayBuffer = new ArrayBuffer(8);
+    const mockAudioBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const mockCache = {
+      match: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    let sharedSignal: AbortSignal | null | undefined;
+
+    mockCaches.open.mockResolvedValue(mockCache);
+    mockFetch
+      .mockImplementationOnce(
+        (_input, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            sharedSignal = init?.signal;
+            sharedSignal?.addEventListener(
+              "abort",
+              () => reject(new DOMException("Operation was aborted", "AbortError")),
+              { once: true },
+            );
+          }),
+      )
+      .mockResolvedValueOnce(new Response(mockArrayBuffer, { status: 200 }));
+    vi.spyOn(audioContextMock, "decodeAudioData").mockResolvedValue(mockAudioBuffer);
+
+    const firstOutcome = cache.getAudioBuffer(audioContextMock, url, firstController.signal).catch((error) => error);
+    const secondOutcome = cache.getAudioBuffer(audioContextMock, url, secondController.signal).catch((error) => error);
+    await vi.waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+    firstController.abort();
+    expect(sharedSignal?.aborted).toBe(false);
+    secondController.abort();
+
+    await expect(firstOutcome).resolves.toMatchObject({ name: "AbortError" });
+    await expect(secondOutcome).resolves.toMatchObject({ name: "AbortError" });
+    expect(sharedSignal?.aborted).toBe(true);
+
+    await expect(cache.getAudioBuffer(audioContextMock, url)).resolves.toBe(mockAudioBuffer);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
   it("clears memory cache correctly", async () => {
     const url = "https://example.com/audio.mp3";
     const mockAudioBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
@@ -1375,7 +1471,7 @@ describe("AudioCache", () => {
 
       expect(result).toBe(mockAudioBuffer);
       expect(mockFetch).toHaveBeenCalledTimes(1);
-      expect(mockFetch).toHaveBeenCalledWith(url, expect.objectContaining({ signal: undefined }));
+      expect(mockFetch).toHaveBeenCalledWith(url, expect.objectContaining({ signal: expect.any(AbortSignal) }));
       expect(consoleErrorSpy).not.toHaveBeenCalled();
       consoleErrorSpy.mockRestore();
     });
@@ -1465,7 +1561,7 @@ describe("AudioCache", () => {
   });
 
   describe("AbortSignal support", () => {
-    it("passes AbortSignal to fetch requests", async () => {
+    it("passes a shared AbortSignal to fetch requests", async () => {
       const url = "https://example.com/audio.mp3";
       const mockArrayBuffer = new ArrayBuffer(8);
       const mockAudioBuffer = new AudioBuffer({ length: 100, sampleRate: 44100 });
@@ -1497,12 +1593,10 @@ describe("AudioCache", () => {
 
       await cache.getAudioBuffer(audioContextMock, url, controller.signal);
 
-      expect(mockFetch).toHaveBeenCalledWith(
-        url,
-        expect.objectContaining({
-          signal: controller.signal,
-        }),
-      );
+      const sharedSignal = mockFetch.mock.calls[0]?.[1]?.signal;
+      expect(sharedSignal).toBeInstanceOf(AbortSignal);
+      expect(sharedSignal).not.toBe(controller.signal);
+      expect(sharedSignal?.aborted).toBe(false);
     });
 
     it("throws AbortError when signal is already aborted", async () => {
@@ -1646,20 +1740,11 @@ describe("AudioCache", () => {
       await cache.getAudioBuffer(audioContextMock, url, controller.signal);
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(mockFetch).toHaveBeenNthCalledWith(
-        1,
-        url,
-        expect.objectContaining({
-          signal: controller.signal,
-        }),
-      );
-      expect(mockFetch).toHaveBeenNthCalledWith(
-        2,
-        url,
-        expect.objectContaining({
-          signal: controller.signal,
-        }),
-      );
+      const initialSignal = mockFetch.mock.calls[0]?.[1]?.signal;
+      const recoverySignal = mockFetch.mock.calls[1]?.[1]?.signal;
+      expect(initialSignal).toBeInstanceOf(AbortSignal);
+      expect(initialSignal).not.toBe(controller.signal);
+      expect(recoverySignal).toBe(initialSignal);
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         `Cache inconsistency detected for ${url}: 304 response but no cached body. Re-fetching.`,
       );
@@ -1696,12 +1781,7 @@ describe("AudioCache", () => {
       const result = await cache.getAudioBuffer(audioContextMock, url);
 
       expect(result).toBe(mockAudioBuffer);
-      expect(mockFetch).toHaveBeenCalledWith(
-        url,
-        expect.objectContaining({
-          signal: undefined,
-        }),
-      );
+      expect(mockFetch).toHaveBeenCalledWith(url, expect.objectContaining({ signal: expect.any(AbortSignal) }));
     });
 
     describe("memory optimization", () => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -189,6 +189,14 @@ export interface ICache {
   clearMemoryCache(): void;
 }
 
+type PendingProgressCallbacks = Pick<CacheCallbacks, "onLoadingProgress">;
+
+interface PendingAudioRequest {
+  promise: Promise<AudioBuffer>;
+  controller: AbortController;
+  callers: number;
+}
+
 /**
  * AudioCache provides efficient caching of audio resources using HTTP caching standards.
  *
@@ -212,8 +220,8 @@ export interface ICache {
  * ```
  */
 export class AudioCache implements ICache {
-  private pendingRequests = new WeakMap<BaseContext, Map<string, Promise<AudioBuffer>>>();
-  private pendingCallbacks = new WeakMap<BaseContext, Map<string, Array<Pick<CacheCallbacks, "onLoadingProgress">>>>();
+  private pendingRequests = new WeakMap<BaseContext, Map<string, PendingAudioRequest>>();
+  private pendingCallbacks = new WeakMap<BaseContext, Map<string, PendingProgressCallbacks[]>>();
   private decodedBuffers = new WeakMap<BaseContext, ByteBoundedLRUCache<string, AudioBuffer>>();
   private static cacheExpirationTime: number = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
 
@@ -247,7 +255,7 @@ export class AudioCache implements ICache {
    * the canonical {@link CacheCallbacks} shape rather than `any`.
    */
   private static callAllCallbacks<K extends keyof CacheCallbacks>(
-    pendingCallbacks: Map<string, Array<Pick<CacheCallbacks, "onLoadingProgress">>> | undefined,
+    pendingCallbacks: Map<string, PendingProgressCallbacks[]> | undefined,
     url: string,
     callbackName: K,
     eventData: Parameters<NonNullable<CacheCallbacks[K]>>[0],
@@ -272,9 +280,9 @@ export class AudioCache implements ICache {
   private async getOrCreatePendingRequest(
     context: BaseContext,
     url: string,
-    createRequest: () => Promise<AudioBuffer | undefined>,
+    createRequest: (signal: AbortSignal) => Promise<AudioBuffer | undefined>,
     signal?: AbortSignal,
-    callbacks?: Pick<CacheCallbacks, "onLoadingProgress">,
+    callbacks?: PendingProgressCallbacks,
   ): Promise<AudioBuffer> {
     if (signal?.aborted) {
       throw new DOMException("Operation was aborted", "AbortError");
@@ -298,37 +306,70 @@ export class AudioCache implements ICache {
       pendingCallbacks.set(url, existingCallbacks);
     }
 
-    const pendingRequest = pendingRequests.get(url);
+    let pendingRequest = pendingRequests.get(url);
     if (!pendingRequest) {
+      const controller = new AbortController();
       const requestPromise = (async () => {
         try {
-          const result = await createRequest();
+          const result = await createRequest(controller.signal);
           if (result === undefined) {
             throw new Error("Failed to create audio buffer.");
           }
           return result;
         } finally {
-          pendingRequests.delete(url);
-          pendingCallbacks.delete(url); // Clean up callbacks too
+          if (pendingRequests.get(url) === pendingRequest) {
+            pendingRequests.delete(url);
+            pendingCallbacks.delete(url);
+          }
         }
       })();
 
-      // Clean up on abort
-      signal?.addEventListener(
-        "abort",
-        () => {
-          if (signal.aborted) {
-            pendingRequests.delete(url);
-            pendingCallbacks.delete(url); // Clean up callbacks too
-          }
-        },
-        { once: true },
-      );
-
-      pendingRequests.set(url, requestPromise);
-      return requestPromise;
+      pendingRequest = { promise: requestPromise, controller, callers: 0 };
+      pendingRequests.set(url, pendingRequest);
     }
-    return pendingRequest;
+
+    pendingRequest.callers++;
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const release = (aborted: boolean) => {
+        if (settled) return;
+        settled = true;
+        signal?.removeEventListener("abort", handleAbort);
+        pendingRequest.callers--;
+
+        if (aborted && callbacks) {
+          const registeredCallbacks = pendingCallbacks.get(url);
+          const callbackIndex = registeredCallbacks?.indexOf(callbacks) ?? -1;
+          if (callbackIndex >= 0) {
+            registeredCallbacks?.splice(callbackIndex, 1);
+          }
+        }
+
+        if (aborted && pendingRequest.callers === 0 && pendingRequests.get(url) === pendingRequest) {
+          pendingRequests.delete(url);
+          pendingCallbacks.delete(url);
+          pendingRequest.controller.abort();
+        }
+      };
+      const handleAbort = () => {
+        release(true);
+        reject(new DOMException("Operation was aborted", "AbortError"));
+      };
+
+      signal?.addEventListener("abort", handleAbort, { once: true });
+      pendingRequest.promise.then(
+        (buffer) => {
+          if (settled) return;
+          release(false);
+          resolve(buffer);
+        },
+        (error: unknown) => {
+          if (settled) return;
+          release(false);
+          reject(error);
+        },
+      );
+    });
   }
 
   private static async updateMetadata(cache: Cache, url: string, data: Partial<CacheMetadata>): Promise<void> {
@@ -836,7 +877,7 @@ export class AudioCache implements ICache {
       return this.getOrCreatePendingRequest(
         context,
         url,
-        async () => {
+        async (requestSignal) => {
           // No persistent cache, so this is always a miss.
           if (callbacks?.onCacheMiss) {
             callbacks.onCacheMiss({
@@ -850,7 +891,7 @@ export class AudioCache implements ICache {
             context,
             url,
             decodedBuffers,
-            () => this.fetchAndDecodeWithoutCache(context, url, signal),
+            () => this.fetchAndDecodeWithoutCache(context, url, requestSignal),
             callbacks,
           );
         },
@@ -900,7 +941,7 @@ export class AudioCache implements ICache {
     return this.getOrCreatePendingRequest(
       context,
       url,
-      async () => {
+      async (requestSignal) => {
         if (shouldFetch) {
           // Cache miss - need to fetch from network
           if (callbacks?.onCacheMiss) {
@@ -921,7 +962,7 @@ export class AudioCache implements ICache {
                 url,
                 cache,
                 { etag: metadata?.etag, lastModified: metadata?.lastModified },
-                signal,
+                requestSignal,
                 { onCacheHit: callbacks?.onCacheHit },
               ),
             callbacks,
@@ -965,7 +1006,7 @@ export class AudioCache implements ICache {
                   url,
                   cache,
                   { etag: metadata?.etag, lastModified: metadata?.lastModified },
-                  signal,
+                  requestSignal,
                   { onCacheHit: callbacks?.onCacheHit },
                 ),
               callbacks,


### PR DESCRIPTION
## Summary

- own each context/URL pending load through a shared `AbortController`
- reject an aborted caller independently without evicting the shared in-flight request
- cancel and replace the underlying request only after every interested caller aborts

## Root cause

`getOrCreatePendingRequest` stored a shared promise but attached the first caller's signal both to the fetch and to URL-wide map cleanup. One caller could therefore abort other waiters and remove the dedup entry while the request was still active.

## TDD

- Red: the focused cache suite reproduced an aborted first caller causing a second fetch and exposing the caller's aborted signal to the shared request
- Green: 47 focused cache tests pass, including continued dedup with one aborted caller and shared teardown when all callers abort

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run ci:test` (82 files, 1,117 tests, no type errors)
- `npm run build` (successful with the existing TS4094 declaration diagnostics and 35 TypeDoc warnings)

Closes #159