### PR TITLE
Preallocate streaming resampler output

### DIFF
--- a/src/webCodecsStream.test.ts
+++ b/src/webCodecsStream.test.ts
@@ -173,6 +173,19 @@ describe("WebCodecs URL streaming", () => {
     expect(media.sourceUrl).toBe("https://example.com/music.ogg");
   });
 
+  it("writes resampled PCM directly into typed storage", async () => {
+    media.sample.sampleRate = audioContextMock.sampleRate / 2;
+    const boxedArrayConversion = vi.spyOn(Float32Array, "from");
+    const stream = await cacophony.createStream("https://example.com/music.ogg");
+
+    stream.play();
+    await vi.waitFor(() => expect(media.sample.close).toHaveBeenCalledOnce());
+
+    const boxedConversionCount = boxedArrayConversion.mock.calls.length;
+    boxedArrayConversion.mockRestore();
+    expect(boxedConversionCount).toBe(0);
+  });
+
   it("threads stereo panning through the WebCodecs stream tier", async () => {
     const stream = await cacophony.createStream("https://example.com/music.ogg", undefined, "stereo");
     expect(stream).toBeInstanceOf(PcmStreamSound);

--- a/src/webCodecsStream.ts
+++ b/src/webCodecsStream.ts
@@ -338,39 +338,44 @@ class StreamingPcmResampler {
     const frameCount = input.length / this.channelCount;
     const firstFrame = this.inputFrames;
     const lastFrame = firstFrame + frameCount - 1;
-    const output: number[] = [];
+    const sourceFramesPerOutput = this.sourceRate / this.targetRate;
+    const outputFrameCount =
+      this.nextSourcePosition > lastFrame
+        ? 0
+        : Math.floor((lastFrame - this.nextSourcePosition) / sourceFramesPerOutput) + 1;
+    const output = new Float32Array(outputFrameCount * this.channelCount);
+    let outputOffset = 0;
 
-    while (this.nextSourcePosition <= lastFrame) {
+    for (let outputFrame = 0; outputFrame < outputFrameCount; outputFrame += 1) {
       const leftFrame = Math.floor(this.nextSourcePosition);
       const fraction = this.nextSourcePosition - leftFrame;
-      if (fraction > 0 && leftFrame + 1 > lastFrame) {
-        break;
-      }
       for (let channel = 0; channel < this.channelCount; channel += 1) {
         const left = this.sampleAt(input, firstFrame, leftFrame, channel);
         const right = this.sampleAt(input, firstFrame, Math.min(leftFrame + 1, lastFrame), channel);
-        output.push(left + (right - left) * fraction);
+        output[outputOffset] = left + (right - left) * fraction;
+        outputOffset += 1;
       }
-      this.nextSourcePosition += this.sourceRate / this.targetRate;
+      this.nextSourcePosition += sourceFramesPerOutput;
     }
 
     this.inputFrames += frameCount;
     this.previousFrame = input.slice(input.length - this.channelCount);
-    return Float32Array.from(output);
+    return output;
   }
 
   finalize(): Float32Array {
     if (this.sourceRate === this.targetRate || !this.previousFrame) {
       return new Float32Array();
     }
-    const output: number[] = [];
-    while (this.nextSourcePosition < this.inputFrames) {
-      for (const sample of this.previousFrame) {
-        output.push(sample);
-      }
-      this.nextSourcePosition += this.sourceRate / this.targetRate;
+    const sourceFramesPerOutput = this.sourceRate / this.targetRate;
+    const remainingSourceFrames = this.inputFrames - this.nextSourcePosition;
+    const outputFrameCount = remainingSourceFrames > 0 ? Math.ceil(remainingSourceFrames / sourceFramesPerOutput) : 0;
+    const output = new Float32Array(outputFrameCount * this.channelCount);
+    for (let outputFrame = 0; outputFrame < outputFrameCount; outputFrame += 1) {
+      output.set(this.previousFrame, outputFrame * this.channelCount);
+      this.nextSourcePosition += sourceFramesPerOutput;
     }
-    return Float32Array.from(output);
+    return output;
   }
 
   private sampleAt(input: Float32Array, firstFrame: number, frame: number, channel: number): number {


### PR DESCRIPTION
## Summary

- precompute the interleaved resampler output size for each decoded chunk
- write interpolation results directly into a preallocated `Float32Array`
- preallocate the final flush buffer and cover the decoded WebCodecs path with a regression

## Root cause

The streaming decode hot path accumulated resampled samples with `number[].push()` and then copied them through `Float32Array.from()`, creating boxed elements and repeated array growth for every chunk.

## Validation

- `npx vitest run src/webCodecsStream.test.ts --no-color`
- `npm run lint`
- `npm run ci:test`
- `npm run build`

Closes #164