### PR TITLE
Clarify WebCodecs pending seek errors

### DIFF
--- a/src/webCodecsStream.test.ts
+++ b/src/webCodecsStream.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PcmStreamSound } from "./pcmStream";
 import { audioContextMock, cacophony, expectReachable } from "./setupTests";
 import { Sound } from "./sound";
+import { WebCodecsPullAdapter } from "./webCodecsStream";
 
 const media = vi.hoisted(() => ({
   formats: {
@@ -191,6 +192,52 @@ describe("WebCodecs URL streaming", () => {
     expect(media.disposeCount).toBe(1);
     expect(media.fetchInits).toHaveLength(2);
     expect(new Headers(media.fetchInits[1]?.headers).get("Range")).toBe("bytes=0-65535");
+  });
+
+  it("reports a pending seek while the decoder is reopening", async () => {
+    let resolveReopen: ((response: Response) => void) | undefined;
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(new Uint8Array([0]), {
+          headers: { "Accept-Ranges": "bytes" },
+          status: 206,
+        }),
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveReopen = resolve;
+          }),
+      );
+    const stream = await cacophony.createStream("https://example.com/music.mp3");
+
+    stream.seek(4.5);
+
+    expect(() => stream.seek(6)).toThrow("Cannot seek while another WebCodecs seek is pending");
+    resolveReopen?.(
+      new Response(new Uint8Array([0]), {
+        headers: { "Accept-Ranges": "bytes" },
+        status: 206,
+      }),
+    );
+    await vi.waitFor(() => expect(media.sampleStarts).toEqual([0, 4.5]));
+  });
+
+  it("does not invent a channel-count mismatch without an attached sound", async () => {
+    const adapter = await WebCodecsPullAdapter.open("https://example.com/music.mp3", audioContextMock.sampleRate);
+    expect(adapter).not.toBeNull();
+    const adapterState = adapter as unknown as {
+      reopenAndPump(time: number): Promise<void>;
+      session?: { input: { dispose(): void } };
+    };
+    adapterState.session?.input.dispose();
+    adapterState.session = undefined;
+
+    await adapterState.reopenAndPump(4.5);
+
+    expect(media.disposeCount).toBe(1);
+    expect(adapter?.channelCount).toBe(2);
   });
 
   it("reports live sources as unseekable with infinite duration", async () => {

--- a/src/webCodecsStream.ts
+++ b/src/webCodecsStream.ts
@@ -99,8 +99,14 @@ export class WebCodecsPullAdapter implements PcmStreamPullSource {
     if (!Number.isFinite(time) || time < 0) {
       throw new RangeError("Stream seek time must be a finite non-negative number");
     }
-    if (!this.session || !this.sound || this.disposed) {
+    if (this.disposed) {
       throw new Error("Cannot seek a WebCodecs stream that has been cleaned up");
+    }
+    if (!this.sound) {
+      throw new Error("Cannot seek a WebCodecs stream before it has been attached");
+    }
+    if (!this.session) {
+      throw new Error("Cannot seek while another WebCodecs seek is pending");
     }
     if (this.session.live) {
       throw new Error("Live streams do not support seeking");
@@ -143,7 +149,8 @@ export class WebCodecsPullAdapter implements PcmStreamPullSource {
       if (!result.session) {
         return;
       }
-      if (result.session.channelCount !== this.channelCountForSound()) {
+      const soundChannelCount = this.channelCountForSound();
+      if (soundChannelCount !== undefined && result.session.channelCount !== soundChannelCount) {
         result.session.input.dispose();
         throw new Error("The audio channel count changed while seeking");
       }
@@ -156,8 +163,8 @@ export class WebCodecsPullAdapter implements PcmStreamPullSource {
     }
   }
 
-  private channelCountForSound(): number {
-    return this.sound?.inputChannelCount ?? 0;
+  private channelCountForSound(): number | undefined {
+    return this.sound?.inputChannelCount;
   }
 
   private startPump(session: DecoderSession, startTime: number): void {


### PR DESCRIPTION
## Summary

- distinguish a decoder reopen in progress from a cleaned-up WebCodecs stream
- report an unattached adapter separately from disposal
- skip channel-count comparison when no attached sound provides an expected count
- cover pending-seek and missing-sound reopen regressions

## TDD evidence

- Red: `npm test -- src/webCodecsStream.test.ts` failed both new regressions against the previous behavior
- Green: `npm test -- src/webCodecsStream.test.ts` (8 passed)

## Validation

- `npm run lint`
- `npm run ci:test` (82 files, 1,122 tests, no type errors)
- `npm run build` (passes with existing TS4094 and TypeDoc warnings)

Closes #163