### PR TITLE
Delegate Bus guards to EffectChain

### DIFF
--- a/src/basePlayback.ts
+++ b/src/basePlayback.ts
@@ -114,28 +114,21 @@ export abstract class BasePlayback extends PannerMixin(VolumeMixin(FilterManager
     if (!this._effectChain) {
       throw new Error("Cannot add a filter before the playback effect chain is initialized");
     }
-    super.addFilter(filter);
-    this._effectChain.add(filter, this._filters.length - 1);
+    this._effectChain.add(filter, this._filters.length);
+    this._filters.push(filter);
   }
 
   removeFilter(filter: BiquadFilterNode): void {
     if (!this._effectChain) {
       throw new Error("Cannot remove a filter before the playback effect chain is initialized");
     }
-    super.removeFilter(filter);
     this._effectChain.remove(filter);
+    this._filters = this._filters.filter((candidate) => candidate !== filter);
   }
 
   setFilterOrder(filters: readonly BiquadFilterNode[]): void {
     if (!this._effectChain) {
       throw new Error("Cannot reorder filters before the playback effect chain is initialized");
-    }
-    const isPermutation =
-      filters.length === this._filters.length &&
-      new Set(filters).size === filters.length &&
-      filters.every((filter) => this._filters.includes(filter));
-    if (!isPermutation) {
-      throw new Error("setFilterOrder requires a permutation of the current filters");
     }
     const nonFilters = this._effectChain.nodes.filter((node) => !this._filters.includes(node as BiquadFilterNode));
     this._effectChain.setOrder([...filters, ...nonFilters]);

--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -91,7 +91,7 @@ describe("Bus: addFilter discrimination", () => {
     const effect = { build: () => ({ input: graphInput, output: graphOutput, handle: graphInput }) };
 
     await bus.addFilter(effect);
-    await expect(bus.addFilter(effect)).rejects.toThrow(/same filter/);
+    await expect(bus.addFilter(effect)).rejects.toThrow("Bus: cannot add the same effect node twice");
   });
 
   it("disposes a built graph rejected for a duplicate handle", async () => {
@@ -115,15 +115,40 @@ describe("Bus: addFilter discrimination", () => {
 
     await bus.addFilter(effect);
 
-    await expect(bus.addFilter(effect)).rejects.toThrow(/same filter/);
+    await expect(bus.addFilter(effect)).rejects.toThrow("Bus: cannot add the same effect node twice");
     expect(disposeDuplicate).toHaveBeenCalledOnce();
     expect(bus.filters).toEqual([handle]);
   });
 
-  it("rejects a raw AudioNode (e.g. context.createGain())", async () => {
+  it("rejects a raw AudioNode synchronously (e.g. context.createGain())", () => {
     const bus = new Bus(cacophony.context, null);
     const raw = cacophony.context.createGain();
-    await expect(bus.addFilter(raw)).rejects.toThrow(/raw AudioNode/);
+    expect(() => bus.addFilter(raw)).toThrow(/raw AudioNode/);
+  });
+
+  it("preserves declaration order when async effect builds resolve out of order", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const first = cacophony.context.createGain();
+    const second = cacophony.context.createGain();
+    let resolveFirst!: (node: AudioNode) => void;
+    let resolveSecond!: (node: AudioNode) => void;
+
+    const firstAdded = bus.addFilter({
+      build: () => new Promise<AudioNode>((resolve) => (resolveFirst = resolve)),
+    });
+    const secondAdded = bus.addFilter({
+      build: () => new Promise<AudioNode>((resolve) => (resolveSecond = resolve)),
+    });
+
+    resolveSecond(second);
+    await secondAdded;
+    expect(bus.filters).toEqual([second]);
+    expectPath(bus.input, [second], bus.output);
+
+    resolveFirst(first);
+    await firstAdded;
+    expect(bus.filters).toEqual([first, second]);
+    expectPath(bus.input, [first, second], bus.output);
   });
 
   it("accepts a ShareEffect-wrapped raw AudioNode", async () => {
@@ -138,7 +163,7 @@ describe("Bus: addFilter discrimination", () => {
     const bus = new Bus(cacophony.context, null);
     const filter = cacophony.createBiquadFilter({ frequency: 500 });
     await bus.addFilter(filter);
-    await expect(bus.addFilter(filter)).rejects.toThrow(/same filter/);
+    await expect(bus.addFilter(filter)).rejects.toThrow("Bus: cannot add the same effect node twice");
   });
 });
 
@@ -409,7 +434,7 @@ describe("Bus: filter chain refresh", () => {
   it("removeFilter throws if the node was never added", () => {
     const bus = new Bus(cacophony.context, null);
     const filter = cacophony.createBiquadFilter({ frequency: 100 });
-    expect(() => bus.removeFilter(filter)).toThrow(/never added/);
+    expect(() => bus.removeFilter(filter)).toThrow("Bus: cannot remove an effect that was never added");
   });
 
   it("adding a filter only touches the changed tail edge, not the unchanged head", async () => {
@@ -521,11 +546,15 @@ describe("Bus: filter chain refresh", () => {
     await bus.addFilter(f3);
 
     // Wrong length (subset).
-    expect(() => bus.setFilterOrder([f1, f2])).toThrow(/permutation/);
+    expect(() => bus.setFilterOrder([f1, f2])).toThrow("Bus: effect order must be a permutation of the current nodes");
     // Right length but contains a foreign node.
-    expect(() => bus.setFilterOrder([f1, f2, foreign])).toThrow(/permutation/);
+    expect(() => bus.setFilterOrder([f1, f2, foreign])).toThrow(
+      "Bus: effect order must be a permutation of the current nodes",
+    );
     // Right length but contains a duplicate.
-    expect(() => bus.setFilterOrder([f1, f2, f2])).toThrow(/permutation/);
+    expect(() => bus.setFilterOrder([f1, f2, f2])).toThrow(
+      "Bus: effect order must be a permutation of the current nodes",
+    );
   });
 });
 
@@ -855,7 +884,7 @@ describe("Bus: per-filter bypass", () => {
     await bus.addFilter(onBus);
     const foreign = cacophony.createBiquadFilter({ frequency: 999 });
 
-    expect(() => bus.setFilterBypassed(foreign, true)).toThrow(/never added/);
+    expect(() => bus.setFilterBypassed(foreign, true)).toThrow("Bus: cannot bypass an effect that was never added");
   });
 
   it("setFilterBypassed throws after the bus is destroyed", async () => {

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -23,7 +23,7 @@ import type { FadeType } from "./cacophony";
 import type { AudioNode, BaseContext, BiquadFilterNode, GainNode } from "./context";
 import { EffectChain } from "./effectChain";
 import type { BuiltEffect, CacophonyEffect } from "./effects";
-import { isBuiltEffectGraph, isCacophonyBuiltBiquad, isCacophonyEffect } from "./effects";
+import { isCacophonyBuiltBiquad, isCacophonyEffect } from "./effects";
 
 /**
  * Connection target for {@link Bus.connect} / {@link Bus.disconnect}. Either
@@ -150,26 +150,45 @@ export class Bus {
    * @throws if the bus has been destroyed, or if the argument is a raw
    *   AudioNode that is not a Cacophony-built biquad.
    */
-  async addFilter(arg: BiquadFilterNode | CacophonyEffect | AudioNode): Promise<AudioNode> {
-    this._throwIfDestroyed();
-    let built: BuiltEffect;
-    if (isCacophonyBuiltBiquad(arg)) {
-      built = arg;
-    } else if (isCacophonyEffect(arg)) {
-      built = await arg.build(this._context);
-    } else {
+  addFilter(arg: BiquadFilterNode | CacophonyEffect | AudioNode): Promise<AudioNode> {
+    if (!isCacophonyBuiltBiquad(arg) && !isCacophonyEffect(arg)) {
       throw new Error(
         "Bus.addFilter rejects raw AudioNodes. Wrap with cacophony.shareEffect(node) or a CacophonyEffect to make the shared-state intent explicit.",
       );
     }
-    const handle = isBuiltEffectGraph(built) ? (built.handle ?? built.input) : built;
-    if (this._effectChain.has(handle)) {
-      if (isBuiltEffectGraph(built)) {
-        built.dispose?.();
-      }
-      throw new Error("Cannot add the same filter node to a bus twice");
+
+    let reservation: symbol;
+    try {
+      this._throwIfDestroyed();
+      reservation = this._effectChain.reserve();
+    } catch (error) {
+      return Promise.reject(error);
     }
-    return this._effectChain.add(built);
+
+    let built: BuiltEffect | Promise<BuiltEffect>;
+    try {
+      built = isCacophonyBuiltBiquad(arg) ? arg : arg.build(this._context);
+    } catch (error) {
+      this._effectChain.cancel(reservation);
+      return Promise.reject(error);
+    }
+
+    if (built instanceof Promise || (typeof built === "object" && built !== null && "then" in built)) {
+      return Promise.resolve(built).then(
+        (resolved) => this._effectChain.resolve(reservation, resolved),
+        (error) => {
+          this._effectChain.cancel(reservation);
+          throw error;
+        },
+      );
+    }
+
+    try {
+      return Promise.resolve(this._effectChain.resolve(reservation, built));
+    } catch (error) {
+      this._effectChain.cancel(reservation);
+      return Promise.reject(error);
+    }
   }
 
   /**
@@ -180,9 +199,6 @@ export class Bus {
    */
   removeFilter(node: AudioNode): void {
     this._throwIfDestroyed();
-    if (!this._effectChain.has(node)) {
-      throw new Error("Cannot remove filter that was never added to this bus");
-    }
     this._effectChain.remove(node);
   }
 
@@ -198,13 +214,6 @@ export class Bus {
    */
   setFilterOrder(nodes: readonly AudioNode[]): void {
     this._throwIfDestroyed();
-    const isPermutation =
-      nodes.length === this._effectChain.nodes.length &&
-      new Set(nodes).size === nodes.length &&
-      nodes.every((node) => this._effectChain.has(node));
-    if (!isPermutation) {
-      throw new Error("setFilterOrder requires a permutation of the current filters");
-    }
     this._effectChain.setOrder(nodes);
   }
 
@@ -227,9 +236,6 @@ export class Bus {
    */
   setFilterBypassed(node: AudioNode, bypassed: boolean): void {
     this._throwIfDestroyed();
-    if (!this._effectChain.has(node)) {
-      throw new Error("Cannot bypass a filter that was never added to this bus");
-    }
     this._effectChain.setBypassed(node, bypassed);
   }
 

--- a/src/effectChain.test.ts
+++ b/src/effectChain.test.ts
@@ -72,7 +72,7 @@ describe("EffectChain", () => {
 
     expect(() =>
       chain.add({ input: duplicateInput, output: duplicateOutput, handle, dispose: disposeDuplicate }),
-    ).toThrow(/same effect/);
+    ).toThrow("EffectChain: cannot add the same effect node twice");
     expect(disposeDuplicate).toHaveBeenCalledOnce();
     expect(chain.nodes).toEqual([handle]);
   });

--- a/src/effectChain.ts
+++ b/src/effectChain.ts
@@ -55,12 +55,12 @@ export class EffectChain {
 
   add(built: BuiltEffect, index = this.entries.length): AudioNode {
     if (this.destroyed) {
-      throw new Error("Cannot add an effect to a destroyed chain");
+      throw this.guardError("cannot add an effect to a destroyed chain");
     }
     const entry = this.normalize(built);
     if (this.has(entry.handle)) {
       entry.dispose?.();
-      throw new Error("Cannot add the same effect node to a chain twice");
+      throw this.guardError("cannot add the same effect node twice");
     }
     this.entries.splice(index, 0, entry);
     this.refresh();
@@ -70,7 +70,7 @@ export class EffectChain {
   /** Reserve a declaration-order position for an asynchronously built effect. */
   reserve(): symbol {
     if (this.destroyed) {
-      throw new Error("Cannot reserve an effect on a destroyed chain");
+      throw this.guardError("cannot reserve an effect on a destroyed chain");
     }
     const reservation = Symbol("effect-chain-reservation");
     this.entries.push({ reservation });
@@ -89,11 +89,12 @@ export class EffectChain {
     );
     if (index === -1) {
       entry.dispose?.();
-      throw new Error("Cannot resolve an unknown effect-chain reservation");
+      throw this.guardError("cannot resolve an unknown effect-chain reservation");
     }
     if (this.has(entry.handle)) {
+      this.entries.splice(index, 1);
       entry.dispose?.();
-      throw new Error("Cannot add the same effect node to a chain twice");
+      throw this.guardError("cannot add the same effect node twice");
     }
     this.entries[index] = entry;
     this.refresh();
@@ -112,7 +113,7 @@ export class EffectChain {
   remove(node: AudioNode): void {
     const index = this.entries.findIndex((entry) => this.isEntry(entry) && entry.handle === node);
     if (index === -1) {
-      throw new Error("Cannot remove an effect that was never added to this chain");
+      throw this.guardError("cannot remove an effect that was never added");
     }
     const [entry] = this.entries.splice(index, 1);
     this.bypassed.delete(node);
@@ -128,7 +129,7 @@ export class EffectChain {
       new Set(nodes).size === nodes.length &&
       nodes.every((node) => this.has(node));
     if (!isPermutation) {
-      throw new Error("Effect chain order must be a permutation of the current nodes");
+      throw this.guardError("effect order must be a permutation of the current nodes");
     }
     const ordered = nodes.map((node) => this.entries.find((entry) => this.isEntry(entry) && entry.handle === node)!);
     let orderedIndex = 0;
@@ -142,7 +143,7 @@ export class EffectChain {
 
   setBypassed(node: AudioNode, bypassed: boolean): void {
     if (!this.has(node)) {
-      throw new Error("Cannot bypass an effect that was never added to this chain");
+      throw this.guardError("cannot bypass an effect that was never added");
     }
     const alreadyBypassed = this.bypassed.has(node);
     if (bypassed === alreadyBypassed) {
@@ -265,6 +266,10 @@ export class EffectChain {
 
   private isEntry(slot: EffectChainSlot): slot is EffectChainEntry {
     return "handle" in slot;
+  }
+
+  private guardError(message: string): Error {
+    return new Error(`${this.diagnosticScope}: ${message}`);
   }
 
   private resolveAudioParam(node: AudioNode, paramName: string): AudioParam | undefined {

--- a/src/playback.test.ts
+++ b/src/playback.test.ts
@@ -665,7 +665,7 @@ describe("Playback error cases", () => {
     playback.addFilter(filter as unknown as BiquadFilterNode);
 
     expect(() => playback.addFilter(filter as unknown as BiquadFilterNode)).toThrow(
-      "Cannot add the same filter instance twice",
+      "Playback: cannot add the same effect node twice",
     );
   });
 
@@ -676,7 +676,7 @@ describe("Playback error cases", () => {
     playback.addFilter(filter1 as unknown as BiquadFilterNode);
 
     expect(() => playback.removeFilter(filter2 as unknown as BiquadFilterNode)).toThrow(
-      "Cannot remove filter that was never added to this container",
+      "Playback: cannot remove an effect that was never added",
     );
   });
 });


### PR DESCRIPTION
## Summary

- centralize duplicate, membership, permutation, and bypass guard messages in `EffectChain`, scoped to each owner
- route `Bus.addFilter` through `reserve`/`resolve` so concurrent async builds retain declaration order
- reject raw `AudioNode` arguments synchronously while preserving Promise rejection behavior for build and lifecycle failures
- make live playback filter operations delegate validation to their `EffectChain`

## TDD proof

- Red: `npx vitest run src/bus.test.ts --no-color` failed the new synchronous-validation and declaration-order regressions (2 failed, 58 passed)
- Green: `npm run ci:test` (82 files, 1,131 tests, no type errors)
- Green: `npm run lint`
- Green: `npm run typecheck`
- Green: `npm run build` (completed with the repository's existing TS4094 and TypeDoc warnings)

Closes #168