### PR TITLE
Unify playback lifecycle events

### DIFF
--- a/src/basePlayback.ts
+++ b/src/basePlayback.ts
@@ -193,6 +193,36 @@ export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager
     this._state = "stopped";
   }
 
+  protected emitPlayStarted(isResume: boolean): void {
+    this.markPlaying();
+    this.emit("play", this);
+    if (isResume) {
+      this.emit("resume", undefined);
+    }
+    this.origin.cacophony?.emit("globalPlay", {
+      source: this.origin,
+      timestamp: Date.now(),
+    });
+  }
+
+  protected emitPaused(): void {
+    this.markPaused();
+    this.emit("pause", undefined);
+    this.origin.cacophony?.emit("globalPause", {
+      source: this.origin,
+      timestamp: Date.now(),
+    });
+  }
+
+  protected emitStopped(): void {
+    this.markStopped();
+    this.emit("stop", undefined);
+    this.origin.cacophony?.emit("globalStop", {
+      source: this.origin,
+      timestamp: Date.now(),
+    });
+  }
+
   /**
    * Register event listener.
    * @returns Cleanup function

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,5 +1,5 @@
 import type { BasePlayback } from "./basePlayback";
-import type { FadeType, Position } from "./cacophony";
+import type { Cacophony, FadeType, Position } from "./cacophony";
 import type { BiquadFilterNode } from "./context";
 import type { FilterManager } from "./filters";
 import type { HrtfPannerOptions, ThreeDOptions } from "./pannerMixin";
@@ -41,6 +41,7 @@ const defaultHrtfThreeDOptions: ThreeDOptions = {
  * carry a number, so the public read shape matches.
  */
 export interface PlaybackContainer {
+  cacophony?: Cacophony;
   playbacks: BasePlayback[];
   preplay(): BasePlayback[];
   play(): BasePlayback[];

--- a/src/mediaStream.test.ts
+++ b/src/mediaStream.test.ts
@@ -173,18 +173,26 @@ describe("MediaStreamSound", () => {
     const sound = cacophony.createMediaStreamSound(stream, {
       stopTracksOnStop: false,
     });
+    const [playback] = sound.preplay();
+    const playbackEvents: string[] = [];
     const events: string[] = [];
 
+    playback.on("play", () => playbackEvents.push("play"));
+    playback.on("pause", () => playbackEvents.push("pause"));
+    playback.on("resume", () => playbackEvents.push("resume"));
+    playback.on("stop", () => playbackEvents.push("stop"));
     cacophony.on("globalPlay", () => events.push("play"));
     cacophony.on("globalPause", () => events.push("pause"));
     cacophony.on("globalStop", () => events.push("stop"));
 
     sound.play();
     sound.pause();
+    sound.resume();
     sound.stop();
 
     expect(sound).toBeInstanceOf(MediaStreamSound);
-    expect(events).toEqual(["play", "pause", "stop"]);
+    expect(playbackEvents).toEqual(["play", "pause", "play", "resume", "stop"]);
+    expect(events).toEqual(["play", "pause", "play", "stop"]);
   });
 
   it("routes a live stream through a bus via the public Cacophony API", () => {

--- a/src/mediaStream.ts
+++ b/src/mediaStream.ts
@@ -110,7 +110,8 @@ export class MediaStreamPlayback extends BasePlayback {
     if (tracks.length > 0 && tracks.every((track) => track.readyState === "ended")) {
       throw new Error("Cannot play a media stream whose tracks have ended");
     }
-    if (this.isPaused && this.pausedTrackStates) {
+    const isResume = this.isPaused;
+    if (isResume && this.pausedTrackStates) {
       tracks.forEach((track) => {
         const enabled = this.pausedTrackStates?.get(track);
         if (enabled !== undefined) {
@@ -122,12 +123,7 @@ export class MediaStreamPlayback extends BasePlayback {
     // Muted autoplay is always permitted, so this needs no user gesture; the
     // returned promise is ignored because failure only loses Chromium priming.
     this.primeElement?.play().catch(() => {});
-    this.markPlaying();
-    this.emit("play", this);
-    this.origin.cacophony?.emit("globalPlay", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitPlayStarted(isResume);
     return [this];
   }
 
@@ -139,12 +135,7 @@ export class MediaStreamPlayback extends BasePlayback {
     this.pausedTrackStates = new Map(tracks.map((track) => [track, track.enabled]));
     tracks.forEach((track) => (track.enabled = false));
     this.primeElement?.pause();
-    this.markPaused();
-    this.emit("pause", undefined);
-    this.origin.cacophony?.emit("globalPause", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitPaused();
   }
 
   resume(): void {
@@ -159,13 +150,10 @@ export class MediaStreamPlayback extends BasePlayback {
     this.stopOwnedTracks();
     this.pausedTrackStates = undefined;
     this.teardownPrimeElement();
-    this.markStopped();
     if (shouldEmitStop) {
-      this.emit("stop", undefined);
-      this.origin.cacophony?.emit("globalStop", {
-        source: this.origin,
-        timestamp: Date.now(),
-      });
+      this.emitStopped();
+    } else {
+      this.markStopped();
     }
   }
 

--- a/src/pcmStream.test.ts
+++ b/src/pcmStream.test.ts
@@ -130,6 +130,23 @@ describe("PcmStreamSound", () => {
     expect(() => sound.play()).toThrow("Cannot play a PCM stream after it has ended");
   });
 
+  it("emits the playback event contract across play, pause, resume, and stop", async () => {
+    const sound = await cacophony.createPcmStreamSound({ latency: 0 });
+    const [playback] = sound.preplay();
+    const events: string[] = [];
+    playback.on("play", () => events.push("play"));
+    playback.on("pause", () => events.push("pause"));
+    playback.on("resume", () => events.push("resume"));
+    playback.on("stop", () => events.push("stop"));
+
+    sound.play();
+    sound.pause();
+    sound.resume();
+    sound.stop();
+
+    expect(events).toEqual(["play", "pause", "play", "resume", "stop"]);
+  });
+
   it("documents unsupported seek and loop operations with explicit errors", async () => {
     const sound = await cacophony.createPcmStreamSound();
 

--- a/src/pcmStream.ts
+++ b/src/pcmStream.ts
@@ -74,13 +74,9 @@ export class PcmStreamPlayback extends BasePlayback {
     if (this.isPlaying) {
       return [this];
     }
+    const isResume = this.isPaused;
     this.source.port.postMessage({ type: "play" });
-    this.markPlaying();
-    this.emit("play", this);
-    this.origin.cacophony?.emit("globalPlay", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitPlayStarted(isResume);
     return [this];
   }
 
@@ -89,12 +85,7 @@ export class PcmStreamPlayback extends BasePlayback {
       return;
     }
     this.source.port.postMessage({ type: "pause" });
-    this.markPaused();
-    this.emit("pause", undefined);
-    this.origin.cacophony?.emit("globalPause", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitPaused();
   }
 
   stop(): void {
@@ -103,13 +94,10 @@ export class PcmStreamPlayback extends BasePlayback {
     }
     const shouldEmitStop = this.isPlaying || this.isPaused;
     this.source.port.postMessage({ type: "stop" });
-    this.markStopped();
     if (shouldEmitStop) {
-      this.emit("stop", undefined);
-      this.origin.cacophony?.emit("globalStop", {
-        source: this.origin,
-        timestamp: Date.now(),
-      });
+      this.emitStopped();
+    } else {
+      this.markStopped();
     }
   }
 

--- a/src/playback.ts
+++ b/src/playback.ts
@@ -291,15 +291,7 @@ export class Playback extends BasePlayback implements BaseSound {
           .then(
             () => {
               this._startTime = this.context.currentTime;
-              this.markPlaying();
-              this.emit("play", this);
-              if (isResume) {
-                this.emit("resume", undefined);
-              }
-              this.origin.cacophony?.emit("globalPlay", {
-                source: this.origin,
-                timestamp: Date.now(),
-              });
+              this.emitPlayStarted(isResume);
             },
             (error: Error) => {
               void this.emitAsync("error", {
@@ -319,15 +311,7 @@ export class Playback extends BasePlayback implements BaseSound {
       } else {
         // For buffer sources, state transition is immediate (start() is synchronous)
         this._startTime = this.context.currentTime;
-        this.markPlaying();
-        this.emit("play", this);
-        if (isResume) {
-          this.emit("resume", undefined);
-        }
-        this.origin.cacophony?.emit("globalPlay", {
-          source: this.origin,
-          timestamp: Date.now(),
-        });
+        this.emitPlayStarted(isResume);
       }
 
       return [this];
@@ -358,14 +342,7 @@ export class Playback extends BasePlayback implements BaseSound {
       this.source.stop();
     }
 
-    this.markPaused();
-    this.emit("pause", undefined);
-
-    // Emit globalPause for all playback
-    this.origin.cacophony?.emit("globalPause", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitPaused();
   }
 
   stop(): void {
@@ -388,14 +365,7 @@ export class Playback extends BasePlayback implements BaseSound {
 
     this._offset = 0;
     this._startTime = 0;
-    this.markStopped();
-    this.emit("stop", undefined);
-
-    // Emit globalStop for all playback
-    this.origin.cacophony?.emit("globalStop", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitStopped();
   }
 
   /**

--- a/src/synthPlayback.ts
+++ b/src/synthPlayback.ts
@@ -55,15 +55,7 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     if (this.oscillatorOptions.type) this.source.type = this.oscillatorOptions.type;
 
     this.source.start();
-    this.markPlaying();
-    this.emit("play", this);
-    if (isResume) {
-      this.emit("resume", undefined);
-    }
-    this.origin.cacophony?.emit("globalPlay", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitPlayStarted(isResume);
     return [this];
   }
 
@@ -73,12 +65,7 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
     }
 
     this.source.stop();
-    this.markPaused();
-    this.emit("pause", undefined);
-    this.origin.cacophony?.emit("globalPause", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitPaused();
   }
 
   stop(): void {
@@ -90,12 +77,7 @@ export class SynthPlayback extends OscillatorMixin implements BaseSound {
       this.source.stop();
     }
 
-    this.markStopped();
-    this.emit("stop", undefined);
-    this.origin.cacophony?.emit("globalStop", {
-      source: this.origin,
-      timestamp: Date.now(),
-    });
+    this.emitStopped();
   }
 
   cleanup(): void {


### PR DESCRIPTION
## Summary

- centralize playback lifecycle state and event emission in `BasePlayback`
- make PCM and media-stream resume paths emit the same `resume` event as buffer and synth playback
- preserve existing global play/pause/stop events and concrete playback guards

## TDD

- Red: focused PCM and media-stream regressions both failed because `resume` was absent
- Green: 105 focused playback tests pass
- Full: `npm run lint`, `npm run ci:test` (1,125 tests, no type errors), and `npm run build`

Closes #173