### PR TITLE
Harden HLS adapter errors and lifecycle

### DIFF
--- a/src/cacophony.test.ts
+++ b/src/cacophony.test.ts
@@ -576,7 +576,7 @@ describe("Cacophony advanced features", () => {
       );
     });
 
-    it("createStream gives install guidance when neither native HLS nor hls.js can play HLS", async () => {
+    it("createStream explains missing Media Source Extensions when neither native HLS nor hls.js can play HLS", async () => {
       const streamingAudio = createControllableAudioElement();
       Object.assign(streamingAudio.audio, { canPlayType: vi.fn().mockReturnValue("") });
       hlsMock.isSupported.mockReturnValue(false);
@@ -585,9 +585,9 @@ describe("Cacophony advanced features", () => {
         return streamingAudio.audio as any;
       });
 
-      await expect(cacophony.createStream("https://example.com/live.m3u8")).rejects.toThrow(
-        "install hls.js or use a direct stream URL",
-      );
+      const creation = cacophony.createStream("https://example.com/live.m3u8");
+      await expect(creation).rejects.toThrow("Media Source Extensions are not supported");
+      await expect(creation).rejects.not.toThrow("install hls.js");
     });
 
     it("createGroupFromUrls passes AbortSignal to all createSound calls", async () => {

--- a/src/hls.test.ts
+++ b/src/hls.test.ts
@@ -1,5 +1,42 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+function mockHlsModule(supported = true) {
+  const instances: MockHls[] = [];
+
+  class MockHls {
+    static readonly Events = { ERROR: "hlsError" };
+    static readonly isSupported = vi.fn(() => supported);
+
+    readonly attachMedia = vi.fn();
+    readonly destroy = vi.fn();
+    readonly detachMedia = vi.fn();
+    readonly listeners: Array<(...args: any[]) => void> = [];
+    readonly loadSource = vi.fn();
+    readonly off = vi.fn((_event: string, listener: (...args: any[]) => void) => {
+      const index = this.listeners.indexOf(listener);
+      if (index >= 0) {
+        this.listeners.splice(index, 1);
+      }
+    });
+    readonly on = vi.fn((_event: string, listener: (...args: any[]) => void) => {
+      this.listeners.push(listener);
+    });
+
+    constructor() {
+      instances.push(this);
+    }
+
+    emitError(data: Record<string, unknown>): void {
+      for (const listener of this.listeners) {
+        listener(MockHls.Events.ERROR, data);
+      }
+    }
+  }
+
+  vi.doMock("hls.js", () => ({ default: MockHls }));
+  return { instances };
+}
+
 describe("HlsAdapter optional peer loading", () => {
   afterEach(() => {
     vi.doUnmock("hls.js");
@@ -7,11 +44,88 @@ describe("HlsAdapter optional peer loading", () => {
   });
 
   it("gives install guidance when hls.js is not installed", async () => {
+    const missingModuleError = Object.assign(new Error("Cannot find package 'hls.js'"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    });
     vi.doMock("hls.js", () => {
-      throw new Error("Cannot find package 'hls.js'");
+      throw missingModuleError;
     });
     const { HlsAdapter } = await import("./hlsAdapter");
 
     await expect(HlsAdapter.create(vi.fn())).rejects.toThrow("install hls.js or use a direct stream URL");
+  });
+
+  it("preserves hls.js module evaluation errors", async () => {
+    const evaluationError = new Error("hls.js module initialization failed");
+    vi.doMock("hls.js", () => {
+      throw evaluationError;
+    });
+    const { HlsAdapter } = await import("./hlsAdapter");
+
+    let caught: unknown;
+    try {
+      await HlsAdapter.create(vi.fn());
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).not.toContain("install hls.js");
+    expect((caught as Error & { cause?: unknown }).cause).toBe(evaluationError);
+  });
+
+  it("explains missing Media Source Extensions without install guidance", async () => {
+    mockHlsModule(false);
+    const { HlsAdapter } = await import("./hlsAdapter");
+
+    const creation = HlsAdapter.create(vi.fn());
+    await expect(creation).rejects.toThrow("Media Source Extensions are not supported");
+    await expect(creation).rejects.not.toThrow("install hls.js");
+  });
+});
+
+describe("HlsAdapter lifecycle", () => {
+  afterEach(() => {
+    vi.doUnmock("hls.js");
+    vi.resetModules();
+  });
+
+  it("registers its error listener only once across repeated attachment", async () => {
+    const { instances } = mockHlsModule();
+    const { HlsAdapter } = await import("./hlsAdapter");
+    const adapter = await HlsAdapter.create(vi.fn());
+    const audio = {} as HTMLAudioElement;
+
+    adapter.attach(audio, "https://example.com/first.m3u8");
+    adapter.attach(audio, "https://example.com/second.m3u8");
+
+    expect(instances[0].on).toHaveBeenCalledOnce();
+    adapter.destroy();
+    expect(instances[0].off).toHaveBeenCalledOnce();
+  });
+
+  it("rejects attachment after destruction without touching hls.js", async () => {
+    const { instances } = mockHlsModule();
+    const { HlsAdapter } = await import("./hlsAdapter");
+    const adapter = await HlsAdapter.create(vi.fn());
+    adapter.destroy();
+    const hls = instances[0];
+
+    expect(() => adapter.attach({} as HTMLAudioElement, "https://example.com/live.m3u8")).toThrow(/destroyed/);
+    expect(hls.on).not.toHaveBeenCalled();
+    expect(hls.loadSource).not.toHaveBeenCalled();
+    expect(hls.attachMedia).not.toHaveBeenCalled();
+  });
+
+  it("does not advertise unimplemented recovery for nonfatal hls.js errors", async () => {
+    const { instances } = mockHlsModule();
+    const onError = vi.fn();
+    const { HlsAdapter } = await import("./hlsAdapter");
+    const adapter = await HlsAdapter.create(onError);
+    adapter.attach({} as HTMLAudioElement, "https://example.com/live.m3u8");
+
+    instances[0].emitError({ type: "networkError", details: "fragLoadError", fatal: false });
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error), false);
   });
 });

--- a/src/hlsAdapter.ts
+++ b/src/hlsAdapter.ts
@@ -1,10 +1,25 @@
 import type Hls from "hls.js";
 import type { ErrorData, Events } from "hls.js";
 
-const HLS_UNAVAILABLE_MESSAGE =
-  "HLS playback is unavailable in this browser; install hls.js or use a direct stream URL.";
+const HLS_NOT_INSTALLED_MESSAGE = "hls.js is not installed; install hls.js or use a direct stream URL.";
+const HLS_UNSUPPORTED_MESSAGE =
+  "HLS playback is unavailable because Media Source Extensions are not supported in this browser; use a direct stream URL.";
 
 type HlsErrorListener = (error: Error, recoverable: boolean) => void;
+
+function isMissingHlsModule(cause: unknown): boolean {
+  let current = cause;
+  const visited = new Set<Error>();
+  while (current instanceof Error && !visited.has(current)) {
+    visited.add(current);
+    const code = (current as Error & { code?: unknown }).code;
+    if (current.message.includes("hls.js") && (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND")) {
+      return true;
+    }
+    current = (current as Error & { cause?: unknown }).cause;
+  }
+  return false;
+}
 
 /**
  * Owns one optional hls.js instance and its media-element attachment.
@@ -14,11 +29,12 @@ type HlsErrorListener = (error: Error, recoverable: boolean) => void;
  */
 export class HlsAdapter {
   private destroyed = false;
+  private errorListenerRegistered = false;
 
   private readonly handleError = (_event: string, data: ErrorData): void => {
     const message = `hls.js ${data.type}: ${data.details}`;
     const error = new Error(message, data.error ? { cause: data.error } : undefined);
-    this.onError(error, !data.fatal);
+    this.onError(error, false);
   };
 
   private constructor(
@@ -32,18 +48,27 @@ export class HlsAdapter {
     try {
       ({ default: HlsConstructor } = await import("hls.js"));
     } catch (cause) {
-      throw new Error(HLS_UNAVAILABLE_MESSAGE, { cause });
+      if (isMissingHlsModule(cause)) {
+        throw new Error(HLS_NOT_INSTALLED_MESSAGE, { cause });
+      }
+      throw cause;
     }
 
     if (!HlsConstructor.isSupported()) {
-      throw new Error(HLS_UNAVAILABLE_MESSAGE);
+      throw new Error(HLS_UNSUPPORTED_MESSAGE);
     }
 
     return new HlsAdapter(new HlsConstructor(), HlsConstructor.Events.ERROR, onError);
   }
 
   attach(audio: HTMLAudioElement, url: string): void {
-    this.hls.on(this.errorEvent, this.handleError);
+    if (this.destroyed) {
+      throw new Error("HlsAdapter has been destroyed");
+    }
+    if (!this.errorListenerRegistered) {
+      this.hls.on(this.errorEvent, this.handleError);
+      this.errorListenerRegistered = true;
+    }
     this.hls.loadSource(url);
     this.hls.attachMedia(audio);
   }
@@ -53,7 +78,10 @@ export class HlsAdapter {
       return;
     }
     this.destroyed = true;
-    this.hls.off(this.errorEvent, this.handleError);
+    if (this.errorListenerRegistered) {
+      this.hls.off(this.errorEvent, this.handleError);
+      this.errorListenerRegistered = false;
+    }
     this.hls.detachMedia();
     this.hls.destroy();
   }


### PR DESCRIPTION
## Summary

- distinguish a missing optional `hls.js` peer from unsupported Media Source Extensions and genuine module-evaluation failures
- guard adapter attachment after destruction and register the hls.js error listener only once
- report hls.js errors as non-recoverable until bounded recovery is implemented

## Root cause

`HlsAdapter` mapped every dynamic-import failure and every unsupported-browser result to the same install guidance, attached its error listener on every call, and exposed a recoverability flag without performing recovery.

## Validation

- red: 6 focused regressions failed before the implementation
- green: `npx vitest run src/hls.test.ts src/cacophony.test.ts --no-color` (81 passed)
- `npm run lint`
- `npm run ci:test` (82 files, 1,130 tests, no type errors)
- `npm run build` (passed with 35 existing TypeDoc warnings and existing TS4094 declaration warnings)

Closes #162