### PR TITLE
Reject malformed FOA HRIR buffers

### DIFF
--- a/src/effects.ts
+++ b/src/effects.ts
@@ -869,12 +869,17 @@ export class FoaDecoder {
     context?: BaseContext,
   ): Promise<FoaDecoder> {
     const ctx = context ?? host.defaultContext();
-    if (!ctx.createChannelSplitter || !ctx.createChannelMerger || !ctx.createConvolver) {
-      throw new Error("FoaDecoder requires createChannelSplitter, createChannelMerger and createConvolver");
+    if (!ctx.createChannelSplitter || !ctx.createChannelMerger || !ctx.createConvolver || !ctx.createBuffer) {
+      throw new Error(
+        "FoaDecoder requires createChannelSplitter, createChannelMerger, createConvolver and createBuffer",
+      );
     }
 
     // SN3D SH-HRIR (4 rows: ACN W,Y,Z,X). Caller override or bundled Omnitone.
     const hrir = options.hrir ?? (await host.loadFoaHrir(ctx));
+    if (hrir.numberOfChannels < 4) {
+      throw new Error(`FoaDecoder requires an HRIR with at least 4 channels; received ${hrir.numberOfChannels}`);
+    }
 
     // Input: 4-channel FOA [W, Y, Z, X] (ACN). Externally-visible input node.
     const input = ctx.createChannelSplitter(4);
@@ -947,15 +952,9 @@ export class FoaDecoder {
   /**
    * Builds a 2-channel `AudioBuffer` from rows `rowA`/`rowB` of the 4-row
    * SH-HRIR — the stereo buffer a WY or ZX `ConvolverNode` convolves against.
-   * Falls back to the source buffer unchanged when the runtime cannot allocate
-   * a buffer or the source lacks the rows (e.g. a stubbed mock buffer in tests
-   * with fewer channels): the graph wiring is unaffected.
    */
   private static sliceHrirRows(context: BaseContext, hrir: AudioBuffer, rowA: number, rowB: number): AudioBuffer {
-    if (!context.createBuffer || hrir.numberOfChannels < rowB + 1) {
-      return hrir;
-    }
-    const stereo = context.createBuffer(2, hrir.length, hrir.sampleRate);
+    const stereo = context.createBuffer!(2, hrir.length, hrir.sampleRate);
     stereo.copyToChannel(hrir.getChannelData(rowA), 0);
     stereo.copyToChannel(hrir.getChannelData(rowB), 1);
     return stereo;

--- a/src/foaDecoder.test.ts
+++ b/src/foaDecoder.test.ts
@@ -64,8 +64,8 @@ function instrumentGraphFactories(): { created: CapturedNode[] } {
   return { created };
 }
 
-/** A 4-channel stub HRIR so create() never touches decodeAudioData/fetch. */
-const stubHrir = () => new AudioContext().createBuffer(4, 256, 48000);
+/** An in-memory HRIR fixture so create() never touches decodeAudioData/fetch. */
+const stubHrir = (numberOfChannels = 4) => new AudioContext().createBuffer(numberOfChannels, 256, 48000);
 
 /**
  * Identify the canonical decoder nodes from the captured-node list, by the
@@ -326,6 +326,14 @@ describe("FoaDecoder — standalone FOA->binaural format converter (Ahrens 2022 
   it("throws if the context lacks channel split/merge/convolve support", async () => {
     const bare = { createGain: vi.fn() } as never;
     await expect(cacophony.createFoaDecoder({ hrir: stubHrir() }, bare)).rejects.toThrow(/createChannelSplitter/);
+  });
+
+  it("rejects an HRIR that cannot supply all four ACN rows", async () => {
+    instrumentGraphFactories();
+
+    await expect(cacophony.createFoaDecoder({ hrir: stubHrir(3) })).rejects.toThrow(
+      "FoaDecoder requires an HRIR with at least 4 channels; received 3",
+    );
   });
 
   it("falls back to loadFoaHrir when no hrir option is supplied", async () => {


### PR DESCRIPTION
## Summary

- reject FOA HRIR buffers that cannot provide all four ACN rows
- require buffer allocation support instead of passing an unsliced HRIR to a convolver
- extend the existing in-memory HRIR helper with a malformed-buffer regression

## Root cause

`sliceHrirRows` returned the original buffer when a requested row was missing. That test-oriented fallback allowed an invalid channel layout into the live binaural decoder graph instead of reporting the malformed HRIR.

## Validation

- red: the new three-channel HRIR regression resolved instead of rejecting
- green: `npx vitest run src/foaDecoder.test.ts --no-color` (26 tests)
- `npm run lint`
- `npm run ci:test` (82 files, 1,124 tests, no type errors)
- `npm run build`

Closes #165
