### PR TITLE
Harden effect admission boundaries

### DIFF
--- a/src/bus.test.ts
+++ b/src/bus.test.ts
@@ -1,5 +1,7 @@
+import { AudioContext } from "standardized-audio-context-mock";
 import { describe, expect, it, vi } from "vitest";
 import { Bus } from "./bus";
+import type { CacophonyEffect } from "./effects";
 import { cacophony, expectPath } from "./setupTests";
 
 describe("Bus: construction", () => {
@@ -49,6 +51,14 @@ describe("Bus: addFilter discrimination", () => {
     expect(bus.filters).toContain(filter);
   });
 
+  it("rejects a Cacophony-built biquad from a different audio context", () => {
+    const otherContext = new AudioContext();
+    const bus = new Bus(otherContext, null);
+    const foreignFilter = cacophony.createBiquadFilter({ frequency: 1000 });
+
+    expect(() => bus.addFilter(foreignFilter)).toThrow(/raw AudioNode/);
+  });
+
   it("accepts a CacophonyEffect by awaiting build()", async () => {
     const bus = new Bus(cacophony.context, null);
     const node = cacophony.context.createGain();
@@ -82,6 +92,15 @@ describe("Bus: addFilter discrimination", () => {
     expect(bus.filters).toEqual([handle]);
     expect(busInputConnect).toHaveBeenCalledWith(graphInput);
     expect(graphOutputConnect).toHaveBeenCalledWith(bus.output);
+  });
+
+  it("rejects a malformed CacophonyEffect build result at the chain boundary", async () => {
+    const bus = new Bus(cacophony.context, null);
+    const effect = { build: () => ({}) } as unknown as CacophonyEffect;
+
+    await expect(bus.addFilter(effect)).rejects.toThrow(
+      "Bus: effect build must return an AudioNode or BuiltEffectGraph",
+    );
   });
 
   it("rejects adding the same graph handle twice", async () => {

--- a/src/bus.ts
+++ b/src/bus.ts
@@ -151,7 +151,7 @@ export class Bus {
    *   AudioNode that is not a Cacophony-built biquad.
    */
   addFilter(arg: BiquadFilterNode | CacophonyEffect | AudioNode): Promise<AudioNode> {
-    if (!isCacophonyBuiltBiquad(arg) && !isCacophonyEffect(arg)) {
+    if (!isCacophonyBuiltBiquad(arg, this._context) && !isCacophonyEffect(arg)) {
       throw new Error(
         "Bus.addFilter rejects raw AudioNodes. Wrap with cacophony.shareEffect(node) or a CacophonyEffect to make the shared-state intent explicit.",
       );
@@ -167,7 +167,7 @@ export class Bus {
 
     let built: BuiltEffect | Promise<BuiltEffect>;
     try {
-      built = isCacophonyBuiltBiquad(arg) ? arg : arg.build(this._context);
+      built = isCacophonyBuiltBiquad(arg, this._context) ? arg : arg.build(this._context);
     } catch (error) {
       this._effectChain.cancel(reservation);
       return Promise.reject(error);

--- a/src/effectChain.ts
+++ b/src/effectChain.ts
@@ -1,7 +1,7 @@
 import type { FadeType } from "./cacophony";
 import type { AudioNode, AudioParam, AudioWorkletNode } from "./context";
 import type { BuiltEffect } from "./effects";
-import { isBuiltEffectGraph } from "./effects";
+import { isBuiltEffect, isBuiltEffectGraph } from "./effects";
 
 interface EffectChainEntry {
   handle: AudioNode;
@@ -248,6 +248,9 @@ export class EffectChain {
   }
 
   private normalize(built: BuiltEffect): EffectChainEntry {
+    if (!isBuiltEffect(built)) {
+      throw this.guardError("effect build must return an AudioNode or BuiltEffectGraph");
+    }
     if (isBuiltEffectGraph(built)) {
       return {
         handle: built.handle ?? built.input,

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -132,10 +132,16 @@ export function markAsCacophonyBiquad(node: BiquadFilterNode): void {
 
 /**
  * Test whether a node was produced by {@link Cacophony.createBiquadFilter}.
- * Used by {@link Bus.addFilter} to admit Biquads directly without wrapping.
+ * When a context is supplied, the node must also belong to that context so a
+ * factory-built biquad cannot be admitted to a foreign audio graph.
  */
-export function isCacophonyBuiltBiquad(node: unknown): node is BiquadFilterNode {
-  return typeof node === "object" && node !== null && cacophonyBuiltBiquads.has(node as BiquadFilterNode);
+export function isCacophonyBuiltBiquad(node: unknown, context?: BaseContext): node is BiquadFilterNode {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    cacophonyBuiltBiquads.has(node as BiquadFilterNode) &&
+    (context === undefined || (node as BiquadFilterNode).context === context)
+  );
 }
 
 /**
@@ -1004,6 +1010,13 @@ export function isBuiltEffectGraph(value: unknown): value is BuiltEffectGraph {
     isAudioNodeLike((value as { input: unknown }).input) &&
     isAudioNodeLike((value as { output: unknown }).output)
   );
+}
+
+/**
+ * Type guard for values returned by {@link CacophonyEffect.build}.
+ */
+export function isBuiltEffect(value: unknown): value is BuiltEffect {
+  return isAudioNodeLike(value) || isBuiltEffectGraph(value);
 }
 
 /**


### PR DESCRIPTION
## Summary

- reject Cacophony-created biquads when their AudioContext does not match the target bus
- validate effect build results at the shared EffectChain boundary
- add focused regressions for cross-context admission and malformed build output

## Root cause

Biquad admission relied only on a module-global WeakSet, so membership from one Cacophony context was accepted by a bus on another context. Separately, structural CacophonyEffect detection validated only that `build` was callable; malformed return values reached graph reconciliation and failed later with an unrelated TypeError.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run ci:test` (82 files, 1,133 tests)
- `npm run build`

Closes #170