### PR TITLE
Fix microphone capture lifecycle

### DIFF
--- a/src/mediaStream.test.ts
+++ b/src/mediaStream.test.ts
@@ -120,6 +120,27 @@ describe("MediaStreamSound", () => {
     expect(track.stop).toHaveBeenCalledOnce();
   });
 
+  it("stops owned tracks when a playback is cleaned up directly", () => {
+    const sound = new MediaStreamSound(stream, context, globalGainNode);
+    const [playback] = sound.play();
+
+    playback.cleanup();
+
+    expect(track.stop).toHaveBeenCalledOnce();
+    expect(source.disconnect).toHaveBeenCalled();
+  });
+
+  it("preserves a deliberately disabled track when playback starts", () => {
+    track.enabled = false;
+    const sound = new MediaStreamSound(stream, context, globalGainNode, {
+      stopTracksOnStop: false,
+    });
+
+    sound.play();
+
+    expect(track.enabled).toBe(false);
+  });
+
   it("throws when replaying after the default stop ends every track", () => {
     const cacophony = new Cacophony(context as any);
     vi.spyOn(context as any, "createMediaStreamSource").mockReturnValue(source);

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -34,6 +34,8 @@ export class MediaStreamPlayback extends BasePlayback {
   public declare origin: MediaStreamSound;
   public declare source?: MediaStreamAudioSourceNode;
   private stopTracksOnStop: boolean;
+  private tracksStopped = false;
+  private pausedTrackStates?: Map<MediaStreamTrack, boolean>;
   /**
    * Muted media element that keeps Chromium's decode pipeline alive for the
    * stream so the Web Audio tap receives real audio. See
@@ -108,7 +110,15 @@ export class MediaStreamPlayback extends BasePlayback {
     if (tracks.length > 0 && tracks.every((track) => track.readyState === "ended")) {
       throw new Error("Cannot play a media stream whose tracks have ended");
     }
-    tracks.forEach((track) => (track.enabled = true));
+    if (this.isPaused && this.pausedTrackStates) {
+      tracks.forEach((track) => {
+        const enabled = this.pausedTrackStates?.get(track);
+        if (enabled !== undefined) {
+          track.enabled = enabled;
+        }
+      });
+    }
+    this.pausedTrackStates = undefined;
     // Muted autoplay is always permitted, so this needs no user gesture; the
     // returned promise is ignored because failure only loses Chromium priming.
     this.primeElement?.play().catch(() => {});
@@ -125,7 +135,9 @@ export class MediaStreamPlayback extends BasePlayback {
     if (!this.source || !this.isPlaying) {
       return;
     }
-    this.source.mediaStream.getTracks().forEach((track) => (track.enabled = false));
+    const tracks = this.source.mediaStream.getTracks();
+    this.pausedTrackStates = new Map(tracks.map((track) => [track, track.enabled]));
+    tracks.forEach((track) => (track.enabled = false));
     this.primeElement?.pause();
     this.markPaused();
     this.emit("pause", undefined);
@@ -144,9 +156,8 @@ export class MediaStreamPlayback extends BasePlayback {
       throw new Error("Cannot stop a media stream that has been cleaned up");
     }
     const shouldEmitStop = this._state === "playing" || this._state === "paused";
-    if (this.stopTracksOnStop) {
-      this.source.mediaStream.getTracks().forEach((track) => track.stop());
-    }
+    this.stopOwnedTracks();
+    this.pausedTrackStates = undefined;
     this.teardownPrimeElement();
     this.markStopped();
     if (shouldEmitStop) {
@@ -197,10 +208,20 @@ export class MediaStreamPlayback extends BasePlayback {
     }
   }
 
+  private stopOwnedTracks(): void {
+    if (!this.stopTracksOnStop || this.tracksStopped || !this.source) {
+      return;
+    }
+    this.source.mediaStream.getTracks().forEach((track) => track.stop());
+    this.tracksStopped = true;
+  }
+
   cleanup(): void {
     if (!this.source) {
       return;
     }
+    this.stopOwnedTracks();
+    this.pausedTrackStates = undefined;
     this.markStopped();
     this.teardownPrimeElement();
     this.source.disconnect();

--- a/src/microphone.test.ts
+++ b/src/microphone.test.ts
@@ -202,6 +202,21 @@ describe("MicrophoneStream", () => {
     expect(mockTrack.stop).toHaveBeenCalledOnce();
   });
 
+  it("can keep microphone tracks live across stop when configured", async () => {
+    (navigator.mediaDevices.getUserMedia as any).mockResolvedValue(mockStream);
+    const cacophony = new Cacophony(context as any);
+    const microphone = await cacophony.getMicrophoneStream({
+      stopTracksOnStop: false,
+    });
+
+    microphone.play();
+    microphone.stop();
+    const [restartedPlayback] = microphone.play();
+
+    expect(mockTrack.stop).not.toHaveBeenCalled();
+    expect(restartedPlayback.isPlaying).toBe(true);
+  });
+
   it("retains live-stream duration, loop, and playback-rate contracts", () => {
     const microphone = new MicrophoneStream(context, mockStream);
     const [playback] = microphone.play();

--- a/src/microphone.ts
+++ b/src/microphone.ts
@@ -4,9 +4,14 @@ import { MediaStreamPlayback, MediaStreamSound, type MediaStreamSoundOptions } f
 import type { HrtfPannerOptions } from "./pannerMixin";
 
 /** Options for acquiring and monitoring a microphone stream. */
-export interface MicrophoneStreamOptions extends Omit<MediaStreamSoundOptions, "stopTracksOnStop"> {
+export interface MicrophoneStreamOptions extends MediaStreamSoundOptions {
   /** Constraints forwarded to `navigator.mediaDevices.getUserMedia`. */
   constraints?: MediaStreamConstraints;
+  /**
+   * Stop the microphone tracks when playback stops or is cleaned up.
+   * Defaults to `true`. Set to `false` to keep the stream reusable.
+   */
+  stopTracksOnStop?: boolean;
   /** Initial left/right pan when `panType` is `"stereo"`. */
   stereoPan?: number;
   /** Initial spatial options when `panType` is `"HRTF"` (the default). */
@@ -52,7 +57,7 @@ export class MicrophoneStream extends MediaStreamSound {
         ...mediaStreamOptions,
         panType,
         primeWithMediaElement: mediaStreamOptions.primeWithMediaElement ?? false,
-        stopTracksOnStop: true,
+        stopTracksOnStop: mediaStreamOptions.stopTracksOnStop ?? true,
       },
       cacophony,
     );


### PR DESCRIPTION
## Summary

- stop owned media-stream tracks during direct playback cleanup
- expose stopTracksOnStop for microphone streams while preserving the true default
- preserve deliberately disabled track state across initial play and pause/resume

## Root cause

MediaStreamPlayback cleanup disconnected its graph without applying track ownership cleanup, MicrophoneStream discarded the shared stopTracksOnStop option, and play forced every track enabled.

## Validation

- red regression: 3 focused failures before implementation
- npx vitest run src/mediaStream.test.ts src/microphone.test.ts --no-color
- npm run lint
- npm run ci:test
- npm run build

Closes #160